### PR TITLE
fix!: Sprint 1 — stop data loss, silent failures, and unbounded writes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,13 +1,24 @@
 {
-  "branches": ["main"],
+  "branches": [
+    "main"
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "package.json"],
+        "assets": [
+          "CHANGELOG.md",
+          "package.json"
+        ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Use Bun 1.2 or newer. There is no separate formatter or linter configured; keep 
 
 ## Gotchas
 
-- **tree-sitter is a native module.** Run `bun install` before anything else. Without `node_modules/`, the AST test files abort with `error: Cannot find package 'tree-sitter'` while the rest of the suite passes, so the failure looks unrelated to your change. The green baseline is 344 pass / 0 fail.
+- **tree-sitter is a native module.** Run `bun install` before anything else. Without `node_modules/`, the AST test files abort with `error: Cannot find package 'tree-sitter'` while the rest of the suite passes, so the failure looks unrelated to your change. The green baseline is 424 pass / 0 fail.
 - **AST load failures are silent.** `getParser()` (`src/core/ast-edit.ts:31-60`) catches parser-init errors and returns `null`; the router then falls back to hash/diff with no warning. If AST edits mysteriously route to diff, check that the tree-sitter bindings actually built.
 - **Route precedence** (`chooseRoute`, `src/core/router.ts:36`) is policy override → AST (language supported *and* AST operation) → hash operation → diff fallback. First match wins.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ HashPilot is a global, tool-agnostic structured editing core for coding agents. 
 ### Three-tier edit hierarchy
 
 1. **AST** — tree-sitter based syntax-aware edits (rename-symbol, replace-body, add/remove-import, insert-before/after). Only available for supported languages.
-2. **Hash** — SHA-256 anchored content replacement. Read a file (with hash), then replace by referencing that hash. Detects stale anchors (file changed since read) and auto-recovers.
+2. **Hash** — SHA-256 anchored content replacement. Read a file (with hash), then replace by referencing that hash. Detects stale anchors (file changed since read) and relocates the anchor when the content moved and appears exactly once; otherwise it refuses rather than overwriting.
 3. **Diff** — Search-and-replace fallback for unsupported languages/operations. Accepts oldContent + newContent, detects duplicates, fails with disambiguation hints.
 
 Supported AST languages: TypeScript, TSX, JavaScript, Python, Go, Rust. `.d.ts` files are excluded from AST editing.
@@ -47,7 +47,7 @@ All core modules live in `src/core/` (paths below are relative to it).
 |--------|---------------|
 | `src/cli.ts` | Commander-based CLI entry point. Every command records a telemetry event. |
 | `ast-edit.ts` | Tree-sitter parsing, symbol finding, rename, body replacement, import add/remove (with per-language configs for import formatting and grouped import handling). |
-| `hash-edit.ts` | SHA-256 anchored content replacement with stale-anchor auto-recovery. |
+| `hash-edit.ts` | SHA-256 anchored content replacement with relocation-based stale-anchor recovery and strict range validation. |
 | `diff-engine.ts` | LCS-based unified diff generation and patch application with fuzzy matching. |
 | `read.ts` | `read-many` (batch file reads with SHA-256 hashes) and `read-hash` (single line with context hashes). |
 | `grep.ts` | `grep-many` (regex search via system grep) and `symbol-lookup-many` (regex-based symbol definition search). |
@@ -56,6 +56,9 @@ All core modules live in `src/core/` (paths below are relative to it).
 | `plan-executor.ts` | **M5** — Executes `EditPlan` steps through the router with dry-run, verify, and revert-on-failure support. `executeIntent()` is the top-level entry point: parse → resolve → plan → execute. |
 | `provenance.ts` | **M6** — Edit history tracking with changeSet IDs. `provenanceQuery(file, line?)` shows who changed what and why (like `git blame` for agent edits). |
 | `config.ts` | Configuration loading with merge priority: env var > CLI arg > project `.hashpilot.json` > global `~/.config/hashpilot/config.json` > defaults. |
+| `paths.ts` | Write boundary. `assertWritable`/`safeWrite` confine every write to the project root (widened by `allowedRoots`), with a hard deny-list (`~/.ssh`, `~/.aws`, `/etc`, shell rc files, the telemetry log) that no flag overrides. Symlinks are resolved on both sides before comparison. |
+| `exit-codes.ts` | Maps `ErrorCode` to process exit codes (0 ok · 1 usage · 2 edit failed · 3 stale/retryable · 4 verify failed · 5 I/O · 70 internal). `finish()` prints JSON and sets the code. |
+| `redact.ts` | Credential scrubbing for anything written to the telemetry log: `redactSecrets`, `isSensitiveFile`, `redactEvent`. |
 | `batch-edit.ts` | Batch editing — applies the same edit to multiple files in parallel (`editMany`) or serially (`editManySerial`). |
 | `verify.ts` | `verify-changes` — runs formatter, linter, and tests on specified files. All checks are opt-in via CLI flags. Auto-detects tools from `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`. |
 | `telemetry.ts` | JSONL telemetry logging to `~/.agentic-tools/logs/`. Includes health reports with threshold warnings (stale-anchor rate, diff fallback rate, verify failure rate, per-language failure rate) and trend comparison. |
@@ -83,7 +86,7 @@ Route policies can override routing per language or per operation, with configur
 
 ### Gotchas
 
-- **tree-sitter is a native module.** Run `bun install` before anything else — without `node_modules/`, the AST test files abort with `error: Cannot find package 'tree-sitter'` while the rest of the suite passes, so the failure looks unrelated. Green baseline is 344 pass / 0 fail.
+- **tree-sitter is a native module.** Run `bun install` before anything else — without `node_modules/`, the AST test files abort with `error: Cannot find package 'tree-sitter'` while the rest of the suite passes, so the failure looks unrelated. Green baseline is 424 pass / 0 fail.
 - **AST load failures are silent.** `getParser()` (`src/core/ast-edit.ts:31-60`) catches parser-init errors and returns `null`. The router then falls back to hash/diff with no warning. If AST edits mysteriously route to diff, check that the tree-sitter bindings actually built.
 
 ### Adapter integrations

--- a/README.md
+++ b/README.md
@@ -238,6 +238,88 @@ The router auto-selects. A single `route-edit` command tries AST first, falls ba
 
 ---
 
+## Exit Codes
+
+Every command exits with a stable code so agents and CI can branch on the result
+without parsing text.
+
+| Code | Meaning | What to do |
+|------|---------|-----------|
+| `0` | Success | Continue |
+| `1` | Usage error — bad arguments, denied path, unsupported operation | Fix the invocation |
+| `2` | Edit failed | Try another route or report |
+| `3` | Stale anchor / precondition failed | **Retryable:** re-read and retry with the fresh hash |
+| `4` | Verification failed (format/lint/test) | Inspect the verify output |
+| `5` | I/O error | Check the path and permissions |
+| `70` | Internal error | File a bug |
+
+Batch commands return the worst code across all items.
+
+---
+
+## Where HashPilot Will Write
+
+By default HashPilot only writes inside the project root (the nearest ancestor
+containing `.git`). Anything else fails with `PATH_DENIED` and exit code `1`.
+
+```bash
+structured-edit --allowed-root /srv/generated ast rename-symbol ...   # widen for one run
+structured-edit --allow-outside-root ...                              # disable containment
+```
+
+```json
+{ "allowedRoots": ["/srv/generated"] }
+```
+
+Some locations are **never** writable, and neither `allowedRoots` nor
+`--allow-outside-root` re-enables them: `~/.ssh`, `~/.aws`, `~/.gnupg`, `/etc`,
+shell startup files (`~/.zshrc`, `~/.bashrc`, `~/.profile`), and HashPilot's own
+telemetry log. Symlinks are resolved before the check, so a link inside the
+project that points outside it is still refused.
+
+---
+
+## Telemetry and Privacy
+
+HashPilot writes a local JSONL event log to `~/.agentic-tools/logs/`. Nothing is
+ever sent off the machine.
+
+**Turning it off** — highest priority first:
+
+```bash
+structured-edit --no-telemetry ast rename-symbol ...   # one invocation
+export HASHPILOT_TELEMETRY=0                           # whole shell (also: false, off, no)
+```
+
+```json
+{ "telemetry": { "enabled": false } }
+```
+
+**What is in the log.** Operation name, route, file path, language, success,
+elapsed time, and any `--actor` / `--task-id` / `--reason` you pass. Source code
+is *not* recorded by default: the log holds content hashes, not content.
+
+**Diff capture is opt-in.** Setting `provenance.captureDiffs` records a unified
+diff of each edit, which puts real source lines on disk in plaintext:
+
+```json
+{ "provenance": { "captureDiffs": true } }
+```
+
+Even then, files that are secret by definition are never diffed — `.env*`,
+`*.pem`, `*.key`, `*.p12`, `*.pfx`, `id_rsa`/`id_ed25519`, `credentials`,
+`.npmrc`, `.netrc`, `secrets.{yaml,json,toml}`. Their hashes still record *that*
+the file changed.
+
+**Redaction.** Everything written to the log is scrubbed for credential shapes
+first — AWS keys, OpenAI/Anthropic/GitHub/Slack/Google tokens, JWTs, private-key
+blocks, `Authorization` headers, passwords in connection strings, and any
+`secret`/`token`/`password`/`api_key`-named assignment. Matches are replaced with
+`[REDACTED]`. The log directory is created `0700` and the log file `0600`;
+pre-existing logs from older versions are tightened on the next write.
+
+---
+
 ## Integrations
 
 HashPilot installs adapters for the three major coding agent platforms:
@@ -306,9 +388,14 @@ Layered config. Highest priority wins:
     "operationOverrides": { "add-import": "diff" },
     "conflictResolution": "operation"
   },
-  "telemetry": { "enabled": true }
+  "telemetry": { "enabled": true },
+  "provenance": { "captureDiffs": false },
+  "allowedRoots": []
 }
 ```
+
+See [Telemetry and Privacy](#telemetry-and-privacy) and
+[Where HashPilot Will Write](#where-hashpilot-will-write) for what those last two do.
 
 ---
 
@@ -318,7 +405,7 @@ Layered config. Highest priority wins:
 git clone https://github.com/bigknoxy/HashPilot.git
 cd HashPilot
 bun install
-bun test              # 344 tests, 96.68% line coverage
+bun test              # 424 tests
 bun run build         # Build CLI to dist/
 bun test tests/hash-edit.test.ts   # Single test file
 bun test -t "test name pattern"    # Filter by test name
@@ -352,3 +439,11 @@ Active development. Core editing engine, AST operations, telemetry, and all thre
 **Docs policy:** The landing page (README.md) and [design doc](docs/ARCHITECTURE.md) are living documents. Every PR that touches `src/` must update one or both. Every deploy is verified with browser automation. See the CI check `docs-verify`.
 
 v1.3.1 — [Release notes](https://github.com/bigknoxy/HashPilot/releases)
+
+<!-- agent-skills:doc-keeper:start -->
+## Reference (auto-tracked by doc-keeper)
+
+### Environment Variables
+- `HASHPILOT_TELEMETRY`: set to `0`/`false`/`off`/`no` to disable telemetry logging. Overridden by `--no-telemetry`.
+- `HASHPILOT_ROUTE_POLICY`: JSON route policy, highest-priority config layer.
+<!-- agent-skills:doc-keeper:end -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,19 +16,19 @@ Milestones: [Sprint 1 — Stop the Bleeding](../../milestone/1) · [Sprint 2 —
 
 Data-loss and silent-failure defects. **Nothing else ships until these land.** Three of these destroy user files today and report `success: true`.
 
-| # | Item | Score | Pri | Evidence | Area |
-|---|------|-------|-----|----------|------|
-| [#3](../../issues/3) | B1 — Stale anchor overwrites the entire file instead of refusing | 64 | P0 | verified | correctness · data-loss |
-| [#6](../../issues/6) | B5 — `--range` with no colon (NaN) silently duplicates the file | 63 | P0 | verified | correctness · data-loss |
-| [#5](../../issues/5) | B3 — No write boundary; paths can escape the project root | 62 | P0 | verified | security · data-loss |
-| [#4](../../issues/4) | B2 — Every command exits 0, including on failure | 61 | P0 | verified | cli |
-| [#8](../../issues/8) | B6 — Telemetry opt-out is a dead switch; logs contain source + secrets | 59 | P0 | verified | security |
-| [#10](../../issues/10) | B13 — Verification result is ignored by the rollback decision | 57 | P1 | reported | correctness |
-| [#9](../../issues/9) | B11 — `remove-parameter` is structurally non-functional but advertised | 56 | P1 | verified | correctness |
-| [#11](../../issues/11) | B20 — Version drift 0.1.0 vs v1.5.3; nothing publishes | 51 | P1 | verified | ops |
-| [#7](../../issues/7) | B7 — `diff apply` without `--patch` crashes and exits 0 | 48 | P0 | verified | cli |
+| # | Item | Score | Pri | Evidence | Area | Status |
+|---|------|-------|-----|----------|------|--------|
+| [#3](../../issues/3) | B1 — Stale anchor overwrites the entire file instead of refusing | 64 | P0 | verified | correctness · data-loss | ✅ done |
+| [#6](../../issues/6) | B5 — `--range` with no colon (NaN) silently duplicates the file | 63 | P0 | verified | correctness · data-loss | ✅ done |
+| [#5](../../issues/5) | B3 — No write boundary; paths can escape the project root | 62 | P0 | verified | security · data-loss | ✅ done |
+| [#4](../../issues/4) | B2 — Every command exits 0, including on failure | 61 | P0 | verified | cli | ✅ done |
+| [#8](../../issues/8) | B6 — Telemetry opt-out is a dead switch; logs contain source + secrets | 59 | P0 | verified | security | ✅ done |
+| [#10](../../issues/10) | B13 — Verification result is ignored by the rollback decision | 57 | P1 | reported | correctness | ⏭ deferred to Sprint 2 |
+| [#9](../../issues/9) | B11 — `remove-parameter` is structurally non-functional but advertised | 56 | P1 | verified | correctness | ✅ done |
+| [#11](../../issues/11) | B20 — Version drift 0.1.0 vs v1.5.3; nothing publishes | 51 | P1 | verified | ops | ✅ done |
+| [#7](../../issues/7) | B7 — `diff apply` without `--patch` crashes and exits 0 | 48 | P0 | verified | cli | ✅ done |
 
-**Sequencing:** B13 must ship with or after [#24](../../issues/24) (B32, unscoped test runs) — otherwise honoring the verify result turns a silent no-op into an aggressive footgun that reverts good work on an unrelated pre-existing test failure.
+**Sequencing:** B13 must ship with or after [#24](../../issues/24) (B32, unscoped test runs) — otherwise honoring the verify result turns a silent no-op into an aggressive footgun that reverts good work on an unrelated pre-existing test failure. It is therefore deferred into Sprint 2 alongside #24; the other eight items landed.
 
 ## Sprint 2 — Foundations
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Single source of truth for what is being worked on and in what order.
 
-- **Source of the backlog:** [`AUDIT-2026-08.md`](AUDIT-2026-08.md) — full repo audit (Aug 2026), 49 scored items.
+- **Source of the backlog:** [`AUDIT-2026-08.md`](AUDIT-2026-08.md) — full repo audit (Aug 2026), 49 scored items. Items B50+ were found later, during review of the sprint work itself.
 - **Tracking:** every item is a GitHub issue labeled `audit-2026-08`, with a `P0`–`P3` label and a sprint milestone.
 - **Scoring:** `Score = (Impact × 5) + (Evidence × 2) − (Effort × 2)`. The score ranks items *within* a sprint; it is not a tier threshold.
 - **Priority tier** reflects sprint assignment, not a score band: **P0**/**P1** = Sprints 1–2 (safety, then engine correctness) · **P2** = Sprints 3–4 · **P3** = Backlog. A high score does not by itself make an item P0 — sequencing risk does. B7 scores only 48 but ships in Sprint 1 as a one-line companion to B2; B33 scores 48 and waits for Sprint 3 because nothing depends on it.
@@ -49,8 +49,10 @@ Correctness of the edit engine itself, plus the output contract everything downs
 | [#15](../../issues/15) | B10 — `intent` reference resolution is regex text matching, skips call sites | 47 | P1 | reported | correctness |
 | [#21](../../issues/21) | B18 — Read-modify-write TOCTOU across all tiers | 46 | P1 | reported | correctness · data-loss |
 | [#20](../../issues/20) | B17 — Concurrent JSONL writes corrupt telemetry; corruption swallowed | 43 | P1 | reported | correctness |
+| [#55](../../issues/55) | B50 — AST tier is non-functional on any file larger than 32KB | 60 | P1 | verified | correctness |
+| [#56](../../issues/56) | B51 — Output contract mixes bare arrays and objects | 44 | P2 | verified | cli |
 
-**Sequencing:** B15's envelope is the contract for the CLI work in Sprint 3 and for the MCP server ([#25](../../issues/25)); land it before either. Changing output shapes requires updating [`docs/ADAPTER-CONTRACT.md`](docs/ADAPTER-CONTRACT.md) and the affected tests in the same PR.
+**Sequencing:** B15's envelope is the contract for the CLI work in Sprint 3 and for the MCP server ([#25](../../issues/25)); land it before either. Changing output shapes requires updating [`docs/ADAPTER-CONTRACT.md`](docs/ADAPTER-CONTRACT.md) and the affected tests in the same PR. [#56](../../issues/56) (B51) must land *inside* B15 rather than before it, so consumers absorb one breaking output change instead of two. [#55](../../issues/55) (B50) and [#13](../../issues/13) (B8) touch the same tree-sitter call sites — sequence them together.
 
 ## Sprint 3 — Parity
 
@@ -98,6 +100,7 @@ Catching up to what competitors already ship: MCP distribution, interactivity, p
 | [#50](../../issues/50) | B48 — Telemetry retention never enforced; backup to a fixed `/tmp` path | 37 | P3 | ops · security |
 | [#43](../../issues/43) | B41 — `intent` parses every repo file twice, serially, per invocation | 36 | P3 | performance |
 | [#47](../../issues/47) | B45 — Add `--quiet`/`--verbose`/`--no-color`; respect `NO_COLOR` | 36 | P3 | cli |
+| [#57](../../issues/57) | B52 — `grep-many` args are positional but read as flags; Commander errors escape the JSON envelope | 38 | P3 | cli |
 | [#51](../../issues/51) | B49 — Long tail: seven small correctness and hygiene defects | 30 | P3 | correctness |
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,6 +36,7 @@ Correctness of the edit engine itself, plus the output contract everything downs
 
 | # | Item | Score | Pri | Evidence | Area |
 |---|------|-------|-----|----------|------|
+| [#55](../../issues/55) | B50 — AST tier is non-functional on any file larger than 32KB | 60 | P1 | verified | correctness |
 | [#13](../../issues/13) | B8 — No `hasError` parse-validity gate; AST edits write garbage | 59 | P1 | verified | correctness |
 | [#12](../../issues/12) | B4 — No atomic writes, no backups, no undo | 56 | P0 | reported | correctness · data-loss |
 | [#16](../../issues/16) | B12 — Plans inject C-style `/* TODO */` comments into Python/Go/Rust | 52 | P1 | reported | correctness |
@@ -48,9 +49,8 @@ Correctness of the edit engine itself, plus the output contract everything downs
 | [#19](../../issues/19) | B16 — `--json` permanently on; no human output mode | 49 | P1 | verified | cli |
 | [#15](../../issues/15) | B10 — `intent` reference resolution is regex text matching, skips call sites | 47 | P1 | reported | correctness |
 | [#21](../../issues/21) | B18 — Read-modify-write TOCTOU across all tiers | 46 | P1 | reported | correctness · data-loss |
-| [#20](../../issues/20) | B17 — Concurrent JSONL writes corrupt telemetry; corruption swallowed | 43 | P1 | reported | correctness |
-| [#55](../../issues/55) | B50 — AST tier is non-functional on any file larger than 32KB | 60 | P1 | verified | correctness |
 | [#56](../../issues/56) | B51 — Output contract mixes bare arrays and objects | 44 | P2 | verified | cli |
+| [#20](../../issues/20) | B17 — Concurrent JSONL writes corrupt telemetry; corruption swallowed | 43 | P1 | reported | correctness |
 
 **Sequencing:** B15's envelope is the contract for the CLI work in Sprint 3 and for the MCP server ([#25](../../issues/25)); land it before either. Changing output shapes requires updating [`docs/ADAPTER-CONTRACT.md`](docs/ADAPTER-CONTRACT.md) and the affected tests in the same PR. [#56](../../issues/56) (B51) must land *inside* B15 rather than before it, so consumers absorb one breaking output change instead of two. [#55](../../issues/55) (B50) and [#13](../../issues/13) (B8) touch the same tree-sitter call sites — sequence them together.
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "hashpilot",
@@ -19,6 +20,7 @@
         "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^11.0.0",
+        "@semantic-release/npm": "^12.0.1",
         "@semantic-release/release-notes-generator": "^14.0.0",
         "@types/bun": "^1.1.0",
         "@types/node": "^20.11.0",
@@ -392,7 +394,7 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
-    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+    "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
@@ -590,11 +592,15 @@
 
     "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 
+    "cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
     "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
 
     "env-ci/execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
     "execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "fdir/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -955,8 +961,6 @@
     "npm/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
-
-    "read-pkg/parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
     "semantic-release/@semantic-release/error": ["@semantic-release/error@4.0.0", "", {}, "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="],
 

--- a/docs/ADAPTER-CONTRACT.md
+++ b/docs/ADAPTER-CONTRACT.md
@@ -173,7 +173,27 @@ structured-edit replace-hash <file> <old-hash> <new-content> [--range start:end]
 - `--range` is 1-indexed, inclusive start and exclusive end
 - Provenance options: `--actor`, `--task-id`, `--reason`
 
-**Auto-recovery:** If the file was modified since the hash was computed (stale anchor), the tool auto-recovers by default, applying the edit to the current file content. Returns `retries: 1` on recovery. For full-file replaces (no `--range`), this is always safe. For range-based replaces, the edit applies to the current range content. To disable auto-recovery and force stale-anchor failure, pass `--no-recovery` (internal API only).
+**Stale-anchor recovery (relocation only).** If the anchor hash no longer matches
+the requested range, the tool tries to *relocate* the anchor: it slides a window
+the same height as the range over the file and looks for content whose hash
+equals `<old-hash>`.
+
+- Exactly one match → the edit applies there. `stale: true`, `retries: 1`, and
+  `relocatedTo: {start, end}` reports where it landed.
+- More than one match → `AMBIGUOUS_ANCHOR`. The file is not touched.
+- No match → `STALE_ANCHOR`. The file is not touched.
+
+**Breaking change:** recovery no longer applies to a whole-file anchor (no
+`--range`). Previously a mismatch there caused `<new-content>` to replace the
+entire file, silently discarding whatever changed since the read. That path now
+fails with `STALE_ANCHOR` — re-read the file and retry with the fresh hash.
+
+Recovery can be disabled with `--no-recovery` (or `recovery: "off"` in the API),
+which turns any mismatch into an immediate `STALE_ANCHOR`.
+
+**Range validation:** `--range` bounds must be integers, `1 <= start <= end`, and
+`end` no greater than the file's last line. Anything else is `INVALID_ARGUMENT`
+with no write attempted.
 
 **Output (success):**
 ```json
@@ -190,7 +210,7 @@ structured-edit replace-hash <file> <old-hash> <new-content> [--range start:end]
 }
 ```
 
-**Output (auto-recovered):**
+**Output (relocated):**
 ```json
 {
   "path": "/abs/path/file.ts",
@@ -198,12 +218,28 @@ structured-edit replace-hash <file> <old-hash> <new-content> [--range start:end]
   "oldHash": "abc123def456",
   "newHash": "789ghi012jkl",
   "linesChanged": 3,
-  "stale": false,
+  "stale": true,
   "retries": 1,
-  "message": "Replaced 5 lines with 3 lines (auto-recovered from stale anchor, range 10-15)",
-  "diff": "- 10 | old line\n+ 10 | new line\n  11 | unchanged"
+  "relocatedTo": { "start": 12, "end": 17 },
+  "message": "Replaced 5 lines with 3 lines (anchor relocated to 12-17)",
+  "diff": "- 12 | old line\n+ 12 | new line\n  13 | unchanged"
 }
 ```
+
+**Output (anchor could not be relocated):**
+```json
+{
+  "path": "/abs/path/file.ts",
+  "success": false,
+  "stale": true,
+  "retries": 0,
+  "errorCode": "STALE_ANCHOR",
+  "message": "Anchor abc123def456 no longer matches and could not be relocated. Re-read the file and retry."
+}
+```
+
+An agent seeing `STALE_ANCHOR` or `AMBIGUOUS_ANCHOR` (exit code `3`) should
+re-read the file and retry rather than give up.
 
 ---
 
@@ -480,7 +516,13 @@ structured-edit intent '<json>' [--project-root <dir>] [--dry-run] [--no-verify]
 {"operation":"add-parameter","symbol":"myFunction","param":{"name":"x","type":"string","default":"\"hello\""}}
 ```
 
-**Supported operations:** `add-parameter`, `remove-parameter`, `rename-exported-symbol`
+**Supported operations:** `add-parameter`, `rename-exported-symbol`
+
+`remove-parameter` is **not implemented** and is rejected with
+`UNSUPPORTED_OPERATION` (exit code `1`). It was previously accepted but produced
+a plan whose call-site steps searched for a literal `/* TODO: remove arg */`
+string that never matches. Remove a parameter with `ast replace-body` on the
+signature plus `diff apply` at each call site.
 
 **Output:**
 ```json
@@ -777,10 +819,27 @@ Compare the current window against the previous window of the same length.
 All commands return JSON with:
 - `success: false` on operation failure
 - `error` field on file-level failures
-- `stale: true` on hash mismatch (auto-recovered by default, `"retries": 1` on recovery)
+- `errorCode` — a stable machine-readable code (see below)
+- `stale: true` on hash mismatch; `relocatedTo` when the anchor was relocated
 - `message` with human-readable description
+
+**Error codes:** `PARSE_ERROR`, `SYMBOL_NOT_FOUND`, `STALE_ANCHOR`,
+`AMBIGUOUS_ANCHOR`, `HASH_MISMATCH`, `INVALID_ARGUMENT`, `PATH_DENIED`,
+`UNSUPPORTED_OPERATION`, `FILE_NOT_FOUND`, `WRITE_FAILED`, `VERIFY_FAILED`.
 
 ## Exit Codes
 
-- `0`: Success
-- `1`: General error (file not found, parse error, stale anchor, etc.)
+Branch on the exit code, not on stderr text.
+
+| Code | Meaning | What an agent should do |
+|------|---------|-------------------------|
+| `0` | Success | Continue |
+| `1` | Usage error — bad arguments, denied path, unsupported operation | Fix the invocation; do not retry as-is |
+| `2` | Edit failed — the operation ran but could not be applied | Try another route or report |
+| `3` | Stale anchor / precondition failed | **Retryable:** re-read the file and reissue with the fresh hash |
+| `4` | Verification failed — the edit applied but format/lint/test did not pass | Inspect the verify output; the edit may have been reverted |
+| `5` | I/O error — file not found, write failed | Check the path and permissions |
+| `70` | Internal error | Report a bug |
+
+Batch commands return the worst code across all items; an all-success batch
+returns `0`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -140,9 +140,37 @@ HashPilot has two complementary docs that must always be kept in sync with the c
 - `provenanceQuery(file, line?)`: Shows edit history per file/line
 - Like `git blame` for agent edits
 - Records: actor, taskId, reason, timestamp, operation, file, hash
+- Unified diffs are **opt-in** (`provenance.captureDiffs`, default off) and are
+  never captured for files `isSensitiveFile` matches; hashes still record that
+  the file changed
+
+#### `src/paths.ts` — Write Boundary
+- `assertWritable(path, opts)`: resolves symlinks, then requires the target to sit
+  inside the project root (or an explicitly allowed root). Otherwise `PATH_DENIED`.
+- Hard deny-list that no option can override: `~/.ssh`, `~/.aws`, `~/.gnupg`,
+  `/etc`, shell startup files, and HashPilot's own telemetry log. Deny targets are
+  themselves realpath-resolved (on macOS `/etc` is a symlink to `/private/etc`).
+- Widened by `allowedRoots` in config or `--allowed-root`; disabled by `--allow-outside-root`.
+- `safeWrite` is the single write path used by every edit route.
+
+#### `src/exit-codes.ts` — Agent-Facing Exit Contract
+- Maps `ErrorCode` → process exit code: `0` ok, `1` usage, `2` edit failed,
+  `3` stale/precondition (retryable), `4` verify failed, `5` I/O, `70` internal.
+- `finish(payload)` prints JSON and sets the code; batch commands take the worst.
+
+#### `src/redact.ts` — Credential Scrubbing
+- `redactSecrets(text)`: replaces credential shapes (AWS, OpenAI, Anthropic,
+  GitHub, Slack, Google, JWT, private-key blocks, auth headers, connection-string
+  passwords, and secret-named assignments) with `[REDACTED]`.
+- `isSensitiveFile(path)`: basename denylist (`.env*`, `*.pem`, `*.key`, `id_rsa`,
+  `credentials`, `.npmrc`, `.netrc`, `secrets.*`) used to suppress diff capture.
+- `redactEvent(event)`: recursive walk applied to every telemetry record.
 
 #### `src/telemetry.ts` — Structured JSONL Logging
-- Logs to `~/.agentic-tools/logs/`
+- Logs to `~/.agentic-tools/logs/` (dir `0700`, file `0600`; older logs tightened on write)
+- Kill switch, highest priority first: `--no-telemetry` → `HASHPILOT_TELEMETRY=0`
+  → `telemetry.enabled` in config → on
+- Every record passes through `redactEvent` before it is written
 - Every CLI command records: operation name, route, file, language, success, elapsed_ms
 - Health reports with threshold warnings:
   - Stale-anchor rate (warns >10%)
@@ -443,3 +471,7 @@ Every deploy to GitHub Pages **must** be verified with browser automation:
 6. **After every deploy:** Browser-verify the live site (see Post-Deploy Verification above).
 
 The CI check `docs-verify` enforces rule 5 — if `src/` files change but neither landing nor design doc changes, the PR fails.
+
+---
+
+_Last updated: 2026-08-11 — Sprint 1 (safety hardening: write boundary, exit codes, telemetry opt-out, anchor relocation)._

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hashpilot",
-  "version": "0.1.0",
-  "description": "HashPilot — Global Tool-Agnostic Structured Editing Core for Coding Agents",
+  "version": "1.5.3",
+  "description": "HashPilot \u2014 Global Tool-Agnostic Structured Editing Core for Coding Agents",
   "type": "module",
   "bin": {
     "structured-edit": "./src/cli.ts"
@@ -59,6 +59,7 @@
     "@semantic-release/release-notes-generator": "^14.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "conventional-changelog-conventionalcommits": "^8.0.0"
+    "conventional-changelog-conventionalcommits": "^8.0.0",
+    "@semantic-release/npm": "^12.0.1"
   }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-HASHPILOT_VERSION="0.1.0"
+# Read the version from package.json so the installer can never drift from the
+# released version. Falls back to "unknown" rather than a stale literal.
+HASHPILOT_VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$(dirname "$0")/../package.json" 2>/dev/null | head -1)"
+HASHPILOT_VERSION="${HASHPILOT_VERSION:-unknown}"
 # shellcheck disable=SC2034
 BOLD='\033[1m'
 DIM='\033[2m'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env bun
 import { Command } from "commander";
+// Single source of truth for the version. Bun inlines this JSON import at build
+// time, so dist/ carries the real version instead of a hardcoded literal.
+import pkg from "../package.json" with { type: "json" };
 import {
   readMany,
   readHash,
@@ -41,14 +44,72 @@ import {
   provenanceQuery,
   changeSetQuery,
   formatProvenanceHuman,
+  safeWrite,
+  assertWritable,
+  PathDeniedError,
+  configureWriteBoundary,
+  finish,
+  usageError,
+  ExitCode,
+  exitCodeFor,
+  configureTelemetry,
+  enableTelemetry,
+  resolveTelemetryEnabled,
 } from "./core/index";
+import type { TelemetryEvent } from "./core/telemetry";
+
+const VERSION: string = pkg.version;
 
 const program = new Command();
+
+/**
+ * Parse `--range`. Accepts `N` (meaning `N:N`) or `N:M`, both 1-indexed and
+ * inclusive. Returns an error string rather than throwing so the caller can
+ * emit it through `usageError`.
+ *
+ * The old implementation was `opts.range.split(":").map(Number)`, which turned
+ * `--range 5` into `{start: 5, end: NaN}` and silently duplicated the file.
+ */
+function parseRange(raw: string): { range: { start: number; end: number } } | { error: string } {
+  const match = /^(\d+)(?::(\d+))?$/.exec(raw.trim());
+  if (!match) {
+    return { error: `Invalid --range "${raw}": expected N or N:M with positive integers.` };
+  }
+  const start = Number(match[1]);
+  const end = match[2] === undefined ? start : Number(match[2]);
+  if (start < 1) return { error: `Invalid --range "${raw}": line numbers are 1-indexed.` };
+  if (start > end) return { error: `Invalid --range "${raw}": start is after end.` };
+  return { range: { start, end } };
+}
+
+/** Parse a numeric flag, rejecting the NaN that bare `parseInt` yields on garbage. */
+function parseIntFlag(raw: string | undefined, name: string, fallback: number): number | { error: string } {
+  if (raw === undefined) return fallback;
+  if (!/^\d+$/.test(String(raw).trim())) {
+    return { error: `Invalid ${name} "${raw}": expected a non-negative integer.` };
+  }
+  return Number(raw);
+}
 
 program
   .name("structured-edit")
   .description("HashPilot — Structured Editing Core for Coding Agents")
-  .version("0.1.0");
+  .version(VERSION)
+  .option("--allow-outside-root", "Permit writes outside the project root (credentials and system paths stay blocked)")
+  .option("--allowed-root <dir...>", "Additional directory writes may target")
+  .option("--no-telemetry", "Disable telemetry logging for this invocation")
+  .hook("preAction", (thisCommand) => {
+    const globals = thisCommand.opts();
+    const config = loadConfig();
+    configureWriteBoundary({
+      allowOutsideRoot: Boolean(globals.allowOutsideRoot),
+      allowedRoots: [...(config.allowedRoots || []), ...(globals.allowedRoot || [])],
+    });
+    // Apply sizing/retention from config, then the kill switch, so the CLI flag
+    // and env var win over `telemetry.enabled`.
+    configureTelemetry(config.telemetry);
+    enableTelemetry(resolveTelemetryEnabled(config.telemetry, globals.telemetry === false));
+  });
 
 program
   .command("read-many")
@@ -65,7 +126,7 @@ program
       success: !results.some((r) => r.error),
       elapsed_ms: Date.now() - start,
     });
-    console.log(JSON.stringify(results, null, 2));
+    finish(results);
   });
 
 program
@@ -77,7 +138,9 @@ program
   .option("--json", "Output as JSON", true)
   .action(async (file: string, line: number, opts) => {
     const start = Date.now();
-    const result = await readHash(file, line, parseInt(opts.context));
+    const context = parseIntFlag(opts.context, "--context", 3);
+    if (typeof context === "object") return usageError(context.error, { path: file });
+    const result = await readHash(file, line, context);
     recordEvent({
       operation: "read-hash",
       route: "hash",
@@ -86,7 +149,7 @@ program
       lines_read: 1 + (result.contextBefore?.length || 0) + (result.contextAfter?.length || 0),
       elapsed_ms: Date.now() - start,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 program
@@ -111,7 +174,7 @@ program
       success: !result.error,
       elapsed_ms: result.elapsed_ms,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 program
@@ -123,7 +186,7 @@ program
   .action(async (paths: string[], opts) => {
     const names = (opts.names || "").split(",").filter(Boolean);
     const results = await symbolLookupMany(names, paths);
-    console.log(JSON.stringify(results, null, 2));
+    finish(results);
   });
 
 program
@@ -132,7 +195,8 @@ program
   .argument("<file>", "File path")
   .argument("<old-hash>", "Hash of content to replace")
   .argument("<new-content>", "New content (or @file to read from file)")
-  .option("--range <start:end>", "Line range (1-indexed)")
+  .option("--range <start:end>", "Line range (1-indexed). N or N:M")
+  .option("--no-recover", "Fail immediately on a stale anchor instead of attempting relocation")
   .option("--dry-run", "Preview without writing")
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
@@ -145,12 +209,15 @@ program
     }
     let range: { start: number; end: number } | undefined;
     if (opts.range) {
-      const [s, e] = opts.range.split(":").map(Number);
-      range = { start: s, end: e };
+      const parsed = parseRange(opts.range);
+      if ("error" in parsed) return usageError(parsed.error, { path: file });
+      range = parsed.range;
     }
     const result = await replaceHash(file, oldHash, content, {
       range,
       dryRun: opts.dryRun,
+      // Commander maps --no-recover to opts.recover === false.
+      recovery: opts.recover === false ? "off" : "relocate",
     });
     const provFields = buildProvenanceFields({
       actor: opts.actor,
@@ -169,7 +236,7 @@ program
       elapsed_ms: 0,
       ...provFields,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 const astCmd = program
@@ -180,7 +247,7 @@ astCmd
   .command("capabilities")
   .description("Show supported AST languages, operations, and limitations")
   .action(() => {
-    console.log(JSON.stringify(astCapabilities(), null, 2));
+    finish(astCapabilities());
   });
 
 astCmd
@@ -190,7 +257,7 @@ astCmd
   .action(async (file: string) => {
     const content = await Bun.file(file).text();
     const symbols = findSymbols(content, file);
-    console.log(JSON.stringify(symbols, null, 2));
+    finish(symbols);
   });
 
 function recordProvenanceEvent(opts: {
@@ -225,7 +292,7 @@ astCmd
     const content = await Bun.file(file).text();
     const result = renameSymbol(content, file, oldName, newName);
     if (result.success && result.newSource && !opts.dryRun) {
-      await Bun.write(file, result.newSource);
+      await safeWrite(file, result.newSource);
     }
     recordProvenanceEvent({
       operation: "rename-symbol", route: "ast", file,
@@ -235,7 +302,7 @@ astCmd
       source: content, newSource: result.newSource, filePath: file,
       actor: opts.actor, taskId: opts.taskId, reason: opts.reason,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 astCmd
@@ -256,7 +323,7 @@ astCmd
     const content = await Bun.file(file).text();
     const result = replaceBody(content, file, symbol, body);
     if (result.success && result.newSource && !opts.dryRun) {
-      await Bun.write(file, result.newSource);
+      await safeWrite(file, result.newSource);
     }
     recordProvenanceEvent({
       operation: "replace-body", route: "ast", file,
@@ -266,7 +333,7 @@ astCmd
       source: content, newSource: result.newSource, filePath: file,
       actor: opts.actor, taskId: opts.taskId, reason: opts.reason,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 astCmd
@@ -284,7 +351,7 @@ astCmd
     const content = await Bun.file(file).text();
     const result = addImport(content, file, importSpec);
     if (result.success && result.newSource && !opts.dryRun) {
-      await Bun.write(file, result.newSource);
+      await safeWrite(file, result.newSource);
     }
     recordProvenanceEvent({
       operation: "add-import", route: "ast", file,
@@ -294,7 +361,7 @@ astCmd
       source: content, newSource: result.newSource, filePath: file,
       actor: opts.actor, taskId: opts.taskId, reason: opts.reason,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 astCmd
@@ -312,7 +379,7 @@ astCmd
     const content = await Bun.file(file).text();
     const result = removeImport(content, file, importSpec);
     if (result.success && result.newSource && !opts.dryRun) {
-      await Bun.write(file, result.newSource);
+      await safeWrite(file, result.newSource);
     }
     recordProvenanceEvent({
       operation: "remove-import", route: "ast", file,
@@ -322,7 +389,7 @@ astCmd
       source: content, newSource: result.newSource, filePath: file,
       actor: opts.actor, taskId: opts.taskId, reason: opts.reason,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 astCmd
@@ -343,7 +410,7 @@ astCmd
     const src = await Bun.file(file).text();
     const result = insertBeforeSymbol(src, file, symbol, c);
     if (result.success && result.newSource && !opts.dryRun) {
-      await Bun.write(file, result.newSource);
+      await safeWrite(file, result.newSource);
     }
     recordProvenanceEvent({
       operation: "insert-before", route: "ast", file,
@@ -353,7 +420,7 @@ astCmd
       source: src, newSource: result.newSource, filePath: file,
       actor: opts.actor, taskId: opts.taskId, reason: opts.reason,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 astCmd
@@ -374,7 +441,7 @@ astCmd
     const src = await Bun.file(file).text();
     const result = insertAfterSymbol(src, file, symbol, c);
     if (result.success && result.newSource && !opts.dryRun) {
-      await Bun.write(file, result.newSource);
+      await safeWrite(file, result.newSource);
     }
     recordProvenanceEvent({
       operation: "insert-after", route: "ast", file,
@@ -384,7 +451,7 @@ astCmd
       source: src, newSource: result.newSource, filePath: file,
       actor: opts.actor, taskId: opts.taskId, reason: opts.reason,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 program
@@ -437,7 +504,7 @@ program
       reason: opts.reason,
     });
 
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 program
@@ -495,7 +562,7 @@ program
       ? await editManySerial(batchParams)
       : await editMany(batchParams);
 
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 program
@@ -532,7 +599,7 @@ program
       });
 
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        finish(result);
       } else {
         console.log(`Intent: ${result.plan.intent.operation} on '${result.plan.definition.name}'`);
         console.log(`Impact: ${result.plan.impactSummary}`);
@@ -603,12 +670,14 @@ diffCmd
     } else if (opts.patch) {
       patchText = await Bun.file(opts.patch).text();
     } else {
-      console.log(JSON.stringify({ success: false, message: "--patch is required" }));
-      process.exitCode = 1;
+      // Must return: without it, patchText is unassigned and applyPatch throws.
+      return usageError("--patch is required", { path: file });
     }
+    const fuzzy = parseIntFlag(opts.fuzzy, "--fuzzy", 3);
+    if (typeof fuzzy === "object") return usageError(fuzzy.error, { path: file });
     const result = await applyPatch(file, patchText, {
       dryRun: opts.dryRun,
-      fuzzyMatch: parseInt(opts.fuzzy),
+      fuzzyMatch: fuzzy,
     });
     const provFields = buildProvenanceFields({
       actor: opts.actor, taskId: opts.taskId, reason: opts.reason, filePath: file,
@@ -622,7 +691,7 @@ diffCmd
       elapsed_ms: Date.now() - start,
       ...provFields,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 program
@@ -655,7 +724,7 @@ program
       revertOnFailure: opts.revertOnFailure,
       timeout: opts.timeout,
     });
-    console.log(JSON.stringify(result, null, 2));
+    finish(result);
   });
 
 const telCmd = program
@@ -668,14 +737,14 @@ telCmd
   .option("-n, --limit <n>", "Number of events", "20")
   .action(async (opts) => {
     const events = readEvents(parseInt(opts.limit));
-    console.log(JSON.stringify(events, null, 2));
+    finish(events);
   });
 
 telCmd
   .command("summary")
   .description("Show telemetry summary")
   .action(() => {
-    console.log(JSON.stringify(summary(), null, 2));
+    finish(summary());
   });
 
 telCmd
@@ -686,10 +755,10 @@ telCmd
   .action((opts) => {
     if (opts.trend) {
       const report = healthTrend(parseInt(opts.window));
-      console.log(JSON.stringify(report, null, 2));
+      finish(report);
     } else {
       const report = health(parseInt(opts.window));
-      console.log(JSON.stringify(report, null, 2));
+      finish(report);
     }
   });
 
@@ -706,7 +775,7 @@ telCmd
   .description("List session summaries")
   .action(() => {
     const sessions = listSessions();
-    console.log(JSON.stringify(sessions, null, 2));
+    finish(sessions);
   });
 
 telCmd
@@ -721,6 +790,8 @@ telCmd
       to: opts.to ? new Date(opts.to) : undefined,
       sessionId: opts.session,
     });
+    // NDJSON: one compact object per line, so `finish` (which pretty-prints a
+    // single payload and sets the exit code) is not the right tool here.
     for (const e of events) {
       console.log(JSON.stringify(e));
     }
@@ -780,7 +851,7 @@ provCmd
       console.log(`Time: ${result.timeRange.first} -- ${result.timeRange.last}\n`);
       console.log(formatProvenanceHuman(result.entries));
     } else {
-      console.log(JSON.stringify(result, null, 2));
+      finish(result);
     }
   });
 
@@ -800,7 +871,7 @@ program
       const icon = check.status === "pass" ? "✓" : check.status === "fail" ? "✗" : check.status === "warn" ? "!" : "·";
       summaryParts.push(`  ${icon} ${check.name}: ${check.message}`);
     }
-    console.log(JSON.stringify(report, null, 2));
+    finish(report);
     console.error(summaryParts.join("\n"));
   });
 
@@ -818,13 +889,13 @@ program
       policy = loadConfig().routePolicy;
     }
     const { route, explanation } = chooseRoute(file, operation, policy);
-    console.log(JSON.stringify({
+    finish({
       file,
       operation,
       language: lang,
       route,
       explanation,
-    }, null, 2));
+    });
   });
 
 program
@@ -833,7 +904,37 @@ program
   .option("--config <path>", "Config file path override")
   .action((opts) => {
     const config = loadConfig(opts.config);
-    console.log(JSON.stringify(config, null, 2));
+    finish(config);
   });
 
-program.parse();
+/**
+ * Nothing below a command action should ever surface a raw stack trace to an
+ * agent parsing stdout. Uncaught failures exit 70 with the same JSON envelope
+ * shape as every other error.
+ */
+function reportInternalError(err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  if (err instanceof PathDeniedError) {
+    finish({ success: false, errorCode: err.errorCode, path: err.path, message }, ExitCode.USAGE);
+    return;
+  }
+  finish(
+    {
+      success: false,
+      errorCode: "INTERNAL_ERROR",
+      message,
+      detail: err instanceof Error ? err.stack : undefined,
+      recovery: "This is a bug in HashPilot. Please report it with the command that triggered it.",
+    },
+    ExitCode.INTERNAL,
+  );
+}
+
+process.on("uncaughtException", reportInternalError);
+process.on("unhandledRejection", reportInternalError);
+
+try {
+  program.parse();
+} catch (err) {
+  reportInternalError(err);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -607,6 +607,9 @@ program
         if (result.execution.verification) {
           console.log(`Verification: ${result.execution.verification.overall}`);
         }
+        // Human output still has to carry the exit contract — an agent may run
+        // without --json and branch on the code.
+        process.exitCode = exitCodeFor(result);
       }
     } catch (err: any) {
       console.error(`Intent failed: ${err.message}`);
@@ -736,7 +739,9 @@ telCmd
   .description("Show recent telemetry events")
   .option("-n, --limit <n>", "Number of events", "20")
   .action(async (opts) => {
-    const events = readEvents(parseInt(opts.limit));
+    const limit = parseIntFlag(opts.limit, "--limit", 20);
+    if (typeof limit === "object") return usageError(limit.error);
+    const events = readEvents(limit);
     finish(events);
   });
 
@@ -753,13 +758,9 @@ telCmd
   .option("-w, --window <days>", "Time window in days", "7")
   .option("-t, --trend", "Compare current window to previous window")
   .action((opts) => {
-    if (opts.trend) {
-      const report = healthTrend(parseInt(opts.window));
-      finish(report);
-    } else {
-      const report = health(parseInt(opts.window));
-      finish(report);
-    }
+    const window = parseIntFlag(opts.window, "--window", 7);
+    if (typeof window === "object") return usageError(window.error);
+    finish(opts.trend ? healthTrend(window) : health(window));
   });
 
 telCmd
@@ -850,6 +851,7 @@ provCmd
       console.log(`Edits: ${result.editCount}`);
       console.log(`Time: ${result.timeRange.first} -- ${result.timeRange.last}\n`);
       console.log(formatProvenanceHuman(result.entries));
+      process.exitCode = exitCodeFor(result);
     } else {
       finish(result);
     }
@@ -907,6 +909,11 @@ program
     finish(config);
   });
 
+/** Node syscall codes that mean "the filesystem said no", not "HashPilot has a bug". */
+const IO_SYSCALL_CODES = new Set([
+  "ENOENT", "EACCES", "EPERM", "EISDIR", "ENOTDIR", "ENOSPC", "EROFS", "EMFILE", "ENFILE", "EBUSY",
+]);
+
 /**
  * Nothing below a command action should ever surface a raw stack trace to an
  * agent parsing stdout. Uncaught failures exit 70 with the same JSON envelope
@@ -916,6 +923,23 @@ function reportInternalError(err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);
   if (err instanceof PathDeniedError) {
     finish({ success: false, errorCode: err.errorCode, path: err.path, message }, ExitCode.USAGE);
+    return;
+  }
+  // Commander's async actions reject outside the try/catch around `parse()`,
+  // so a plain missing file lands here. Those are ordinary I/O failures, not
+  // HashPilot bugs — reporting them as exit 70 tells an agent to file a bug
+  // report instead of fixing its path.
+  const syscall = (err as { code?: string } | undefined)?.code;
+  if (syscall !== undefined && IO_SYSCALL_CODES.has(syscall)) {
+    finish(
+      {
+        success: false,
+        errorCode: syscall === "ENOENT" ? ErrorCode.FILE_NOT_FOUND : ErrorCode.WRITE_FAILED,
+        message,
+        recovery: "Check that the path exists and is readable and writable.",
+      },
+      ExitCode.IO,
+    );
     return;
   }
   finish(

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -23,12 +23,20 @@ export interface ProvenanceConfig {
   defaultActor?: string;
   /** Max length of stored context field (prevents log bloat), default 500 */
   maxContextLength?: number;
+  /**
+   * Record a unified diff of every edit in the telemetry log. Off by default:
+   * a diff puts real source lines on disk in plaintext, which is a leak for
+   * private repos and anything holding credentials. Turn on deliberately.
+   */
+  captureDiffs?: boolean;
 }
 
 export interface HashPilotConfig {
   routePolicy?: RoutePolicy;
   telemetry?: TelemetryConfig;
   provenance?: ProvenanceConfig;
+  /** Extra directories writes may target, beyond the project root. Relative entries resolve against cwd. */
+  allowedRoots?: string[];
 }
 
 const DEFAULT_CONFIG: HashPilotConfig = {
@@ -118,5 +126,8 @@ function mergeConfig(base: HashPilotConfig, override: Partial<HashPilotConfig>):
   }
   if (override.provenance) {
     base.provenance = { ...base.provenance, ...override.provenance };
+  }
+  if (override.allowedRoots) {
+    base.allowedRoots = [...(base.allowedRoots || []), ...override.allowedRoots];
   }
 }

--- a/src/core/diff-engine.ts
+++ b/src/core/diff-engine.ts
@@ -1,3 +1,4 @@
+import { safeWrite } from "./paths";
 export interface Hunk {
   oldStart: number;
   oldLines: number;
@@ -264,7 +265,7 @@ export async function applyPatch(
 
   if (result.success && result.newSource && !dryRun) {
     try {
-      await Bun.write(filePath, result.newSource);
+      await safeWrite(filePath, result.newSource);
     } catch {
       return { success: false, hunksApplied: result.hunksApplied, hunksFailed: result.hunksFailed, message: `Cannot write file: ${filePath}` };
     }

--- a/src/core/exit-codes.ts
+++ b/src/core/exit-codes.ts
@@ -1,0 +1,90 @@
+import { ErrorCode } from "./telemetry";
+
+/**
+ * Process exit codes. Agents branch on these, so the numbers are a contract —
+ * see docs/ADAPTER-CONTRACT.md. Never renumber an existing code.
+ */
+export enum ExitCode {
+  /** Operation succeeded. */
+  OK = 0,
+  /** Bad invocation: missing/malformed flag, denied path, unsupported operation. Retrying verbatim will not help. */
+  USAGE = 1,
+  /** The edit itself failed (symbol not found, parse error, ambiguous match). */
+  EDIT_FAILED = 2,
+  /** A precondition no longer holds (stale anchor, hash mismatch). Agent-retryable after a fresh read. */
+  PRECONDITION = 3,
+  /** The edit applied but verification (format/lint/test) failed. */
+  VERIFY_FAILED = 4,
+  /** Filesystem-level failure: file missing, unreadable, or unwritable. */
+  IO = 5,
+  /** Uncaught internal error — a bug in HashPilot. */
+  INTERNAL = 70,
+}
+
+const ERROR_CODE_EXITS: Record<string, ExitCode> = {
+  [ErrorCode.STALE_ANCHOR]: ExitCode.PRECONDITION,
+  [ErrorCode.HASH_MISMATCH]: ExitCode.PRECONDITION,
+  [ErrorCode.FILE_NOT_FOUND]: ExitCode.IO,
+  [ErrorCode.WRITE_FAILED]: ExitCode.IO,
+  [ErrorCode.PATH_DENIED]: ExitCode.USAGE,
+  [ErrorCode.INVALID_ARGUMENT]: ExitCode.USAGE,
+  [ErrorCode.UNSUPPORTED_OPERATION]: ExitCode.USAGE,
+  [ErrorCode.SYMBOL_NOT_FOUND]: ExitCode.EDIT_FAILED,
+  [ErrorCode.PARSE_ERROR]: ExitCode.EDIT_FAILED,
+  [ErrorCode.DUPLICATE_MATCH]: ExitCode.EDIT_FAILED,
+  [ErrorCode.UNSUPPORTED_LANGUAGE]: ExitCode.EDIT_FAILED,
+  [ErrorCode.VERIFY_FAILED]: ExitCode.VERIFY_FAILED,
+};
+
+/** Shape every command result is inspected through. All fields optional — results vary by command. */
+export interface ResultLike {
+  success?: boolean;
+  passed?: boolean;
+  error?: string | { code?: string };
+  errorCode?: string;
+  stale?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Derive an exit code from a command result. Falls back to EDIT_FAILED for an
+ * unrecognized failure rather than OK — an unmapped error must never exit 0.
+ */
+export function exitCodeFor(result: ResultLike | ResultLike[] | undefined): ExitCode {
+  if (result === undefined) return ExitCode.OK;
+
+  if (Array.isArray(result)) {
+    // Batch: worst (highest) code wins, so a single failure is never masked.
+    return result.reduce<ExitCode>((worst, r) => {
+      const code = exitCodeFor(r);
+      return code > worst ? code : worst;
+    }, ExitCode.OK);
+  }
+
+  const explicit = result.errorCode ?? (typeof result.error === "object" ? result.error?.code : undefined);
+  if (explicit && ERROR_CODE_EXITS[explicit]) return ERROR_CODE_EXITS[explicit];
+
+  const failed =
+    result.success === false ||
+    result.passed === false ||
+    (result.error !== undefined && result.error !== null);
+  if (!failed) return ExitCode.OK;
+
+  if (result.stale === true) return ExitCode.PRECONDITION;
+  return ExitCode.EDIT_FAILED;
+}
+
+/**
+ * Single exit point for every CLI command: emit the JSON payload, then set the
+ * exit code. Uses `process.exitCode` rather than `process.exit()` so pending
+ * stdout writes and telemetry flushes are not truncated.
+ */
+export function finish(payload: unknown, code?: ExitCode): void {
+  console.log(JSON.stringify(payload, null, 2));
+  process.exitCode = code ?? exitCodeFor(payload as ResultLike);
+}
+
+/** Emit a usage error and exit 1. For malformed flags and missing required options. */
+export function usageError(message: string, extra: Record<string, unknown> = {}): void {
+  finish({ success: false, errorCode: ErrorCode.INVALID_ARGUMENT, message, ...extra }, ExitCode.USAGE);
+}

--- a/src/core/hash-edit.ts
+++ b/src/core/hash-edit.ts
@@ -1,11 +1,28 @@
 import { computeHash } from "./read";
+import { ErrorCode } from "./telemetry";
+import { assertWritable, PathDeniedError, type AssertWritableOptions } from "./paths";
+
+/**
+ * What to do when the anchor hash no longer matches the content at the given range.
+ *
+ * - `relocate` (default): search the file for a window whose hash equals `oldHash`.
+ *   Exactly one match relocates the edit; zero or several is a hard failure.
+ * - `off`: any mismatch fails immediately.
+ *
+ * Neither mode ever applies the edit to content the caller did not anchor to.
+ */
+export type RecoveryMode = "relocate" | "off";
 
 export interface ReplaceHashOptions {
   range?: { start: number; end: number };
   dryRun?: boolean;
   contextLines?: number;
-  /** Skip auto-recovery when stale anchor is detected */
+  /** Stale-anchor policy. Defaults to `"relocate"`. */
+  recovery?: RecoveryMode;
+  /** @deprecated Use `recovery: "off"`. Retained for source compatibility. */
   noRecovery?: boolean;
+  /** Write-boundary overrides forwarded to `assertWritable`. */
+  pathOptions?: AssertWritableOptions;
 }
 
 export interface ReplaceHashResult {
@@ -19,6 +36,29 @@ export interface ReplaceHashResult {
   diff?: string;
   /** Number of auto-retries performed (1 if recovered from stale anchor, 0 otherwise) */
   retries?: number;
+  /** Machine-readable failure cause. Absent on success. */
+  errorCode?: ErrorCode;
+  /** What the caller should do next when `success` is false. */
+  recovery?: string;
+  /** Range the anchor was relocated to, when relocation succeeded. */
+  relocatedTo?: { start: number; end: number };
+}
+
+/**
+ * Slide a window of `windowSize` lines across the file, collecting every start
+ * index whose content hashes to `oldHash`. Stops after two hits — one is enough
+ * to relocate, two is enough to know it is ambiguous.
+ */
+function findAnchorCandidates(lines: string[], windowSize: number, oldHash: string): number[] {
+  const hits: number[] = [];
+  if (windowSize <= 0 || windowSize > lines.length) return hits;
+  for (let start = 0; start + windowSize <= lines.length; start++) {
+    if (computeHash(lines.slice(start, start + windowSize).join("\n")) === oldHash) {
+      hits.push(start);
+      if (hits.length > 1) break;
+    }
+  }
+  return hits;
 }
 
 export async function replaceHash(
@@ -27,24 +67,77 @@ export async function replaceHash(
   newContent: string,
   options: ReplaceHashOptions = {}
 ): Promise<ReplaceHashResult> {
-  const { range, dryRun = false, noRecovery = false } = options;
+  const { range, dryRun = false } = options;
+  // `noRecovery: true` is the legacy spelling of `recovery: "off"`.
+  const recoveryMode: RecoveryMode = options.recovery ?? (options.noRecovery ? "off" : "relocate");
+
+  const fail = (
+    message: string,
+    errorCode: ErrorCode,
+    recovery: string,
+    extra: Partial<ReplaceHashResult> = {},
+  ): ReplaceHashResult => ({
+    path: filePath,
+    success: false,
+    oldHash,
+    newHash: "",
+    linesChanged: 0,
+    stale: false,
+    retries: 0,
+    message,
+    errorCode,
+    recovery,
+    ...extra,
+  });
+
   let content: string;
   try {
     content = await Bun.file(filePath).text();
   } catch (e: any) {
-    return {
-      path: filePath,
-      success: false,
-      oldHash,
-      newHash: "",
-      linesChanged: 0,
-      stale: false,
-      message: `Failed to read file: ${e.message}`,
-      retries: 0,
-    };
+    return fail(
+      `Failed to read file: ${e.message}`,
+      ErrorCode.FILE_NOT_FOUND,
+      "Check that the path exists and is readable.",
+    );
   }
 
   const lines = content.split("\n");
+
+  // Defensive range validation. The CLI validates too, but replaceHash is a
+  // public API: a NaN or inverted range must never reach the slice arithmetic,
+  // where `slice(x, NaN)` yields an empty window and `slice(NaN)` re-appends
+  // the whole file.
+  if (range) {
+    const { start, end } = range;
+    if (!Number.isInteger(start) || !Number.isInteger(end)) {
+      return fail(
+        `Invalid range: start and end must be integers (got ${start}:${end}).`,
+        ErrorCode.INVALID_ARGUMENT,
+        "Pass --range as N or N:M with positive integers.",
+      );
+    }
+    if (start < 1 || end < 1) {
+      return fail(
+        `Invalid range ${start}:${end}: line numbers are 1-indexed.`,
+        ErrorCode.INVALID_ARGUMENT,
+        "Use a start and end of 1 or greater.",
+      );
+    }
+    if (start > end) {
+      return fail(
+        `Invalid range ${start}:${end}: start is after end.`,
+        ErrorCode.INVALID_ARGUMENT,
+        "Swap the bounds so start <= end.",
+      );
+    }
+    if (end > lines.length) {
+      return fail(
+        `Invalid range ${start}:${end}: file has only ${lines.length} lines.`,
+        ErrorCode.INVALID_ARGUMENT,
+        `Use an end of at most ${lines.length}.`,
+      );
+    }
+  }
 
   let targetStart: number;
   let targetEnd: number;
@@ -57,31 +150,77 @@ export async function replaceHash(
     targetEnd = lines.length;
   }
 
-  const targetLines = lines.slice(targetStart, targetEnd);
-  const targetText = targetLines.join("\n");
+  let targetLines = lines.slice(targetStart, targetEnd);
+  let targetText = targetLines.join("\n");
   const currentHash = computeHash(targetText);
+  let stale = false;
+  let retries = 0;
+  let messageSuffix = "";
+  let relocatedTo: { start: number; end: number } | undefined;
 
   if (currentHash !== oldHash) {
-    if (!noRecovery) {
-      // Auto-recovery: the file has changed since the hash was computed.
-      // Apply the edit to the current file content instead of failing.
-      return applyReplacement(filePath, lines, targetStart, targetEnd, targetLines, targetText, newContent, oldHash, dryRun, true, 1, " (auto-recovered from stale anchor)");
+    // A whole-file anchor has nothing to relocate to — the anchor *is* the
+    // file, so a mismatch means the caller's view of the file is stale. There
+    // is no safe interpretation; refuse.
+    const relocatable = recoveryMode === "relocate" && range !== undefined;
+
+    if (!relocatable) {
+      return fail(
+        buildStaleMessage(oldHash, currentHash, targetStart + 1, targetEnd),
+        ErrorCode.STALE_ANCHOR,
+        "Re-read the file to obtain a current hash, then retry.",
+        { newHash: currentHash, stale: true },
+      );
     }
 
-    const staleMsg = buildStaleMessage(oldHash, currentHash, targetStart + 1, targetEnd);
-    return {
-      path: filePath,
-      success: false,
-      oldHash,
-      newHash: currentHash,
-      linesChanged: 0,
-      stale: true,
-      retries: 0,
-      message: staleMsg,
-    };
+    const candidates = findAnchorCandidates(lines, targetEnd - targetStart, oldHash);
+
+    if (candidates.length === 0) {
+      return fail(
+        buildStaleMessage(oldHash, currentHash, targetStart + 1, targetEnd) +
+          `\n  The anchored content was not found anywhere else in the file.`,
+        ErrorCode.STALE_ANCHOR,
+        "Re-read the file to obtain a current hash, then retry.",
+        { newHash: currentHash, stale: true },
+      );
+    }
+    if (candidates.length > 1) {
+      return fail(
+        `AMBIGUOUS ANCHOR: content matching hash ${oldHash} appears at more than one location in ${filePath}.`,
+        ErrorCode.AMBIGUOUS_ANCHOR,
+        "Widen the range so the anchored content is unique, then retry.",
+        { newHash: currentHash, stale: true },
+      );
+    }
+
+    // Exactly one match: the content moved. Re-anchor onto it.
+    const windowSize = targetEnd - targetStart;
+    targetStart = candidates[0]!;
+    targetEnd = targetStart + windowSize;
+    targetLines = lines.slice(targetStart, targetEnd);
+    targetText = targetLines.join("\n");
+    stale = true;
+    retries = 1;
+    relocatedTo = { start: targetStart + 1, end: targetEnd };
+    messageSuffix = ` (anchor relocated to lines ${relocatedTo.start}-${relocatedTo.end})`;
   }
 
-  return applyReplacement(filePath, lines, targetStart, targetEnd, targetLines, targetText, newContent, oldHash, dryRun, false, 0);
+  let writePath: string | undefined;
+  if (!dryRun) {
+    try {
+      writePath = assertWritable(filePath, options.pathOptions);
+    } catch (e) {
+      if (e instanceof PathDeniedError) {
+        return fail(e.message, ErrorCode.PATH_DENIED, "Pass --allow-outside-root or choose a path inside the project root.");
+      }
+      throw e;
+    }
+  }
+
+  return applyReplacement(
+    filePath, lines, targetStart, targetEnd, targetLines, targetText,
+    newContent, oldHash, dryRun, stale, retries, messageSuffix, relocatedTo, writePath,
+  );
 }
 
 async function applyReplacement(
@@ -96,7 +235,10 @@ async function applyReplacement(
   dryRun: boolean,
   stale: boolean,
   retries: number,
-  messageSuffix: string = ""
+  messageSuffix: string = "",
+  relocatedTo?: { start: number; end: number },
+  /** Symlink-resolved destination returned by assertWritable. Falls back to filePath on dry runs. */
+  writePath?: string
 ): Promise<ReplaceHashResult> {
   const newContentLines = newContent.split("\n");
   if (newContentLines[newContentLines.length - 1] === "" && !targetText.endsWith("\n")) {
@@ -115,7 +257,7 @@ async function applyReplacement(
   const rangeLabel = `range ${targetStart + 1}-${targetEnd}`;
 
   if (!dryRun) {
-    await Bun.write(filePath, newFullContent);
+    await Bun.write(writePath ?? filePath, newFullContent);
   }
 
   const action = dryRun ? "Dry run: would replace" : "Replaced";
@@ -127,6 +269,7 @@ async function applyReplacement(
     linesChanged,
     stale,
     retries,
+    relocatedTo,
     message: dryRun
       ? `${action} ${targetLines.length} lines with ${newContentLines.length} lines${messageSuffix}`
       : `${action} ${targetLines.length} lines with ${newContentLines.length} lines${messageSuffix} (${rangeLabel})`,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -34,6 +34,8 @@ export {
   exportEvents,
   pruneEvents,
   configureTelemetry,
+  enableTelemetry,
+  resolveTelemetryEnabled,
   getSessionId,
   MAX_FILE_SIZE,
   MAX_ROTATED_FILES,
@@ -66,4 +68,18 @@ export { createChangeSet, buildProvenanceFields, provenanceQuery, changeSetQuery
 export type { ProvenanceInput, ProvenanceEntry, ChangeSetResult } from "./provenance";
 export { doctor } from "./doctor";
 export type { DoctorReport, DoctorCheck } from "./doctor";
-export { escapeRegex } from "./utils";
+export { escapeRegex } from "./utils";export {
+  assertWritable,
+  assertAllWritable,
+  safeWrite,
+  findProjectRoot,
+  configureWriteBoundary,
+  resetWriteBoundary,
+  PathDeniedError,
+} from "./paths";
+export type { AssertWritableOptions } from "./paths";
+export { ExitCode, exitCodeFor, finish, usageError } from "./exit-codes";
+export type { ResultLike } from "./exit-codes";
+export type { RecoveryMode } from "./hash-edit";
+export { UnsupportedIntentError } from "./intent";
+export { redactSecrets, redactEvent, isSensitiveFile } from "./redact";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -68,7 +68,8 @@ export { createChangeSet, buildProvenanceFields, provenanceQuery, changeSetQuery
 export type { ProvenanceInput, ProvenanceEntry, ChangeSetResult } from "./provenance";
 export { doctor } from "./doctor";
 export type { DoctorReport, DoctorCheck } from "./doctor";
-export { escapeRegex } from "./utils";export {
+export { escapeRegex } from "./utils";
+export {
   assertWritable,
   assertAllWritable,
   safeWrite,

--- a/src/core/intent.ts
+++ b/src/core/intent.ts
@@ -5,6 +5,15 @@ import { escapeRegex } from "./utils";
 
 // ── Intent types ──────────────────────────────────────────────────────
 
+/** Thrown for an intent operation the planner cannot perform. Maps to exit code 1. */
+export class UnsupportedIntentError extends Error {
+  readonly errorCode = "UNSUPPORTED_OPERATION";
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedIntentError";
+  }
+}
+
 export type IntentOperation =
   | "add-parameter"
   | "remove-parameter"
@@ -101,13 +110,14 @@ export function parseIntent(raw: string): StructuredIntent {
       };
     }
     case "remove-parameter": {
-      if (!obj.paramName) throw new Error("remove-parameter requires 'paramName'");
-      return {
-        operation: "remove-parameter",
-        symbol: obj.symbol,
-        paramName: obj.paramName,
-        file: obj.file,
-      };
+      // Never implemented. The plan it used to generate emitted a no-op
+      // `remove-import` for the signature and a literal
+      // `/* TODO: remove arg for X */` string as the search text at every call
+      // site — which never matches, so the plan reported steps it could not
+      // perform. Refusing is strictly safer than advertising it.
+      throw new UnsupportedIntentError(
+        "remove-parameter is not implemented. Use rename-exported-symbol, or edit the signature with `ast replace-body` and each call site with `diff apply`.",
+      );
     }
     case "rename-exported-symbol": {
       if (!obj.newName) throw new Error("rename-exported-symbol requires 'newName'");
@@ -119,7 +129,7 @@ export function parseIntent(raw: string): StructuredIntent {
       };
     }
     default:
-      throw new Error(`Unknown intent operation: ${obj.operation}. Supported: add-parameter, remove-parameter, rename-exported-symbol`);
+      throw new Error(`Unknown intent operation: ${obj.operation}. Supported: add-parameter, rename-exported-symbol`);
   }
 }
 
@@ -265,28 +275,7 @@ export function generatePlan(
     }
 
     case "remove-parameter": {
-      steps.push({
-        order: 0,
-        file: definition.file,
-        operation: "remove-import",
-        description: `Remove parameter '${intent.paramName}' from '${intent.symbol}' — requires manual signature edit`,
-        params: {},
-      });
-
-      const refFiles = [...new Set(references.map((r) => r.file))];
-      refFiles.forEach((file, i) => {
-        steps.push({
-          order: i + 1,
-          file,
-          operation: "diff",
-          description: `Remove argument '${intent.paramName}' from call sites in ${shortPath(file)}`,
-          params: {
-            oldContent: `/* TODO: remove arg for ${intent.paramName} */`,
-            newContent: "",
-          },
-        });
-      });
-      break;
+      throw new UnsupportedIntentError("remove-parameter is not implemented.");
     }
 
     case "rename-exported-symbol": {

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,0 +1,226 @@
+import { existsSync, realpathSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { ErrorCode } from "./telemetry";
+
+/**
+ * Filesystem write boundary.
+ *
+ * Every write in HashPilot funnels through `assertWritable`. Enforcing this in
+ * the write helpers rather than in `cli.ts` means a new command cannot forget
+ * the check, and the library API is bounded too — not just the CLI.
+ */
+
+/** Thrown when a write target fails the boundary check. */
+export class PathDeniedError extends Error {
+  readonly errorCode = ErrorCode.PATH_DENIED;
+  readonly path: string;
+  readonly reason: string;
+
+  constructor(path: string, reason: string) {
+    super(`Refusing to write ${path}: ${reason}`);
+    this.name = "PathDeniedError";
+    this.path = path;
+    this.reason = reason;
+  }
+}
+
+export interface AssertWritableOptions {
+  /** Directory the project root is discovered from. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Extra roots to permit, from config `allowedRoots`. Relative entries resolve against `cwd`. */
+  allowedRoots?: string[];
+  /** Sole bypass for the containment check. Does NOT bypass the hard-deny list. */
+  allowOutsideRoot?: boolean;
+  /** Suppress the stderr warning emitted when `allowOutsideRoot` is used. For tests. */
+  quiet?: boolean;
+}
+
+/**
+ * Process-wide defaults, set once at CLI bootstrap from config + global flags,
+ * so that write helpers deep in the call graph get the boundary policy without
+ * every caller threading options through.
+ */
+let boundaryDefaults: AssertWritableOptions = {};
+
+export function configureWriteBoundary(options: AssertWritableOptions): void {
+  boundaryDefaults = { ...boundaryDefaults, ...options };
+}
+
+/** Reset to built-in defaults. For tests. */
+export function resetWriteBoundary(): void {
+  boundaryDefaults = {};
+}
+
+/** macOS and Windows are case-insensitive; comparing case-sensitively there lets `/ETC/passwd` slip past. */
+const CASE_INSENSITIVE = platform() === "darwin" || platform() === "win32";
+
+function normalizeForCompare(p: string): string {
+  return CASE_INSENSITIVE ? p.toLowerCase() : p;
+}
+
+/** True when `child` is `parent` or lives beneath it. Segment-aware: `/foo/bar-baz` is not inside `/foo/bar`. */
+function isInside(child: string, parent: string): boolean {
+  const c = normalizeForCompare(child);
+  const p = normalizeForCompare(parent);
+  if (c === p) return true;
+  const rel = relative(p, c);
+  return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+}
+
+/**
+ * Directories and files never writable, regardless of `--allow-outside-root`
+ * or `allowedRoots`. A structured editor has no legitimate reason to touch
+ * credentials, agent configuration, or system config.
+ */
+function hardDenyTargets(): { dirs: string[]; files: string[] } {
+  const home = homedir();
+  return {
+    dirs: [
+      join(home, ".ssh"),
+      join(home, ".aws"),
+      join(home, ".gnupg"),
+      join(home, ".claude"),
+      join(home, ".config", "hashpilot"),
+      join(home, ".agentic-tools"),
+      "/etc",
+    ],
+    files: [
+      ".bashrc", ".bash_profile", ".bash_login", ".profile",
+      ".zshrc", ".zshenv", ".zprofile", ".zlogin",
+      ".netrc", ".npmrc", ".gitconfig",
+    ].map((f) => join(home, f)),
+  };
+}
+
+/**
+ * Resolve a path to absolute, following symlinks on the longest existing
+ * ancestor. Resolving the *parent* rather than the target itself matters: the
+ * target may not exist yet (a new file), and a symlinked parent directory is
+ * the classic escape vector.
+ */
+function resolveThroughSymlinks(target: string): string {
+  const abs = resolve(target);
+  let existing = abs;
+  const trailing: string[] = [];
+
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) return abs; // hit the filesystem root; nothing to resolve
+    trailing.unshift(existing.slice(parent.length + 1));
+    existing = parent;
+  }
+
+  try {
+    return trailing.length ? join(realpathSync(existing), ...trailing) : realpathSync(existing);
+  } catch {
+    return abs;
+  }
+}
+
+/**
+ * Locate the project root: the nearest ancestor of `cwd` containing `.git`,
+ * falling back to `cwd` itself for non-repo usage.
+ */
+export function findProjectRoot(cwd: string = process.cwd()): string {
+  let dir = resolveThroughSymlinks(cwd);
+  while (true) {
+    if (existsSync(join(dir, ".git"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return resolveThroughSymlinks(cwd);
+}
+
+/**
+ * Validate that `target` may be written, and return its resolved absolute path.
+ * Callers must write to the returned path, not the input — the returned value
+ * is the symlink-resolved location that was actually checked.
+ *
+ * @throws {PathDeniedError} if the target is on the hard-deny list, or escapes
+ *   the project root without `allowOutsideRoot`.
+ */
+export function assertWritable(target: string, options: AssertWritableOptions = {}): string {
+  const { cwd = process.cwd(), allowedRoots = [], allowOutsideRoot = false, quiet = false } = {
+    ...boundaryDefaults,
+    ...options,
+  };
+
+  if (!target || target.trim() === "") {
+    throw new PathDeniedError(String(target), "empty path");
+  }
+  if (target.includes("\0")) {
+    throw new PathDeniedError(target, "path contains a null byte");
+  }
+
+  const resolved = resolveThroughSymlinks(target);
+
+  // Hard-deny first: unconditional, and not bypassable by any flag or config.
+  const { dirs, files } = hardDenyTargets();
+  for (const rawDir of dirs) {
+    // Resolve the deny target too: on macOS `/etc` is a symlink to
+    // `/private/etc`, so comparing against the literal path misses everything.
+    const dir = resolveThroughSymlinks(rawDir);
+    if (isInside(resolved, dir)) {
+      throw new PathDeniedError(resolved, `${dir} is never writable by HashPilot`);
+    }
+  }
+  for (const rawFile of files) {
+    const file = resolveThroughSymlinks(rawFile);
+    if (normalizeForCompare(resolved) === normalizeForCompare(file)) {
+      throw new PathDeniedError(resolved, "shell and tool configuration files are never writable by HashPilot");
+    }
+  }
+
+  if (allowOutsideRoot) {
+    if (!quiet) {
+      console.error(
+        `WARNING: --allow-outside-root is set; writing outside the project root to ${resolved}`,
+      );
+    }
+    return resolved;
+  }
+
+  const roots = [findProjectRoot(cwd), ...allowedRoots.map((r) => resolveThroughSymlinks(resolve(cwd, r)))];
+  if (roots.some((root) => isInside(resolved, root))) return resolved;
+
+  throw new PathDeniedError(
+    resolved,
+    `outside the project root (${roots[0]}). Pass --allow-outside-root or add the location to "allowedRoots" in .hashpilot.json`,
+  );
+}
+
+/** Batch form. Reports every rejection at once rather than failing on the first. */
+export function assertAllWritable(targets: string[], options: AssertWritableOptions = {}): string[] {
+  const resolved: string[] = [];
+  const denied: string[] = [];
+  for (const t of targets) {
+    try {
+      resolved.push(assertWritable(t, options));
+    } catch (err) {
+      denied.push(err instanceof PathDeniedError ? err.message : String(err));
+    }
+  }
+  if (denied.length) throw new PathDeniedError(targets.join(", "), denied.join("; "));
+  return resolved;
+}
+
+/**
+ * The only write primitive in the codebase. Validates the boundary, then writes
+ * to the *resolved* path. Call this instead of `Bun.write` for any file the
+ * user or an agent supplied the path for.
+ *
+ * @throws {PathDeniedError} if the target fails the boundary check.
+ */
+export async function safeWrite(
+  target: string,
+  content: string,
+  options: AssertWritableOptions = {},
+): Promise<string> {
+  const resolved = assertWritable(target, options);
+  await Bun.write(resolved, content);
+  return resolved;
+}
+
+export const PATH_SEPARATOR = sep;

--- a/src/core/plan-executor.ts
+++ b/src/core/plan-executor.ts
@@ -1,4 +1,5 @@
 import { EditPlan, findSymbolDefinition, findReferences, generatePlan, parseIntent, StructuredIntent } from "./intent";
+import { safeWrite } from "./paths";
 import { insertParameter, insertCallArg, renameSymbol, detectLanguage } from "./ast-edit";
 import { replaceHash } from "./hash-edit";
 import { computeHash } from "./read";
@@ -131,7 +132,7 @@ export async function executePlan(
       stepNewSource = result.newSource;
 
       if (stepSuccess && stepNewSource && !dryRun) {
-        await Bun.write(step.file, stepNewSource);
+        await safeWrite(step.file, stepNewSource);
       }
     } catch (err: any) {
       stepSuccess = false;
@@ -194,7 +195,7 @@ export async function executePlan(
   let reverted = false;
   if (!allPassed && doRevert && !dryRun && originals.size > 0) {
     for (const [file, original] of originals) {
-      try { await Bun.write(file, original); } catch {}
+      try { await safeWrite(file, original); } catch {}
     }
     reverted = true;
   }

--- a/src/core/provenance.ts
+++ b/src/core/provenance.ts
@@ -2,6 +2,7 @@ import { exportEvents, type TelemetryEvent } from "./telemetry";
 import { computeHash } from "./read";
 import { generateUnifiedDiff } from "./diff-engine";
 import { loadConfig, type HashPilotConfig } from "./config";
+import { isSensitiveFile, redactSecrets } from "./redact";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -56,8 +57,13 @@ function getConfig(): HashPilotConfig {
   return _cachedConfig;
 }
 
-export function clearConfigCache(): void {
-  _cachedConfig = null;
+/**
+ * Drop the cached config so the next call re-reads it. Pass an override to pin
+ * a config instead of loading from disk (tests use this to exercise opt-in
+ * behavior like `provenance.captureDiffs` without touching the user's files).
+ */
+export function clearConfigCache(override?: HashPilotConfig): void {
+  _cachedConfig = override ?? null;
 }
 
 // ── Factory ────────────────────────────────────────────────────────────
@@ -90,11 +96,15 @@ export function buildProvenanceFields(input: ProvenanceInput): Partial<Telemetry
 
   if (input.source !== undefined && input.newSource !== undefined) {
     fields.afterHash = computeHash(input.newSource);
-    if (input.source !== input.newSource) {
-      fields.diff = generateUnifiedDiff(
+    // Diff capture is opt-in and never applies to files that are secret by
+    // definition. Hashes still record *that* the file changed.
+    const captureDiffs = config.provenance?.captureDiffs === true;
+    const sensitive = input.filePath !== undefined && isSensitiveFile(input.filePath);
+    if (captureDiffs && !sensitive && input.source !== input.newSource) {
+      fields.diff = redactSecrets(generateUnifiedDiff(
         input.source, input.newSource,
         input.filePath ? input.filePath.replace(/^\//, "") : "unknown", 3
-      );
+      ));
     }
   }
 

--- a/src/core/redact.ts
+++ b/src/core/redact.ts
@@ -1,0 +1,88 @@
+import { basename } from "node:path";
+
+/**
+ * Secret redaction for anything that reaches the telemetry log.
+ *
+ * Telemetry is written to `~/.agentic-tools/logs/` in plaintext and may be
+ * exported or shared. Provenance diffs put real source lines in there, so a
+ * `.env` edit or a pasted key would be persisted verbatim. Redaction runs on
+ * every string field before the event is serialized.
+ */
+
+const REDACTED = "[REDACTED]";
+
+interface Rule {
+  name: string;
+  pattern: RegExp;
+  /** Replacement; `$1` etc. refer to capture groups kept as context. */
+  replacement: string;
+}
+
+const RULES: Rule[] = [
+  { name: "aws-access-key-id", pattern: /\b(?:AKIA|ASIA|AGPA|AIDA|AROA|ANPA|ANVA)[0-9A-Z]{16}\b/g, replacement: REDACTED },
+  { name: "aws-secret-access-key", pattern: /\b(aws_secret_access_key\s*[:=]\s*)\S+/gi, replacement: `$1${REDACTED}` },
+  { name: "openai-key", pattern: /\bsk-[A-Za-z0-9_-]{16,}\b/g, replacement: REDACTED },
+  { name: "anthropic-key", pattern: /\bsk-ant-[A-Za-z0-9_-]{16,}\b/g, replacement: REDACTED },
+  { name: "github-token", pattern: /\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{16,}\b/g, replacement: REDACTED },
+  { name: "slack-token", pattern: /\bxox[abprs]-[A-Za-z0-9-]{10,}\b/g, replacement: REDACTED },
+  { name: "google-api-key", pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g, replacement: REDACTED },
+  { name: "jwt", pattern: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g, replacement: REDACTED },
+  { name: "private-key-block", pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, replacement: `-----BEGIN PRIVATE KEY-----${REDACTED}-----END PRIVATE KEY-----` },
+  { name: "authorization-header", pattern: /\b(authorization\s*[:=]\s*["']?)(?:bearer|basic|token)\s+\S+/gi, replacement: `$1${REDACTED}` },
+  { name: "connection-string-password", pattern: /(\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:)[^\s@/]+(@)/gi, replacement: `$1${REDACTED}$2` },
+  // Assignments whose *name* implies a secret. Deliberately last: the value is
+  // replaced wholesale rather than pattern-matched, so it catches formats the
+  // rules above do not know about.
+  {
+    name: "secretish-assignment",
+    pattern: /\b([A-Za-z0-9_.-]*(?:secret|token|password|passwd|api[_-]?key|access[_-]?key|credential)[A-Za-z0-9_.-]*\s*[:=]\s*)(["']?)([^\s"',;)}]{6,})\2/gi,
+    replacement: `$1$2${REDACTED}$2`,
+  },
+];
+
+/** Redact every known secret shape in a string. Returns the input unchanged when nothing matches. */
+export function redactSecrets(input: string): string {
+  let out = input;
+  for (const rule of RULES) out = out.replace(rule.pattern, rule.replacement);
+  return out;
+}
+
+/**
+ * Files whose *contents* are secret by definition. Their diffs and source are
+ * never recorded, regardless of what redaction would catch.
+ */
+const SENSITIVE_FILE_PATTERNS: RegExp[] = [
+  /^\.env(\..*)?$/i,
+  /\.pem$/i,
+  /\.key$/i,
+  /\.p12$/i,
+  /\.pfx$/i,
+  /^id_(rsa|dsa|ecdsa|ed25519)(\.pub)?$/i,
+  /^credentials$/i,
+  /^\.npmrc$/i,
+  /^\.netrc$/i,
+  /^.*\.keystore$/i,
+  /^secrets?\.(ya?ml|json|toml)$/i,
+];
+
+/** True when the file's contents must never appear in telemetry. */
+export function isSensitiveFile(filePath: string): boolean {
+  const name = basename(filePath);
+  return SENSITIVE_FILE_PATTERNS.some((re) => re.test(name));
+}
+
+/**
+ * Recursively redact the string fields of a telemetry event. Object keys and
+ * non-string values pass through untouched — only values can carry secrets.
+ */
+export function redactEvent<T>(event: T): T {
+  const walk = (value: unknown): unknown => {
+    if (typeof value === "string") return redactSecrets(value);
+    if (Array.isArray(value)) return value.map(walk);
+    if (value && typeof value === "object") {
+      return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, walk(v)]));
+    }
+    return value;
+  };
+  return walk(event) as T;
+}

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -1,3 +1,4 @@
+import { safeWrite } from "./paths";
 import {
   isLanguageSupported,
   detectLanguage,
@@ -201,7 +202,7 @@ export async function routeEdit(params: {
       }
       // Write result to file if successful
       if (result.success && (result as any).newSource && !dryRun) {
-        await Bun.write(filePath, (result as any).newSource);
+        await safeWrite(filePath, (result as any).newSource);
         editResult = (result as any).newSource;
       }
       break;
@@ -226,7 +227,7 @@ export async function routeEdit(params: {
       }
       result = applyTextReplace(source, filePath, oldContent, newContent);
       if (result.success && (result as any).newSource && !dryRun) {
-        await Bun.write(filePath, (result as any).newSource);
+        await safeWrite(filePath, (result as any).newSource);
         editResult = (result as any).newSource;
       }
       break;

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, appendFileSync, readFileSync, existsSync, writeFileSync, renameSync, unlinkSync, statSync, readdirSync } from "fs";
+import { mkdirSync, appendFileSync, readFileSync, existsSync, writeFileSync, renameSync, unlinkSync, statSync, readdirSync, chmodSync } from "fs";
 import { join } from "path";
 import type { TelemetryConfig } from "./config";
+import { redactEvent } from "./redact";
 
 const LOG_DIR = join(process.env.HOME || "/root", ".agentic-tools", "logs");
 const LOG_FILE = join(LOG_DIR, "telemetry.jsonl");
@@ -11,10 +12,26 @@ export let MAX_FILE_SIZE = 10 * 1024 * 1024;
 export let MAX_ROTATED_FILES = 10;
 export let RETENTION_DAYS = 30;
 
-export function configureTelemetry(cfg: TelemetryConfig): void {
+export function configureTelemetry(cfg: TelemetryConfig | undefined): void {
+  if (!cfg) return;
   if (cfg.maxFileSize !== undefined) MAX_FILE_SIZE = cfg.maxFileSize;
   if (cfg.maxRotatedFiles !== undefined) MAX_ROTATED_FILES = cfg.maxRotatedFiles;
   if (cfg.retentionDays !== undefined) RETENTION_DAYS = cfg.retentionDays;
+  // `enabled` used to be parsed and then ignored, so opting out via config did
+  // nothing. It is the lowest-priority switch: env and CLI still override it.
+  if (cfg.enabled !== undefined) sessionEnabled = cfg.enabled;
+}
+
+/**
+ * Resolve the telemetry kill switch. Precedence, highest first:
+ *   CLI `--no-telemetry` > `HASHPILOT_TELEMETRY=0` > config `telemetry.enabled` > on.
+ */
+export function resolveTelemetryEnabled(cfg: TelemetryConfig | undefined, cliDisabled: boolean): boolean {
+  if (cliDisabled) return false;
+  const env = process.env.HASHPILOT_TELEMETRY;
+  if (env !== undefined && ["0", "false", "off", "no"].includes(env.trim().toLowerCase())) return false;
+  if (cfg?.enabled !== undefined) return cfg.enabled;
+  return true;
 }
 
 export enum ErrorCode {
@@ -26,6 +43,16 @@ export enum ErrorCode {
   UNSUPPORTED_LANGUAGE = "UNSUPPORTED_LANGUAGE",
   HASH_MISMATCH = "HASH_MISMATCH",
   WRITE_FAILED = "WRITE_FAILED",
+  /** Write target is outside the project root or on the hard-deny list. */
+  PATH_DENIED = "PATH_DENIED",
+  /** A flag or argument was malformed (bad --range, non-numeric value). */
+  INVALID_ARGUMENT = "INVALID_ARGUMENT",
+  /** The requested operation exists in the CLI surface but is not implemented for this input. */
+  UNSUPPORTED_OPERATION = "UNSUPPORTED_OPERATION",
+  /** The edit applied but format/lint/test verification failed. */
+  VERIFY_FAILED = "VERIFY_FAILED",
+  /** The anchor could not be relocated unambiguously (multiple candidate matches). */
+  AMBIGUOUS_ANCHOR = "AMBIGUOUS_ANCHOR",
 }
 
 export interface TelemetryEvent {
@@ -95,7 +122,21 @@ export function getSessionId(): string {
 // --- File helpers ---
 
 function ensureLogDir(): void {
-  if (!existsSync(LOG_DIR)) mkdirSync(LOG_DIR, { recursive: true });
+  // 0700/0600: the log can contain file paths, edit reasons, and (when
+  // provenance.captureDiffs is on) source lines. Other users on the box have
+  // no business reading it.
+  if (!existsSync(LOG_DIR)) mkdirSync(LOG_DIR, { recursive: true, mode: 0o700 });
+}
+
+/**
+ * Narrow permissions on a log dir/file created by an older version, which used
+ * the process umask. The `mode` options above only apply at creation time.
+ */
+function tightenLogPermissions(): void {
+  try {
+    if ((statSync(LOG_DIR).mode & 0o077) !== 0) chmodSync(LOG_DIR, 0o700);
+    if (existsSync(LOG_FILE) && (statSync(LOG_FILE).mode & 0o077) !== 0) chmodSync(LOG_FILE, 0o600);
+  } catch {}
 }
 
 function rotatedFiles(): string[] {
@@ -140,13 +181,14 @@ export function recordEvent(event: Omit<TelemetryEvent, "timestamp" | "sessionId
   if (!sessionEnabled) return;
   try {
     ensureLogDir();
+    tightenLogPermissions();
     maybeRotate();
-    const entry: TelemetryEvent = {
+    const entry: TelemetryEvent = redactEvent({
       ...event,
       timestamp: new Date().toISOString(),
       sessionId,
-    };
-    appendFileSync(LOG_FILE, JSON.stringify(entry) + "\n");
+    });
+    appendFileSync(LOG_FILE, JSON.stringify(entry) + "\n", { mode: 0o600 });
   } catch {}
 }
 

--- a/src/core/verify.ts
+++ b/src/core/verify.ts
@@ -1,4 +1,5 @@
 import { computeHash } from "./read";
+import { safeWrite } from "./paths";
 import { recordEvent } from "./telemetry";
 
 export interface VerifyResult {
@@ -329,7 +330,7 @@ export async function verifyChanges(
   if (overall === "fail" && options.revertOnFailure && originals.size > 0) {
     const reverted: string[] = [];
     for (const [f, original] of originals) {
-      try { await Bun.write(f, original); reverted.push(f); } catch {}
+      try { await safeWrite(f, original); reverted.push(f); } catch {}
     }
     result.revertedFiles = reverted;
   }

--- a/tests/diff-engine.test.ts
+++ b/tests/diff-engine.test.ts
@@ -8,6 +8,7 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { configureWriteBoundary, resetWriteBoundary } from "../src/core/paths";
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hashpilot-diff-"));
 const testFile = path.join(tmpDir, "test.txt");
@@ -21,6 +22,8 @@ function readFile(): string {
 }
 
 beforeAll(() => {
+  // Fixtures live in the OS temp dir, outside the project write boundary.
+  configureWriteBoundary({ allowedRoots: [tmpDir] });
   writeFile(`line1
 line2
 line3
@@ -34,6 +37,7 @@ line10`);
 });
 
 afterAll(() => {
+  resetWriteBoundary();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 

--- a/tests/exit-codes.test.ts
+++ b/tests/exit-codes.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "bun:test";
+import { ExitCode, exitCodeFor } from "../src/core/exit-codes";
+import { ErrorCode } from "../src/core/telemetry";
+
+describe("exitCodeFor", () => {
+  test("success is 0", () => {
+    expect(exitCodeFor({ success: true })).toBe(ExitCode.OK);
+  });
+
+  test("stale anchors are retryable preconditions, not generic failures", () => {
+    // Agents branch on this: 3 means "re-read and try again", 2 means "stop".
+    expect(exitCodeFor({ success: false, errorCode: ErrorCode.STALE_ANCHOR })).toBe(ExitCode.PRECONDITION);
+    expect(exitCodeFor({ success: false, errorCode: ErrorCode.HASH_MISMATCH })).toBe(ExitCode.PRECONDITION);
+  });
+
+  test("bad input is a usage error", () => {
+    expect(exitCodeFor({ success: false, errorCode: ErrorCode.INVALID_ARGUMENT })).toBe(ExitCode.USAGE);
+    expect(exitCodeFor({ success: false, errorCode: ErrorCode.PATH_DENIED })).toBe(ExitCode.USAGE);
+    expect(exitCodeFor({ success: false, errorCode: ErrorCode.UNSUPPORTED_OPERATION })).toBe(ExitCode.USAGE);
+  });
+
+  test("missing or unwritable files are I/O errors", () => {
+    expect(exitCodeFor({ success: false, errorCode: ErrorCode.FILE_NOT_FOUND })).toBe(ExitCode.IO);
+    expect(exitCodeFor({ success: false, errorCode: ErrorCode.WRITE_FAILED })).toBe(ExitCode.IO);
+  });
+
+  test("verification failure has its own code", () => {
+    expect(exitCodeFor({ success: false, errorCode: ErrorCode.VERIFY_FAILED })).toBe(ExitCode.VERIFY_FAILED);
+  });
+
+  test("an unmapped failure is never reported as success", () => {
+    expect(exitCodeFor({ success: false })).toBe(ExitCode.EDIT_FAILED);
+    expect(exitCodeFor({ success: false, errorCode: "SOMETHING_NEW" as ErrorCode })).toBe(ExitCode.EDIT_FAILED);
+  });
+
+  test("undefined payloads do not claim success", () => {
+    expect(exitCodeFor(undefined)).toBe(ExitCode.OK);
+  });
+
+  test("for a batch, the worst code wins", () => {
+    expect(exitCodeFor([
+      { success: true },
+      { success: false, errorCode: ErrorCode.STALE_ANCHOR },
+      { success: false, errorCode: ErrorCode.SYMBOL_NOT_FOUND },
+    ])).toBe(ExitCode.PRECONDITION);
+  });
+
+  test("an all-success batch is 0", () => {
+    expect(exitCodeFor([{ success: true }, { success: true }])).toBe(ExitCode.OK);
+  });
+});

--- a/tests/hash-edit.test.ts
+++ b/tests/hash-edit.test.ts
@@ -147,26 +147,26 @@ describe("replaceHash", () => {
     expect(after).toBe(original);
   });
 
-  test("auto-recovers from stale hash when file changed externally", async () => {
+  test("refuses a whole-file anchor that went stale", async () => {
     const fp = join(TMP_DIR, "sample.ts");
     const content = await Bun.file(fp).text();
     const oldHash = computeHash(content);
 
-    // Modify the file externally (simulates AST operation modifying the file)
+    // Modify the file externally (simulates an AST operation touching the file).
     await Bun.write(fp, "// added by AST\n" + content);
 
-    // replace-hash with the OLD hash should auto-recover:
-    // newContent replaces the entire file (no range), so the external modification is replaced too
+    // With no range the anchor *is* the whole file. The old behavior called
+    // this "auto-recovery" and overwrote everything, silently discarding the
+    // external edit. There is nothing to relocate here, so it must fail.
     const newContent = content.replace(/hello/g, "world");
     const result = await replaceHash(fp, oldHash, newContent);
-    expect(result.success).toBe(true);
-    expect(result.retries).toBe(1);
-    expect(result.message).toContain("auto-recovered");
+    expect(result.success).toBe(false);
+    expect(result.stale).toBe(true);
+    expect(result.errorCode).toBe("STALE_ANCHOR");
 
     const updated = await Bun.file(fp).text();
-    expect(updated).toBe(newContent);  // Full file replaced via auto-recovery
-    expect(updated).toContain("world");
-    expect(updated).not.toContain("hello");
+    expect(updated).toContain("// added by AST");
+    expect(updated).toContain("hello");
   });
 
   test("noRecovery option returns stale error instead of auto-recovering", async () => {

--- a/tests/hash-recovery.test.ts
+++ b/tests/hash-recovery.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from "fs";
+import { join } from "path";
+import { computeHash } from "../src/core/read";
+import { replaceHash } from "../src/core/hash-edit";
+import { ErrorCode } from "../src/core/telemetry";
+
+const TMP = join(import.meta.dir, "__tmp_test_recovery__");
+const FILE = join(TMP, "sample.ts");
+
+const BASE = [
+  "const a = 1;",
+  "const b = 2;",
+  "function target() {",
+  "  return 'payload';",
+  "}",
+  "const c = 3;",
+];
+
+function write(lines: string[]) {
+  writeFileSync(FILE, lines.join("\n"));
+}
+
+function hashOf(lines: string[], start: number, end: number): string {
+  return computeHash(lines.slice(start - 1, end).join("\n"));
+}
+
+beforeEach(() => {
+  mkdirSync(TMP, { recursive: true });
+  write(BASE);
+});
+afterEach(() => rmSync(TMP, { recursive: true, force: true }));
+
+describe("stale-anchor relocation", () => {
+  test("relocates when the anchored block moved down", async () => {
+    const anchor = hashOf(BASE, 3, 5);
+    // Two lines inserted above: the block is now at 5-7.
+    write(["// header", "// header", ...BASE]);
+
+    const result = await replaceHash(FILE, anchor, "function target() {\n  return 'new';\n}", {
+      range: { start: 3, end: 5 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.stale).toBe(true);
+    expect(result.retries).toBe(1);
+    expect(result.relocatedTo).toEqual({ start: 5, end: 7 });
+
+    const after = readFileSync(FILE, "utf-8").split("\n");
+    expect(after).toHaveLength(8);
+    expect(after[5]).toBe("  return 'new';");
+    expect(after[0]).toBe("// header");
+    expect(after[7]).toBe("const c = 3;");
+  });
+
+  test("refuses when the anchored content appears more than once", async () => {
+    // A two-line block that occurs twice. The requested range no longer matches,
+    // so relocation runs and finds two equally good candidates.
+    const block = ["const a = 1;", "const b = 2;"];
+    const anchor = computeHash(block.join("\n"));
+    const lines = ["// header", "// header", ...block, "// mid", ...block];
+    write(lines);
+
+    const result = await replaceHash(FILE, anchor, "const a = 9;", { range: { start: 1, end: 2 } });
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe(ErrorCode.AMBIGUOUS_ANCHOR);
+    expect(readFileSync(FILE, "utf-8")).toBe(lines.join("\n"));
+  });
+
+  test("refuses when the anchored content is gone", async () => {
+    const anchor = hashOf(BASE, 3, 5);
+    write(["const a = 1;", "const b = 2;", "// deleted", "// deleted", "// deleted", "const c = 3;"]);
+
+    const result = await replaceHash(FILE, anchor, "x", { range: { start: 3, end: 5 } });
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe(ErrorCode.STALE_ANCHOR);
+    expect(result.stale).toBe(true);
+    expect(readFileSync(FILE, "utf-8")).toContain("// deleted");
+  });
+
+  test("a whole-file anchor mismatch never rewrites the file", async () => {
+    // Regression: the old recovery path treated the whole file as the anchor
+    // and replaced all of it with the new content.
+    const anchor = computeHash(BASE.join("\n"));
+    write([...BASE, "const d = 4;"]);
+
+    const result = await replaceHash(FILE, anchor, "TOTALLY DIFFERENT");
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe(ErrorCode.STALE_ANCHOR);
+    expect(readFileSync(FILE, "utf-8")).not.toContain("TOTALLY DIFFERENT");
+  });
+
+  test("recovery: \"off\" fails instead of relocating", async () => {
+    const anchor = hashOf(BASE, 3, 5);
+    write(["// header", ...BASE]);
+
+    const result = await replaceHash(FILE, anchor, "x", { range: { start: 3, end: 5 }, recovery: "off" });
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe(ErrorCode.STALE_ANCHOR);
+  });
+
+  test("noRecovery is still honored as the legacy spelling", async () => {
+    const anchor = hashOf(BASE, 3, 5);
+    write(["// header", ...BASE]);
+
+    const result = await replaceHash(FILE, anchor, "x", { range: { start: 3, end: 5 }, noRecovery: true });
+    expect(result.success).toBe(false);
+  });
+
+  test("a matching anchor applies without relocation", async () => {
+    const anchor = hashOf(BASE, 3, 5);
+    const result = await replaceHash(FILE, anchor, "function target() {\n  return 'new';\n}", {
+      range: { start: 3, end: 5 },
+    });
+    expect(result.success).toBe(true);
+    expect(result.stale).toBe(false);
+    expect(result.relocatedTo).toBeUndefined();
+  });
+});
+
+describe("range validation", () => {
+  const anchor = () => hashOf(BASE, 1, 1);
+
+  test("rejects a NaN bound rather than duplicating the file", async () => {
+    const result = await replaceHash(FILE, anchor(), "x", { range: { start: 1, end: NaN } });
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe(ErrorCode.INVALID_ARGUMENT);
+    expect(readFileSync(FILE, "utf-8")).toBe(BASE.join("\n"));
+  });
+
+  test("rejects a zero start (ranges are 1-indexed)", async () => {
+    const result = await replaceHash(FILE, anchor(), "x", { range: { start: 0, end: 2 } });
+    expect(result.errorCode).toBe(ErrorCode.INVALID_ARGUMENT);
+  });
+
+  test("rejects an inverted range", async () => {
+    const result = await replaceHash(FILE, anchor(), "x", { range: { start: 3, end: 1 } });
+    expect(result.errorCode).toBe(ErrorCode.INVALID_ARGUMENT);
+  });
+
+  test("rejects an end past the last line", async () => {
+    const result = await replaceHash(FILE, anchor(), "x", { range: { start: 1, end: 999 } });
+    expect(result.errorCode).toBe(ErrorCode.INVALID_ARGUMENT);
+  });
+});
+
+describe("write boundary", () => {
+  test("replaceHash refuses a target outside the project root", async () => {
+    const outside = join(require("os").tmpdir(), "hashpilot-recovery-outside.ts");
+    writeFileSync(outside, BASE.join("\n"));
+    try {
+      const result = await replaceHash(outside, computeHash(BASE.join("\n")), "x");
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(ErrorCode.PATH_DENIED);
+      expect(readFileSync(outside, "utf-8")).toBe(BASE.join("\n"));
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
+  test("a dry run needs no write permission", async () => {
+    const outside = join(require("os").tmpdir(), "hashpilot-recovery-dry.ts");
+    writeFileSync(outside, BASE.join("\n"));
+    try {
+      const result = await replaceHash(outside, computeHash(BASE.join("\n")), "x", { dryRun: true });
+      expect(result.success).toBe(true);
+      expect(readFileSync(outside, "utf-8")).toBe(BASE.join("\n"));
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+});

--- a/tests/intent.test.ts
+++ b/tests/intent.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { parseIntent, findSymbolDefinition, findReferences, generatePlan } from "../src/core/intent";
+import { parseIntent, findSymbolDefinition, findReferences, generatePlan, UnsupportedIntentError } from "../src/core/intent";
 import { executePlan, executeIntent } from "../src/core/plan-executor";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
@@ -99,16 +99,15 @@ describe("parseIntent", () => {
     }
   });
 
-  test("parses remove-parameter intent", () => {
-    const intent = parseIntent(JSON.stringify({
+  test("refuses remove-parameter instead of planning a no-op", () => {
+    // It was accepted but never implemented: the plan emitted an unmatchable
+    // `/* TODO: remove arg */` search string at each call site and reported
+    // success. Refusing at parse time is the honest answer.
+    expect(() => parseIntent(JSON.stringify({
       operation: "remove-parameter",
       symbol: "greet",
       paramName: "name",
-    }));
-    expect(intent.operation).toBe("remove-parameter");
-    if (intent.operation === "remove-parameter") {
-      expect(intent.paramName).toBe("name");
-    }
+    }))).toThrow(UnsupportedIntentError);
   });
 
   test("parses rename-exported-symbol intent", () => {
@@ -277,16 +276,32 @@ describe("generatePlan", () => {
     expect(plan.steps[0].params.newName).toBe("sayHello");
   });
 
-  test("generates remove-parameter plan", () => {
+  test("generatePlan also refuses remove-parameter", () => {
     const def = { file: FILE_A, name: "process", kind: "function_declaration", line: 8, column: 17 };
     const refs = [{ file: FILE_C, line: 4, column: 3, context: 'process("test", 1)' }];
-    const plan = generatePlan(
-      { operation: "remove-parameter", symbol: "process", paramName: "count" },
+    expect(() => generatePlan(
+      { operation: "remove-parameter", symbol: "process", paramName: "count" } as never,
       def,
       refs
-    );
-    expect(plan.steps.length).toBeGreaterThanOrEqual(1);
-    expect(plan.steps[0].operation).toBe("remove-import");
+    )).toThrow(UnsupportedIntentError);
+  });
+
+  // A TODO placeholder is fine as *inserted* text (add-parameter emits one as
+  // the new argument for a caller to fill in), but never as text the step has
+  // to find in the file — that step can only ever fail.
+  test("no plan step searches for a TODO placeholder", () => {
+    const def = { file: FILE_A, name: "greet", kind: "function_declaration", line: 1, column: 17 };
+    const refs = [{ file: FILE_C, line: 4, column: 3, context: 'greet("test")' }];
+    for (const intent of [
+      { operation: "add-parameter", symbol: "greet", param: { name: "x", type: "string" } },
+      { operation: "rename-exported-symbol", symbol: "greet", newName: "sayHello" },
+    ] as never[]) {
+      for (const step of generatePlan(intent, def, refs).steps) {
+        for (const key of ["oldContent", "oldName", "search", "content"]) {
+          expect(String(step.params[key] ?? "")).not.toContain("TODO:");
+        }
+      }
+    }
   });
 });
 

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync, symlinkSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join } from "path";
+import {
+  assertWritable,
+  assertAllWritable,
+  safeWrite,
+  findProjectRoot,
+  configureWriteBoundary,
+  resetWriteBoundary,
+  PathDeniedError,
+} from "../src/core/paths";
+
+const ROOT = join(import.meta.dir, "__tmp_test_paths__");
+const OUTSIDE = join(tmpdir(), "hashpilot-outside-root");
+
+beforeEach(() => {
+  resetWriteBoundary();
+  mkdirSync(ROOT, { recursive: true });
+  mkdirSync(OUTSIDE, { recursive: true });
+  writeFileSync(join(ROOT, "in.ts"), "x");
+});
+
+afterEach(() => {
+  resetWriteBoundary();
+  rmSync(ROOT, { recursive: true, force: true });
+  rmSync(OUTSIDE, { recursive: true, force: true });
+});
+
+describe("assertWritable containment", () => {
+  test("allows a path inside the project root", () => {
+    expect(assertWritable(join(ROOT, "in.ts"))).toContain("in.ts");
+  });
+
+  test("allows a file that does not exist yet inside the root", () => {
+    expect(assertWritable(join(ROOT, "nested", "new.ts"))).toContain("new.ts");
+  });
+
+  test("rejects a path outside the project root", () => {
+    expect(() => assertWritable(join(OUTSIDE, "escape.ts"))).toThrow(PathDeniedError);
+  });
+
+  test("rejects traversal that climbs out of the root", () => {
+    expect(() => assertWritable(join(ROOT, "..", "..", "..", "escape.ts"))).toThrow(PathDeniedError);
+  });
+
+  test("a sibling directory sharing a name prefix is not inside an allowed root", () => {
+    // /foo/bar-baz must not count as inside /foo/bar — a prefix string compare
+    // would wrongly allow it.
+    const sibling = `${OUTSIDE}-sibling`;
+    mkdirSync(sibling, { recursive: true });
+    try {
+      expect(() => assertWritable(join(sibling, "file.ts"), { allowedRoots: [OUTSIDE] })).toThrow(PathDeniedError);
+    } finally {
+      rmSync(sibling, { recursive: true, force: true });
+    }
+  });
+
+  test("allowedRoots widens the boundary", () => {
+    expect(assertWritable(join(OUTSIDE, "ok.ts"), { allowedRoots: [OUTSIDE] })).toContain("ok.ts");
+  });
+
+  test("allowOutsideRoot bypasses containment", () => {
+    expect(assertWritable(join(OUTSIDE, "ok.ts"), { allowOutsideRoot: true, quiet: true })).toContain("ok.ts");
+  });
+
+  test("configureWriteBoundary supplies process-wide defaults", () => {
+    configureWriteBoundary({ allowedRoots: [OUTSIDE] });
+    expect(assertWritable(join(OUTSIDE, "ok.ts"))).toContain("ok.ts");
+  });
+});
+
+describe("assertWritable hard-deny", () => {
+  const denied = [
+    join(homedir(), ".ssh", "id_rsa"),
+    join(homedir(), ".aws", "credentials"),
+    join(homedir(), ".zshrc"),
+    join(homedir(), ".agentic-tools", "logs", "telemetry.jsonl"),
+    "/etc/passwd",
+  ];
+
+  for (const target of denied) {
+    test(`refuses ${target}`, () => {
+      expect(() => assertWritable(target, { allowOutsideRoot: true, quiet: true })).toThrow(PathDeniedError);
+    });
+  }
+
+  test("allowedRoots cannot re-enable a hard-denied path", () => {
+    const ssh = join(homedir(), ".ssh");
+    expect(() => assertWritable(join(ssh, "config"), { allowedRoots: [ssh] })).toThrow(PathDeniedError);
+  });
+
+  test("hard-deny is case-insensitive on macOS", () => {
+    if (process.platform !== "darwin") return;
+    expect(() => assertWritable("/ETC/passwd", { allowOutsideRoot: true, quiet: true })).toThrow(PathDeniedError);
+  });
+});
+
+describe("assertWritable input validation", () => {
+  test("rejects an empty path", () => {
+    expect(() => assertWritable("")).toThrow(PathDeniedError);
+  });
+
+  test("rejects a path containing a null byte", () => {
+    expect(() => assertWritable(join(ROOT, "a\0b.ts"))).toThrow(PathDeniedError);
+  });
+});
+
+describe("symlink resolution", () => {
+  test("a symlinked directory inside the root that points outside is rejected", () => {
+    const link = join(ROOT, "link");
+    symlinkSync(OUTSIDE, link);
+    expect(() => assertWritable(join(link, "escape.ts"))).toThrow(PathDeniedError);
+  });
+});
+
+describe("assertAllWritable", () => {
+  test("reports every rejection, not just the first", () => {
+    try {
+      assertAllWritable([join(OUTSIDE, "a.ts"), join(OUTSIDE, "b.ts")]);
+      throw new Error("expected PathDeniedError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PathDeniedError);
+      expect((err as PathDeniedError).message).toContain("a.ts");
+      expect((err as PathDeniedError).message).toContain("b.ts");
+    }
+  });
+});
+
+describe("safeWrite", () => {
+  test("writes an allowed path and returns the resolved destination", async () => {
+    const written = await safeWrite(join(ROOT, "out.ts"), "hello");
+    expect(await Bun.file(written).text()).toBe("hello");
+  });
+
+  test("refuses a denied path and writes nothing", async () => {
+    const target = join(OUTSIDE, "nope.ts");
+    await expect(safeWrite(target, "hello")).rejects.toThrow(PathDeniedError);
+    expect(await Bun.file(target).exists()).toBe(false);
+  });
+});
+
+describe("findProjectRoot", () => {
+  test("finds the nearest ancestor containing .git", () => {
+    expect(findProjectRoot(import.meta.dir)).toBe(
+      require("fs").realpathSync(join(import.meta.dir, "..")),
+    );
+  });
+});

--- a/tests/provenance.test.ts
+++ b/tests/provenance.test.ts
@@ -8,7 +8,36 @@ import {
   formatProvenanceHuman,
 } from "../src/core/provenance";
 import type { ProvenanceEntry } from "../src/core/provenance";
+import { clearConfigCache } from "../src/core/provenance";
 import { computeHash } from "../src/core/read";
+
+// Diff capture is opt-in (it writes source lines to the telemetry log), so the
+// tests below that assert on `diff` have to turn it on explicitly.
+beforeEach(() => clearConfigCache({ provenance: { captureDiffs: true } }));
+afterEach(() => clearConfigCache());
+
+describe("captureDiffs default", () => {
+  test("no diff is recorded unless captureDiffs is enabled", () => {
+    clearConfigCache({});
+    const fields = buildProvenanceFields({
+      source: "const a = 1;",
+      newSource: "const a = 2;",
+      filePath: "a.ts",
+    });
+    expect(fields.afterHash).toBe(computeHash("const a = 2;"));
+    expect(fields.diff).toBeUndefined();
+  });
+
+  test("a sensitive file is never diffed even with captureDiffs on", () => {
+    clearConfigCache({ provenance: { captureDiffs: true } });
+    const fields = buildProvenanceFields({
+      source: "TOKEN=old",
+      newSource: "TOKEN=new",
+      filePath: "/repo/.env",
+    });
+    expect(fields.diff).toBeUndefined();
+  });
+});
 
 describe("createChangeSet", () => {
   test("returns valid UUID string", () => {

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from "bun:test";
+import { redactSecrets, redactEvent, isSensitiveFile } from "../src/core/redact";
+
+describe("redactSecrets", () => {
+  const cases: Array<[string, string]> = [
+    ["aws access key id", "AKIAIOSFODNN7EXAMPLE"],
+    ["openai key", "sk-abcdefghijklmnopqrstuvwx"],
+    ["anthropic key", "sk-ant-api03-abcdefghijklmnopqrstuvwx"],
+    ["github pat", "ghp_abcdefghijklmnopqrstuvwxyz0123456789"],
+    ["slack token", "xoxb-123456789012-abcdefghij"],
+    ["google api key", "AIzaSyA1234567890abcdefghijklmnopqrstuv"],
+  ];
+
+  for (const [name, secret] of cases) {
+    test(`redacts ${name}`, () => {
+      const out = redactSecrets(`value = ${secret}`);
+      expect(out).not.toContain(secret);
+      expect(out).toContain("[REDACTED]");
+    });
+  }
+
+  test("redacts a private key block", () => {
+    const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\nsecretbytes\n-----END RSA PRIVATE KEY-----";
+    const out = redactSecrets(pem);
+    expect(out).not.toContain("secretbytes");
+  });
+
+  test("redacts a bearer authorization header", () => {
+    const out = redactSecrets('Authorization: Bearer abc123def456');
+    expect(out).not.toContain("abc123def456");
+  });
+
+  test("redacts the password in a connection string", () => {
+    const out = redactSecrets("postgres://user:hunter2pass@db.example.com:5432/app");
+    expect(out).not.toContain("hunter2pass");
+    expect(out).toContain("db.example.com");
+  });
+
+  test("redacts secret-named assignments regardless of value shape", () => {
+    for (const line of [
+      'const apiKey = "zzzzzzzzzzzz"',
+      "DB_PASSWORD=correcthorse",
+      'client_secret: "abcdefghijkl"',
+      "ACCESS_TOKEN = qwertyuiopas",
+    ]) {
+      expect(redactSecrets(line)).toContain("[REDACTED]");
+    }
+  });
+
+  test("leaves ordinary source untouched", () => {
+    const src = "function add(a: number, b: number) { return a + b; }";
+    expect(redactSecrets(src)).toBe(src);
+  });
+});
+
+describe("isSensitiveFile", () => {
+  const sensitive = [".env", ".env.local", "server.pem", "tls.key", "id_rsa", "id_ed25519.pub",
+    "credentials", ".npmrc", ".netrc", "cert.p12", "secrets.yaml"];
+  const ordinary = ["index.ts", "keyboard.ts", "environment.md", "README.md", "credentials.test.ts"];
+
+  for (const f of sensitive) {
+    test(`${f} is sensitive`, () => expect(isSensitiveFile(`/repo/${f}`)).toBe(true));
+  }
+  for (const f of ordinary) {
+    test(`${f} is not sensitive`, () => expect(isSensitiveFile(`/repo/${f}`)).toBe(false));
+  }
+});
+
+describe("redactEvent", () => {
+  test("walks nested strings and arrays without changing structure", () => {
+    const out = redactEvent({
+      operation: "replace-hash",
+      success: true,
+      retries: 1,
+      diff: "+ const token = ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+      failed_in: ["lint: AKIAIOSFODNN7EXAMPLE"],
+      nested: { reason: "rotate sk-abcdefghijklmnopqrstuvwx" },
+    });
+    expect(out.success).toBe(true);
+    expect(out.retries).toBe(1);
+    expect(JSON.stringify(out)).not.toContain("ghp_");
+    expect(JSON.stringify(out)).not.toContain("AKIA");
+    expect(out.nested.reason).toContain("[REDACTED]");
+  });
+});

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1,6 +1,7 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { chooseRoute, routeEdit } from "../src/core/router";
 import { computeHash } from "../src/core/read";
+import { configureWriteBoundary, resetWriteBoundary } from "../src/core/paths";
 import { loadConfig, policyForce } from "../src/core/config";
 import type { RoutePolicy } from "../src/core/config";
 import { mkdirSync, rmSync, writeFileSync, readFileSync } from "fs";
@@ -127,6 +128,11 @@ describe("config loading", () => {
 
 describe("routeEdit", () => {
   const tmpDir = "/tmp/hashpilot-route-edit-tests";
+
+  // These fixtures live outside the repo, so the write boundary has to be told
+  // about them explicitly.
+  beforeAll(() => configureWriteBoundary({ allowedRoots: [tmpDir] }));
+  afterAll(() => resetWriteBoundary());
 
   function setup(filePath: string, content: string) {
     mkdirSync(tmpDir, { recursive: true });
@@ -401,7 +407,9 @@ describe("routeEdit", () => {
     const file = `${tmpDir}/policy.ts`;
     setup(file, "function xyz() { return 1; }\n");
     const policy: RoutePolicy = { languageOverrides: { typescript: "hash" } };
-    const hash = computeHash("function xyz() { return 1; }");
+    // Whole-file anchor: must include the trailing newline. A mismatch here is
+    // now a hard failure rather than a silent whole-file overwrite.
+    const hash = computeHash("function xyz() { return 1; }\n");
     const result = await routeEdit({
       filePath: file,
       operation: "rename-symbol",

--- a/tests/telemetry-optout.test.ts
+++ b/tests/telemetry-optout.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { resolveTelemetryEnabled } from "../src/core/telemetry";
+
+const ENV = "HASHPILOT_TELEMETRY";
+
+afterEach(() => {
+  delete process.env[ENV];
+});
+
+describe("resolveTelemetryEnabled", () => {
+  test("telemetry is on when nothing opts out", () => {
+    expect(resolveTelemetryEnabled(undefined, false)).toBe(true);
+  });
+
+  test("config can turn it off", () => {
+    expect(resolveTelemetryEnabled({ enabled: false }, false)).toBe(false);
+  });
+
+  test("the env var overrides a config that enables it", () => {
+    for (const v of ["0", "false", "off", "no", " OFF "]) {
+      process.env[ENV] = v;
+      expect(resolveTelemetryEnabled({ enabled: true }, false)).toBe(false);
+    }
+  });
+
+  test("an unrecognized env value does not disable telemetry", () => {
+    process.env[ENV] = "1";
+    expect(resolveTelemetryEnabled(undefined, false)).toBe(true);
+  });
+
+  test("--no-telemetry wins over everything", () => {
+    process.env[ENV] = "1";
+    expect(resolveTelemetryEnabled({ enabled: true }, true)).toBe(false);
+  });
+});


### PR DESCRIPTION
Sprint 1 of the [Aug 2026 audit backlog](../blob/main/ROADMAP.md). Eight of the nine milestone issues land here.

## What changed

| Issue | Fix |
|---|---|
| #3 (B1) | `replace-hash` no longer overwrites the file when the anchor goes stale. A moved anchor is relocated only when a window slide finds exactly one match; >1 is `AMBIGUOUS_ANCHOR`, 0 is `STALE_ANCHOR`. A whole-file anchor has nothing to relocate and now refuses. |
| #6 (B5) | `--range` without a colon parsed to `NaN` and silently duplicated the file. Ranges are now validated and rejected. |
| #5 (B3) | New write boundary in `src/core/paths.ts`. Every write is confined to the project root (widened by `allowedRoots` / `--allowed-root` / `--allow-outside-root`), with a hard deny-list (`~/.ssh`, `~/.aws`, `/etc`, shell rc files, the telemetry log) that no flag overrides. Both sides are realpath-resolved, so `/etc` on macOS is caught via `/private/etc`. |
| #4 (B2) | New `src/core/exit-codes.ts`. `0` ok · `1` usage · `2` edit failed · `3` stale/precondition (agent-retryable) · `4` verify failed · `5` I/O · `70` internal. Batch operations return worst-wins. |
| #8 (B6) | `HASHPILOT_TELEMETRY` and `--no-telemetry` are actually honored; `src/core/redact.ts` scrubs credentials; provenance diff capture is opt-in via `provenance.captureDiffs` and never runs on sensitive files; log files are `chmod` 0700/0600 even when they already exist. |
| #9 (B11) | `remove-parameter` emitted an unmatchable `/* TODO: remove arg */` search string and reported success. It now returns `UNSUPPORTED_OPERATION` at parse time. |
| #11 (B20) | Package version aligned with the released tag; publishing fixed. |
| #7 (B7) | `diff apply` without `--patch` reports a usage error instead of crashing with exit 0. |

**Deferred:** #10 (B13, honoring the verify result in the rollback decision) must ship with or after #24 (B32, unscoped test runs) — otherwise honoring the verify result turns a silent no-op into a footgun that reverts good work on an unrelated pre-existing test failure. It moves to Sprint 2; `ROADMAP.md` records this.

## Breaking changes

- `replace-hash` no longer "auto-recovers" a stale whole-file anchor by overwriting the file. That path was data loss reported as `success: true`.
- Commands now exit non-zero on failure. Any caller that ignored exit codes will start seeing them.

Agents should treat exit code `3` as "re-read the file and retry". `docs/ADAPTER-CONTRACT.md` documents the new outcomes, the `relocatedTo` field, all 11 error codes, and the exit-code table.

## Verification

- `bun test` — 424 pass / 0 fail (was 344 before this branch; 80 new tests across 5 new files)
- `bun run build` — clean
- `bash tests/smoke.sh` — 26 passed / 0 failed

## Docs

Synced per the documentation policy: `docs/ADAPTER-CONTRACT.md`, `docs/ARCHITECTURE.md` (three new module sections + footer timestamp), `README.md` (exit codes, write boundary, telemetry & privacy), `CLAUDE.md`, `AGENTS.md`, `ROADMAP.md`.

## Review follow-up (`14afcbc`)

A `/review` pass over this branch found four defects in the new exit-code work; all are fixed in `14afcbc`:

- **I/O errors reported as exit 70 (internal).** Commander's async action handlers reject *outside* the `try/catch` around `program.parse()`, so an ordinary `ENOENT` landed in `unhandledRejection` and was labelled a HashPilot bug — telling an agent to file a bug report instead of fixing its path. `reportInternalError` now classifies on the Node syscall code (`ENOENT`, `EACCES`, …) and returns `ExitCode.IO` (5) with a recovery hint.
- **`intent execute` and `provenance query` never set an exit code in human (non-`--json`) output.** An agent running without `--json` saw 0 on failure. Both branches now call `exitCodeFor(result)`.
- **`telemetry show --limit` and `telemetry health --window` bypassed `parseIntFlag`,** so a non-numeric value produced `NaN` instead of a usage error. Both now route through `usageError()` (exit 1).
- **`src/core/index.ts` had two `export` statements on one line** from the Sprint 1 commit. Split.

Verified after the fix: `missing-file → 5`, `bad-window → 1`, `bad-limit → 1`, `bun run build` clean, `bun test` 424 pass / 0 fail.

## Findings filed as separate issues

Out of scope for this PR's contract, tracked in `ROADMAP.md`:

- **#55 (P1, Sprint 2)** — the AST tier is non-functional on any file ≥32767 chars; the tree-sitter Node binding rejects `parse(string)` at that size with a bare `Invalid argument`. Not covered by the syscall fix above (the error carries no syscall code). Sequenced with #13, which touches the same call sites.
- **#56 (P2, Sprint 2)** — the output contract mixes bare top-level arrays with objects. Must land *inside* #18 (B15, uniform envelope) so consumers absorb one breaking change instead of two.
- **#57 (P3, Backlog)** — `grep-many` takes positional args that read like flags, and Commander's own errors escape the JSON envelope.

Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
Closes #9
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
