### PR TITLE
feat: generated CLI quickref and roadmap consistency lint

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: backlog
+description: Add, close, or re-prioritize a HashPilot backlog item. Keeps the GitHub issue, its labels and milestone, and the ROADMAP.md table consistent with each other. Use whenever a new defect or improvement is found, an issue is completed, or a roadmap row needs to move.
+---
+
+# Backlog
+
+Every backlog item lives in two places: a GitHub issue and a row in `ROADMAP.md`.
+Editing one and not the other is the failure mode this skill exists to prevent —
+it has already produced a duplicated row and an out-of-order table.
+
+`bun run lint:roadmap` is the gate. It is also run in CI (`Docs Verify`) and by
+`bun test`. Never hand-verify what the linter checks.
+
+## Conventions
+
+- **Score** = `(Impact × 5) + (Evidence × 2) − (Effort × 2)`, each factor 1–10.
+  The score ranks items *within* a table; it is not a tier threshold.
+- **Priority** reflects sprint assignment, not the score: `P0`/`P1` → Sprints 1–2,
+  `P2` → Sprints 3–4, `P3` → Backlog.
+- **Evidence** is `verified` (reproduced live against the CLI) or `reported`
+  (read at `file:line`, not executed). Do not write `verified` for something you
+  only read.
+- **Item** column is `B<n> — <one-line defect statement>`. `B<n>` continues the
+  numbering in `AUDIT-2026-08.md`; new post-audit findings keep counting up.
+- Every issue carries the `audit-2026-08` label, a `P0`–`P3` label, and a
+  milestone. Milestones: `Sprint 1 — Stop the Bleeding`, `Sprint 2 — Foundations`,
+  `Sprint 3 — Parity`, `Sprint 4 — Differentiation`, `Backlog`.
+
+## Adding an item
+
+1. Confirm it is not already tracked: `gh issue list --label audit-2026-08 --search "<keywords>" --state all`.
+2. Score it. State the Impact/Evidence/Effort numbers you used in the issue body
+   so the score can be re-derived later.
+3. File the issue. The body must be self-contained — a memoryless agent picks
+   these up one at a time and will not read the audit:
+
+   ```
+   ## Problem
+   <what is wrong, at file:line>
+
+   ## Reproduction
+   <exact commands, exact observed output>
+
+   ## Required behavior
+   <what it must do instead>
+
+   ## Acceptance criteria
+   - [ ] <observable, testable statements>
+
+   ## Tests
+   <which test file, which cases>
+
+   Score: <n> (Impact <i> × 5 + Evidence <e> × 2 − Effort <f> × 2) · <P0-P3>
+   ```
+
+   ```bash
+   gh issue create --title "B<n> — <statement>" \
+     --label audit-2026-08 --label P<n> \
+     --milestone "<milestone>" --body-file <file>
+   ```
+4. Insert the row into the matching `ROADMAP.md` table **in descending score
+   order**. Column count must match that table's header — the Sprint 1 table has
+   an extra `Status` column.
+5. Run `bun run lint:roadmap`. Fix what it reports; do not eyeball the ordering.
+
+## Closing an item
+
+Close via `Closes #N` in the PR body so the milestone burns down. For Sprint 1
+style tables that carry a `Status` column, also set the row to `✅ done` or
+`⏭ deferred to <sprint>`; deferrals must say *why* in the table's **Sequencing**
+paragraph.
+
+## Moving an item between sprints
+
+Move the row, do not copy it — `bun run lint:roadmap` will reject a duplicate,
+but only after you have already made the mistake. Update the milestone in the
+same step:
+
+```bash
+gh issue edit <N> --milestone "<new milestone>"
+```
+
+If the move changes the sequencing story (something now depends on it, or no
+longer does), update the destination table's **Sequencing** paragraph too. That
+paragraph is the only place ordering constraints that the score cannot express
+are written down.
+
+## Always finish with
+
+```bash
+bun run lint:roadmap
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,21 @@ jobs:
   docs-verify:
     name: Docs Verify
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      # Structural checks: the CLI quickref must match the CLI's own --help, and
+      # ROADMAP.md must have no duplicate or out-of-order issue rows.
+      - name: Lint generated and hand-maintained docs
+        run: bun run lint:docs
       - name: Check docs are updated when source changes
         run: |
           if git diff --name-only HEAD~1...HEAD | grep -q '^src/'; then

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ dist/
 *.log
 .DS_Store
 logs/
-.claude/
+# Local Claude Code state stays untracked, but shared project skills ship.
+.claude/*
+!.claude/skills/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ HashPilot is a Bun/TypeScript CLI. The entry point is `src/cli.ts`; reusable edi
 - `bun run install-cli` — symlink the CLI into `~/.agentic-tools/bin/`.
 - `bash scripts/doctor.sh` — check the local installation environment.
 - `bash tests/smoke.sh` — run end-to-end checks against the installed CLI.
+- `bun run lint:docs` — verify the CLI quickref matches `--help` and `ROADMAP.md` is consistent.
+- `bun run gen:cli-quickref` — regenerate the quickref command reference after a CLI change.
+
+`docs/CLI-QUICKREF.md` is the agent-facing invocation reference: every command, flag, output shape, and exit code, plus the gotchas that cause guess-and-retry loops. Read it before invoking the CLI. Its command-reference block is generated from the CLI's own `--help`, so any CLI change requires `bun run gen:cli-quickref`; otherwise `bun run lint:docs` fails in CI (`Docs Verify`) and in `tests/cli-contract.test.ts`. Backlog changes (new issue, closed issue, re-prioritized row) must keep the GitHub issue and the `ROADMAP.md` row in step — `bun run lint:roadmap` is the gate.
 
 Use Bun 1.2 or newer. There is no separate formatter or linter configured; keep changes consistent with nearby code and run tests before submitting.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,15 @@ bun run build               # Bundle src/cli.ts to dist/
 bun run install-cli         # Symlink CLI into ~/.agentic-tools/bin/
 bun run src/cli.ts doctor   # Exercise the CLI directly without installing
 bash scripts/doctor.sh      # Check local installation environment
+bun run lint:docs           # CLI quickref matches --help + ROADMAP.md is consistent
+bun run gen:cli-quickref    # Regenerate the command reference after a CLI change
 ```
+
+`docs/CLI-QUICKREF.md` is the agent-facing invocation reference: every command, flag,
+output shape, and exit code, plus the gotchas that cause guess-and-retry. Its command
+reference block is generated from the CLI's own `--help`, so any CLI change requires
+`bun run gen:cli-quickref` — otherwise `bun run lint:docs` (CI `Docs Verify`, and
+`tests/cli-contract.test.ts`) fails.
 
 There is no separate linter or formatter configured. Tests use Bun's built-in test runner (`bun test`). To run a single test file:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 **AI agents edit code blind. HashPilot gives them cryptographic certainty.**
 
 Landing page: **[https://bigknoxy.github.io/HashPilot/](https://bigknoxy.github.io/HashPilot/)**
-Architecture: **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** · Roadmap & backlog: **[ROADMAP.md](ROADMAP.md)**
+Architecture: **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** · CLI reference: **[docs/CLI-QUICKREF.md](docs/CLI-QUICKREF.md)** · Roadmap & backlog: **[ROADMAP.md](ROADMAP.md)**
 
 Every edit is anchored by a SHA-256 hash — not a fragile line number or a fuzzy text match. If the hash matches, you're editing the right content. No guessing, no retries, no silent corruption.
 
@@ -437,6 +437,8 @@ MIT — see [LICENSE](LICENSE).
 Active development. Core editing engine, AST operations, telemetry, and all three adapter integrations are production-ready. Intent-based editing (M5) and provenance tracking (M6) are available as preview features.
 
 **Docs policy:** The landing page (README.md) and [design doc](docs/ARCHITECTURE.md) are living documents. Every PR that touches `src/` must update one or both. Every deploy is verified with browser automation. See the CI check `docs-verify`.
+
+**Agent quick reference:** [docs/CLI-QUICKREF.md](docs/CLI-QUICKREF.md) is the one page an agent should read before invoking the CLI — every command, flag, output shape, exit code, and the gotchas that otherwise cost a guess-and-retry loop. Its command reference is generated from the CLI's own `--help`, and `bun run lint:docs` (run in CI and by `bun test`) fails if the doc drifts from the binary or if `ROADMAP.md` grows a duplicate or out-of-order row.
 
 v1.3.1 — [Release notes](https://github.com/bigknoxy/HashPilot/releases)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,6 +36,7 @@ Correctness of the edit engine itself, plus the output contract everything downs
 
 | # | Item | Score | Pri | Evidence | Area |
 |---|------|-------|-----|----------|------|
+| [#60](../../issues/60) | B53 — `read-hash` emits an 8-char `lineHash` that `replace-hash` rejects as stale | 61 | P1 | verified | correctness |
 | [#55](../../issues/55) | B50 — AST tier is non-functional on any file larger than 32KB | 60 | P1 | verified | correctness |
 | [#13](../../issues/13) | B8 — No `hasError` parse-validity gate; AST edits write garbage | 59 | P1 | verified | correctness |
 | [#12](../../issues/12) | B4 — No atomic writes, no backups, no undo | 56 | P0 | reported | correctness · data-loss |
@@ -52,7 +53,7 @@ Correctness of the edit engine itself, plus the output contract everything downs
 | [#56](../../issues/56) | B51 — Output contract mixes bare arrays and objects | 44 | P2 | verified | cli |
 | [#20](../../issues/20) | B17 — Concurrent JSONL writes corrupt telemetry; corruption swallowed | 43 | P1 | reported | correctness |
 
-**Sequencing:** B15's envelope is the contract for the CLI work in Sprint 3 and for the MCP server ([#25](../../issues/25)); land it before either. Changing output shapes requires updating [`docs/ADAPTER-CONTRACT.md`](docs/ADAPTER-CONTRACT.md) and the affected tests in the same PR. [#56](../../issues/56) (B51) must land *inside* B15 rather than before it, so consumers absorb one breaking output change instead of two. [#55](../../issues/55) (B50) and [#13](../../issues/13) (B8) touch the same tree-sitter call sites — sequence them together.
+**Sequencing:** [#60](../../issues/60) (B53) is first — it is a one-line width mismatch that currently makes the read → write round-trip unusable, and the `STALE_ANCHOR` it produces is documented as retryable, so an agent loops on it forever. B15's envelope is the contract for the CLI work in Sprint 3 and for the MCP server ([#25](../../issues/25)); land it before either. Changing output shapes requires updating [`docs/ADAPTER-CONTRACT.md`](docs/ADAPTER-CONTRACT.md) and the affected tests in the same PR. [#56](../../issues/56) (B51) must land *inside* B15 rather than before it, so consumers absorb one breaking output change instead of two. [#55](../../issues/55) (B50) and [#13](../../issues/13) (B8) touch the same tree-sitter call sites — sequence them together.
 
 ## Sprint 3 — Parity
 
@@ -71,7 +72,7 @@ Catching up to what competitors already ship: MCP distribution, interactivity, p
 | [#29](../../issues/29) | B26 — `--yes` and `--dry-run` on destructive operations | 46 | P2 | verified | cli |
 | [#31](../../issues/31) | B28 — Property test: `apply(diff(A,B)) === B` | 45 | P2 | reported | testing |
 | [#32](../../issues/32) | B29 — Deleted line starting with `--` breaks unified-diff parsing | 42 | P2 | reported | correctness |
-| [#59](../../issues/59) | B47 — Telemetry reads report corruption and I/O failure as an empty log | 38 | P2 | verified | ops |
+| [#59](../../issues/59) | B52 — Telemetry reads report corruption and I/O failure as an empty log | 38 | P2 | verified | ops |
 
 **Sequencing:** B21's operation registry subsumes [#48](../../issues/48) (B46, `cli.ts` duplication) — do not fix the duplication separately. B34 must be resolved before flipping `npmPublish` in B20's fix.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,12 +95,12 @@ Catching up to what competitors already ship: MCP distribution, interactivity, p
 | [#40](../../issues/40) | B38 — Empty-string `newContent` unroutable; hash-tier deletion impossible | 39 | P3 | correctness |
 | [#46](../../issues/46) | B44 — `doctor` inverts stdout/stderr and always exits 0 | 39 | P3 | cli |
 | [#49](../../issues/49) | B47 — `gh-pages` publishes the entire repository | 39 | P3 | ops |
+| [#57](../../issues/57) | B52 — `grep-many` args are positional but read as flags; Commander errors escape the JSON envelope | 38 | P3 | cli |
 | [#39](../../issues/39) | B37 — Symbol search silently truncates at depth 10 | 37 | P3 | correctness |
 | [#45](../../issues/45) | B43 — Publish a config JSON Schema; add `config validate` and `init` | 37 | P3 | cli |
 | [#50](../../issues/50) | B48 — Telemetry retention never enforced; backup to a fixed `/tmp` path | 37 | P3 | ops · security |
 | [#43](../../issues/43) | B41 — `intent` parses every repo file twice, serially, per invocation | 36 | P3 | performance |
 | [#47](../../issues/47) | B45 — Add `--quiet`/`--verbose`/`--no-color`; respect `NO_COLOR` | 36 | P3 | cli |
-| [#57](../../issues/57) | B52 — `grep-many` args are positional but read as flags; Commander errors escape the JSON envelope | 38 | P3 | cli |
 | [#51](../../issues/51) | B49 — Long tail: seven small correctness and hygiene defects | 30 | P3 | correctness |
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,6 +71,7 @@ Catching up to what competitors already ship: MCP distribution, interactivity, p
 | [#29](../../issues/29) | B26 — `--yes` and `--dry-run` on destructive operations | 46 | P2 | verified | cli |
 | [#31](../../issues/31) | B28 — Property test: `apply(diff(A,B)) === B` | 45 | P2 | reported | testing |
 | [#32](../../issues/32) | B29 — Deleted line starting with `--` breaks unified-diff parsing | 42 | P2 | reported | correctness |
+| [#59](../../issues/59) | B47 — Telemetry reads report corruption and I/O failure as an empty log | 38 | P2 | verified | ops |
 
 **Sequencing:** B21's operation registry subsumes [#48](../../issues/48) (B46, `cli.ts` duplication) — do not fix the duplication separately. B34 must be resolved before flipping `npmPublish` in B20's fix.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -474,4 +474,4 @@ The CI check `docs-verify` enforces rule 5 — if `src/` files change but neithe
 
 ---
 
-_Last updated: 2026-08-11 — Sprint 1 (safety hardening: write boundary, exit codes, telemetry opt-out, anchor relocation) · agent ergonomics ([CLI quickref](CLI-QUICKREF.md) generated from `--help`, roadmap consistency lint)._
+_Last updated: 2026-08-11 — Sprint 1 (safety hardening: write boundary, exit codes, telemetry opt-out, anchor relocation) · agent ergonomics ([CLI quickref](CLI-QUICKREF.md) generated from `--help`, roadmap consistency lint). Telemetry queries are reads: they exit 0 on success regardless of the `success` field of the events they return, and `readEvents(0)` returns nothing rather than the whole log. Surfacing a corrupt or unreadable log as an error rather than an empty one is tracked in [#59](../../issues/59)._

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -474,4 +474,4 @@ The CI check `docs-verify` enforces rule 5 — if `src/` files change but neithe
 
 ---
 
-_Last updated: 2026-08-11 — Sprint 1 (safety hardening: write boundary, exit codes, telemetry opt-out, anchor relocation)._
+_Last updated: 2026-08-11 — Sprint 1 (safety hardening: write boundary, exit codes, telemetry opt-out, anchor relocation) · agent ergonomics ([CLI quickref](CLI-QUICKREF.md) generated from `--help`, roadmap consistency lint)._

--- a/docs/CLI-QUICKREF.md
+++ b/docs/CLI-QUICKREF.md
@@ -41,6 +41,15 @@ Do not assume `.results` or `.success` on every command. The uniform envelope is
 [#18 (B15)](../../issues/18); until it lands, shapes are per-command and the tables
 below plus `ADAPTER-CONTRACT.md` are the source of truth.
 
+### `telemetry show -n 0` means zero, and reads always exit 0
+
+A telemetry query reports on *past* operations. Its exit code describes the query,
+not the events: a log full of failures still exits 0. Do not infer health from the
+exit code — read `telemetry health`.
+
+`-n 0` returns `[]`. (It used to return the entire log, because `slice(-0)` is
+`slice(0)`.)
+
 ### The telemetry subcommand is `show`, not `recent`
 
 `structured-edit telemetry show -n 50`. Siblings: `summary`, `health`, `clear`,

--- a/docs/CLI-QUICKREF.md
+++ b/docs/CLI-QUICKREF.md
@@ -89,6 +89,21 @@ looks unrelated to AST. Green baseline is `bun test` fully passing.
 
 _31 commands, generated from `--help`. Do not edit by hand — run `bun run gen:cli-quickref`._
 
+### Global options
+
+Accepted before the subcommand, e.g. `structured-edit --allowed-root /srv/app read-many f.ts`.
+
+```
+structured-edit [options] [command]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `-V, --version` | output the version number |
+| `--allow-outside-root` | Permit writes outside the project root (credentials and system paths stay blocked) |
+| `--allowed-root <dir...>` | Additional directory writes may target |
+| `--no-telemetry` | Disable telemetry logging for this invocation |
+
 ### Command groups
 
 | Group | Subcommands |

--- a/docs/CLI-QUICKREF.md
+++ b/docs/CLI-QUICKREF.md
@@ -1,0 +1,656 @@
+# CLI Quick Reference
+
+Copy-paste reference for `structured-edit`, aimed at agents driving the CLI without
+prior context. The command tables below are **generated from the CLI's own `--help`**,
+so they cannot drift from what the binary accepts.
+
+- Regenerate: `bun run gen:cli-quickref`
+- CI enforces freshness with `bun run gen:cli-quickref:check` (also covered by `bun test`).
+- Output *shapes* and exit codes are asserted by `tests/cli-contract.test.ts` — the
+  "Gotchas" section below is executable, not folklore.
+
+Related: [`ADAPTER-CONTRACT.md`](ADAPTER-CONTRACT.md) for the machine contract,
+[`ARCHITECTURE.md`](ARCHITECTURE.md) for how the routing tiers fit together.
+
+---
+
+## Gotchas
+
+Each of these cost a real agent a wasted round-trip. Every claim has a test in
+`tests/cli-contract.test.ts`.
+
+### Positionals are positional — there is no `--pattern` or `--paths`
+
+```bash
+structured-edit grep-many '<pattern>' <path>...      # ✅
+structured-edit grep-many --pattern x --paths src    # ❌ unknown option, exit 1
+```
+
+`symbol-lookup-many` is the exception in the search family: paths are positional but
+names come from `--names n1,n2`.
+
+### `read-many` returns a bare top-level array, not an envelope
+
+```jsonc
+[ { "path": "…", "hash": "…", "content": "…" } ]   // read-many
+{ "pattern": "…", "results": [ … ] }               // grep-many
+{ "checks": [ … ] }                                // doctor
+```
+
+Do not assume `.results` or `.success` on every command. The uniform envelope is
+[#18 (B15)](../../issues/18); until it lands, shapes are per-command and the tables
+below plus `ADAPTER-CONTRACT.md` are the source of truth.
+
+### The telemetry subcommand is `show`, not `recent`
+
+`structured-edit telemetry show -n 50`. Siblings: `summary`, `health`, `clear`,
+`sessions`, `export`, `prune`.
+
+### Never read an exit code through a pipe
+
+```bash
+structured-edit doctor | head        # $? is head's status — always 0
+structured-edit doctor >/dev/null 2>&1; echo $?   # ✅ the real code
+```
+
+This masked a genuine exit-70 during review and made a broken build look green.
+
+### Exit codes are the retry contract
+
+| Code | Meaning | What an agent should do |
+|------|---------|-------------------------|
+| 0 | ok | continue |
+| 1 | usage error | fix the command line; do not retry as-is |
+| 2 | edit failed | the edit was refused; re-read and re-plan |
+| 3 | stale anchor / precondition | **re-read the file and retry** — this one is retryable |
+| 4 | verification failed | the edit applied but checks failed |
+| 5 | I/O error | check the path exists and is writable |
+| 70 | internal error | a HashPilot bug — report it |
+
+Batch commands return worst-wins across their files.
+
+### AST edits fail on files ≥ 32 KB
+
+The tree-sitter Node binding rejects `parse(string)` at 32767 characters with a bare
+`Invalid argument`, and the router does not fall back cleanly. Tracked as
+[#55 (B50)](../../issues/55). On a large file, force `--method hash` or `--method diff`.
+
+### `bun install` before anything else
+
+tree-sitter is a native module. Without `node_modules/`, the AST test files abort with
+`Cannot find package 'tree-sitter'` while the rest of the suite passes — the failure
+looks unrelated to AST. Green baseline is `bun test` fully passing.
+
+---
+
+## Command reference
+
+<!-- BEGIN GENERATED: command reference -->
+
+_31 commands, generated from `--help`. Do not edit by hand — run `bun run gen:cli-quickref`._
+
+### Command groups
+
+| Group | Subcommands |
+|-------|-------------|
+| `ast` | `capabilities`, `find-symbols`, `rename-symbol`, `replace-body`, `add-import`, `remove-import`, `insert-before`, `insert-after` |
+| `diff` | `generate`, `apply` |
+| `telemetry` | `show`, `summary`, `health`, `clear`, `sessions`, `export`, `prune` |
+| `provenance` | `query`, `changeset` |
+
+### Commands
+
+#### `read-many`
+
+Read multiple files, return content + hashes
+
+```
+structured-edit read-many [options] <files...>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `files` | File paths |
+
+| Flag | Meaning |
+|------|---------|
+| `--json` | Output as JSON (default: true) |
+
+#### `read-hash`
+
+Read a line with hash and context
+
+```
+structured-edit read-hash [options] <file> <line>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `line` | Line number |
+
+| Flag | Meaning |
+|------|---------|
+| `-c, --context <n>` | Context lines (default: "3") |
+| `--json` | Output as JSON (default: true) |
+
+#### `grep-many`
+
+Search pattern across multiple paths
+
+```
+structured-edit grep-many [options] <pattern> <paths...>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `pattern` | Regex pattern |
+| `paths` | Paths to search |
+
+| Flag | Meaning |
+|------|---------|
+| `-i, --ignore-case` | Case insensitive |
+| `--file-pattern <glob>` | File pattern filter |
+| `--max-results <n>` | Max results |
+| `--json` | Output as JSON (default: true) |
+
+#### `symbol-lookup-many`
+
+Find symbol definitions. Usage: symbol-lookup-many <paths...> --names n1,n2
+
+```
+structured-edit symbol-lookup-many [options] <paths...>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `paths` | Paths to search |
+
+| Flag | Meaning |
+|------|---------|
+| `--names <names>` | Comma-separated symbol names |
+| `--json` | Output as JSON (default: true) |
+
+#### `replace-hash`
+
+Replace content identified by hash anchor
+
+```
+structured-edit replace-hash [options] <file> <old-hash> <new-content>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `old-hash` | Hash of content to replace |
+| `new-content` | New content (or @file to read from file) |
+
+| Flag | Meaning |
+|------|---------|
+| `--range <start:end>` | Line range (1-indexed). N or N:M |
+| `--no-recover` | Fail immediately on a stale anchor instead of attempting relocation |
+| `--dry-run` | Preview without writing |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--json` | Output as JSON (default: true) |
+
+#### `ast capabilities`
+
+Show supported AST languages, operations, and limitations
+
+```
+structured-edit ast capabilities [options]
+```
+
+#### `ast find-symbols`
+
+List symbols in a file
+
+```
+structured-edit ast find-symbols [options] <file>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+
+#### `ast rename-symbol`
+
+Rename a symbol across a file
+
+```
+structured-edit ast rename-symbol [options] <file> <old-name> <new-name>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `old-name` | Current symbol name |
+| `new-name` | New symbol name |
+
+| Flag | Meaning |
+|------|---------|
+| `--dry-run` | Preview only |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--json` | Output as JSON (default: true) |
+
+#### `ast replace-body`
+
+Replace function/method body
+
+```
+structured-edit ast replace-body [options] <file> <symbol> <new-body>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `symbol` | Symbol name |
+| `new-body` | New body (or @file) |
+
+| Flag | Meaning |
+|------|---------|
+| `--dry-run` | Preview only |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--json` | Output as JSON (default: true) |
+
+#### `ast add-import`
+
+Add an import statement
+
+```
+structured-edit ast add-import [options] <file> <import-spec>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `import-spec` | Import spec (e.g. '{ Foo } from ./bar') |
+
+| Flag | Meaning |
+|------|---------|
+| `--dry-run` | Preview only |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--json` | Output as JSON (default: true) |
+
+#### `ast remove-import`
+
+Remove an import statement
+
+```
+structured-edit ast remove-import [options] <file> <import-spec>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `import-spec` | Import spec to remove |
+
+| Flag | Meaning |
+|------|---------|
+| `--dry-run` | Preview only |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--json` | Output as JSON (default: true) |
+
+#### `ast insert-before`
+
+Insert content before a symbol
+
+```
+structured-edit ast insert-before [options] <file> <symbol> <content>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `symbol` | Symbol name |
+| `content` | Content to insert (or @file) |
+
+| Flag | Meaning |
+|------|---------|
+| `--dry-run` | Preview only |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--json` | Output as JSON (default: true) |
+
+#### `ast insert-after`
+
+Insert content after a symbol
+
+```
+structured-edit ast insert-after [options] <file> <symbol> <content>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `symbol` | Symbol name |
+| `content` | Content to insert (or @file) |
+
+| Flag | Meaning |
+|------|---------|
+| `--dry-run` | Preview only |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--json` | Output as JSON (default: true) |
+
+#### `route-edit`
+
+Auto-routed structured edit through AST → Hash → Diff pipeline
+
+```
+structured-edit route-edit [options] <file> <operation>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `operation` | Operation (rename-symbol, replace-body, add-import, remove-import, insert-before, insert-after, replace-hash, replace-content) |
+
+| Flag | Meaning |
+|------|---------|
+| `--method <route>` | Force a specific route (ast, hash, diff) |
+| `--old-hash <hash>` | Hash for hash-route verification |
+| `--new-content <text>` | New content (or @file) |
+| `--old-content <text>` | Old content for diff-route search-and-replace |
+| `--range <start:end>` | Line range for hash route |
+| `--old-name <name>` | Old symbol name (rename-symbol) |
+| `--new-name <name>` | New symbol name (rename-symbol) |
+| `--symbol <name>` | Symbol name (replace-body, insert-before, insert-after) |
+| `--new-body <text>` | New body content (replace-body, or @file) |
+| `--import-spec <spec>` | Import spec (add-import, remove-import) |
+| `--content <text>` | Content (insert-before, insert-after, or @file) |
+| `--policy <json>` | Inline RoutePolicy JSON |
+| `--dry-run` | Preview without writing |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--json` | Output as JSON (default: true) |
+
+#### `batch`
+
+Apply the same edit to multiple files in parallel
+
+```
+structured-edit batch [options] <operation> <files...>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `operation` | Operation (rename-symbol, replace-body, add-import, remove-import, insert-before, insert-after, replace-hash, replace-content) |
+| `files` | Files to edit |
+
+| Flag | Meaning |
+|------|---------|
+| `--method <route>` | Force a specific route (ast, hash, diff) |
+| `--old-hash <hash>` | Hash for hash-route verification |
+| `--new-content <text>` | New content (or @file) |
+| `--old-content <text>` | Old content for diff-route search-and-replace |
+| `--range <start:end>` | Line range for hash route |
+| `--old-name <name>` | Old symbol name (rename-symbol) |
+| `--new-name <name>` | New symbol name (rename-symbol) |
+| `--symbol <name>` | Symbol name (replace-body, insert-before, insert-after) |
+| `--new-body <text>` | New body content (replace-body, or @file) |
+| `--import-spec <spec>` | Import spec (add-import, remove-import) |
+| `--content <text>` | Content (insert-before, insert-after, or @file) |
+| `--policy <json>` | Inline RoutePolicy JSON |
+| `--serial` | Execute sequentially instead of parallel |
+| `--dry-run` | Preview without writing |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--json` | Output as JSON (default: true) |
+
+#### `intent`
+
+Execute an editing intent — one command, full blast radius
+
+```
+structured-edit intent [options] <intent>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `intent` | Intent as JSON: {"operation":"add-parameter","symbol":"fn","param":{"name":"x"}} |
+
+| Flag | Meaning |
+|------|---------|
+| `--project-root <dir>` | Project root directory |
+| `--dry-run` | Preview plan without modifying files |
+| `--no-verify` | Skip verification after execution |
+| `--no-revert` | Don't roll back on failure |
+| `--timeout <ms>` | Timeout per operation in ms (default: "30000") |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--context <text>` | Agent prompt/context (or @file) |
+| `--json` | Output as JSON (default: true) |
+
+#### `diff generate`
+
+Generate a unified diff between old and new content
+
+```
+structured-edit diff generate [options] <file> <old-content> <new-content>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path (for diff header) |
+| `old-content` | Old content (or @file) |
+| `new-content` | New content (or @file) |
+
+| Flag | Meaning |
+|------|---------|
+| `-c, --context <n>` | Context lines (default: "3") |
+
+#### `diff apply`
+
+Apply a unified diff patch to a file
+
+```
+structured-edit diff apply [options] <file>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File to patch |
+
+| Flag | Meaning |
+|------|---------|
+| `--patch <file>` | Patch file to apply (or '-' for stdin) |
+| `--dry-run` | Preview without writing |
+| `-f, --fuzzy <n>` | Fuzzy match tolerance (default: "3") |
+| `--actor <name>` | Agent identity for provenance tracking |
+| `--task-id <id>` | Task/issue reference for provenance |
+| `--reason <text>` | Human-readable reason for the edit |
+| `--json` | Output as JSON (default: true) |
+
+#### `verify-changes`
+
+Run formatter, linter, typechecker, and tests on changed files
+
+```
+structured-edit verify-changes [options] <files...>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `files` | Files to verify |
+
+| Flag | Meaning |
+|------|---------|
+| `--formatter <cmd>` | Formatter command |
+| `--linter <cmd>` | Linter command |
+| `--typecheck <cmd>` | Type checker command (e.g. 'tsc --noEmit') |
+| `--test-filter <pattern>` | Test filter pattern |
+| `--test-runner <runner>` | Test runner (bun test, vitest, jest, pytest, go test, cargo test) |
+| `--formatter-args <args...>` | Formatter args |
+| `--linter-args <args...>` | Linter args |
+| `--test-args <args...>` | Test runner args |
+| `--auto-detect` | Auto-detect tools from project config files |
+| `--revert-on-failure` | Restore original file contents if any check fails |
+| `--timeout <ms>` | Per-check timeout in ms (default 30000) |
+| `--json` | Output as JSON (default: true) |
+
+#### `telemetry show`
+
+Show recent telemetry events
+
+```
+structured-edit telemetry show [options]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `-n, --limit <n>` | Number of events (default: "20") |
+
+#### `telemetry summary`
+
+Show telemetry summary
+
+```
+structured-edit telemetry summary [options]
+```
+
+#### `telemetry health`
+
+Show telemetry health report with per-language stats and threshold warnings
+
+```
+structured-edit telemetry health [options]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `-w, --window <days>` | Time window in days (default: "7") |
+| `-t, --trend` | Compare current window to previous window |
+
+#### `telemetry clear`
+
+Clear telemetry log
+
+```
+structured-edit telemetry clear [options]
+```
+
+#### `telemetry sessions`
+
+List session summaries
+
+```
+structured-edit telemetry sessions [options]
+```
+
+#### `telemetry export`
+
+Export telemetry events as NDJSON
+
+```
+structured-edit telemetry export [options]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--from <date>` | Start date (ISO format) |
+| `--to <date>` | End date (ISO format) |
+| `--session <id>` | Session ID filter |
+
+#### `telemetry prune`
+
+Delete old rotated telemetry files
+
+```
+structured-edit telemetry prune [options]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `-d, --older-than <days>` | Days threshold (default: "30") |
+
+#### `provenance query`
+
+Show edit history for a file (like git blame for agent edits)
+
+```
+structured-edit provenance query [options] <file> [line]
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `line` | Optional line number to filter by |
+
+| Flag | Meaning |
+|------|---------|
+| `--human` | Human-readable output |
+| `--json` | JSON output (default) (default: true) |
+| `--fuzzy` | Include edits without diff data in line-filtered queries |
+| `--limit <n>` | Max entries to show |
+
+#### `provenance changeset`
+
+Show all edits in a changeSet
+
+```
+structured-edit provenance changeset [options] <changeSetId>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `changeSetId` | ChangeSet UUID |
+
+| Flag | Meaning |
+|------|---------|
+| `--human` | Human-readable output |
+
+#### `doctor`
+
+Verify HashPilot installation health
+
+```
+structured-edit doctor [options]
+```
+
+#### `route`
+
+Show which edit route would be chosen (with detailed explanation)
+
+```
+structured-edit route [options] <file> <operation>
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `file` | File path |
+| `operation` | Operation name |
+
+| Flag | Meaning |
+|------|---------|
+| `--policy <json>` | Inline policy JSON to test |
+| `--no-default-config` | Ignore config file policies |
+
+#### `config`
+
+Show current HashPilot configuration
+
+```
+structured-edit config [options]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--config <path>` | Config file path override |
+
+<!-- END GENERATED: command reference -->

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "test": "bun test",
     "build": "bun build src/cli.ts --outdir dist --target bun",
     "install-cli": "ln -sf $(pwd)/src/cli.ts ~/.agentic-tools/bin/structured-edit",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "gen:cli-quickref": "bun run scripts/gen-cli-quickref.ts",
+    "gen:cli-quickref:check": "bun run scripts/gen-cli-quickref.ts --check",
+    "lint:roadmap": "bun run scripts/roadmap-lint.ts",
+    "lint:docs": "bun run gen:cli-quickref:check && bun run lint:roadmap"
   },
   "files": [
     "src/",

--- a/scripts/gen-cli-quickref.ts
+++ b/scripts/gen-cli-quickref.ts
@@ -32,13 +32,24 @@ export interface CommandDoc {
 }
 
 function help(path: string[]): string {
+  const label = path.join(" ") || "(root)";
   const res = spawnSync("bun", ["run", CLI, ...path, "--help"], {
     encoding: "utf8",
     cwd: ROOT,
     env: { ...process.env, HASHPILOT_TELEMETRY: "0" },
+    timeout: 30_000,
+    maxBuffer: 8 * 1024 * 1024,
   });
-  if (res.status !== 0 && !res.stdout) {
-    throw new Error(`help failed for '${path.join(" ")}': ${res.stderr}`);
+  // Anything short of a clean exit means the captured stdout may be a partial
+  // help page, and a partial page generates plausible-looking but wrong docs
+  // that still satisfy `--check`. Refuse rather than publish it.
+  if (res.error) throw new Error(`help failed for '${label}': ${res.error.message}`);
+  if (res.signal) throw new Error(`help for '${label}' was killed by ${res.signal}`);
+  if (res.status !== 0) {
+    throw new Error(`help for '${label}' exited ${res.status}: ${res.stderr?.trim()}`);
+  }
+  if (!res.stdout.includes("Usage:")) {
+    throw new Error(`help for '${label}' produced no Usage: line (truncated output?)`);
   }
   return res.stdout;
 }
@@ -112,7 +123,10 @@ export function walk(path: string[] = []): CommandDoc[] {
     children,
   };
 
-  const results: CommandDoc[] = path.length ? [doc] : [];
+  // The root document carries the global flags (`--allowed-root`,
+  // `--allow-outside-root`, `--no-telemetry`, `--version`), so it is kept, not
+  // dropped — those are exactly the flags an agent must not have to guess at.
+  const results: CommandDoc[] = [doc];
   // The root's own description lives above `Usage:`; subcommand descriptions
   // come from the parent's Commands table, so backfill them during recursion.
   for (const child of children) {
@@ -132,12 +146,27 @@ function cell(text: string): string {
 }
 
 export function render(docs: CommandDoc[]): string {
-  const leaves = docs.filter((d) => d.children.length === 0);
-  const groups = docs.filter((d) => d.children.length > 0);
+  const root = docs.find((d) => d.path.length === 0);
+  const leaves = docs.filter((d) => d.path.length > 0 && d.children.length === 0);
+  const groups = docs.filter((d) => d.path.length > 0 && d.children.length > 0);
 
   const out: string[] = [];
   out.push(`_${leaves.length} commands, generated from \`--help\`. Do not edit by hand — run \`bun run gen:cli-quickref\`._`);
   out.push("");
+  if (root) {
+    out.push("### Global options");
+    out.push("");
+    out.push("Accepted before the subcommand, e.g. `structured-edit --allowed-root /srv/app read-many f.ts`.");
+    out.push("");
+    out.push("```");
+    out.push(root.usage);
+    out.push("```");
+    out.push("");
+    out.push("| Flag | Meaning |");
+    out.push("|------|---------|");
+    for (const o of root.options) out.push(`| \`${cell(o.flags)}\` | ${cell(o.description)} |`);
+    out.push("");
+  }
   out.push("### Command groups");
   out.push("");
   out.push("| Group | Subcommands |");

--- a/scripts/gen-cli-quickref.ts
+++ b/scripts/gen-cli-quickref.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env bun
+/**
+ * Generates the command table in docs/CLI-QUICKREF.md by walking the CLI's own
+ * `--help` output. Reading the real help (rather than importing the Commander
+ * program) means the reference can never describe a command shape the shipped
+ * binary does not actually accept — src/cli.ts calls `program.parse()` at module
+ * load, so it cannot be imported without executing it.
+ *
+ *   bun run scripts/gen-cli-quickref.ts           # rewrite the generated block
+ *   bun run scripts/gen-cli-quickref.ts --check   # exit 1 if the file is stale
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+export const BEGIN_MARKER = "<!-- BEGIN GENERATED: command reference -->";
+export const END_MARKER = "<!-- END GENERATED: command reference -->";
+
+const ROOT = join(import.meta.dir, "..");
+const DOC_PATH = join(ROOT, "docs", "CLI-QUICKREF.md");
+const CLI = join(ROOT, "src", "cli.ts");
+
+export interface CommandDoc {
+  /** Full subcommand path, e.g. `["ast", "rename-symbol"]`. */
+  path: string[];
+  description: string;
+  usage: string;
+  args: Array<{ name: string; description: string }>;
+  options: Array<{ flags: string; description: string }>;
+  /** Present only on group commands like `ast` or `telemetry`. */
+  children: string[];
+}
+
+function help(path: string[]): string {
+  const res = spawnSync("bun", ["run", CLI, ...path, "--help"], {
+    encoding: "utf8",
+    cwd: ROOT,
+    env: { ...process.env, HASHPILOT_TELEMETRY: "0" },
+  });
+  if (res.status !== 0 && !res.stdout) {
+    throw new Error(`help failed for '${path.join(" ")}': ${res.stderr}`);
+  }
+  return res.stdout;
+}
+
+/** Splits `--help` output into its `Usage:` line and named sections. */
+function sections(text: string): { usage: string; sections: Map<string, string[]> } {
+  const lines = text.split("\n");
+  let usage = "";
+  const out = new Map<string, string[]>();
+  let current: string | null = null;
+  for (const line of lines) {
+    if (line.startsWith("Usage:")) {
+      usage = line.slice("Usage:".length).trim();
+      current = null;
+      continue;
+    }
+    const header = /^([A-Z][A-Za-z ]*):\s*$/.exec(line);
+    if (header) {
+      current = header[1]!;
+      out.set(current, []);
+      continue;
+    }
+    if (current && line.trim()) out.get(current)!.push(line);
+  }
+  return { usage, sections: out };
+}
+
+/**
+ * Splits an entry line into its term and description. Commander pads the two
+ * columns apart with at least two spaces, and a description may wrap onto
+ * continuation lines that carry no term at all.
+ */
+function entries(lines: string[]): Array<{ term: string; description: string }> {
+  const out: Array<{ term: string; description: string }> = [];
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+    const indent = line.length - line.trimStart().length;
+    const body = line.trim();
+    if (!body) continue;
+    // A continuation line is indented past the term column and has no gap.
+    const split = /^(\S.*?)\s{2,}(.*)$/.exec(body);
+    if (!split) {
+      if (out.length && indent > 4) out[out.length - 1]!.description += ` ${body}`;
+      else out.push({ term: body, description: "" });
+      continue;
+    }
+    out.push({ term: split[1]!, description: split[2]!.trim() });
+  }
+  return out;
+}
+
+/** Recursively walks every subcommand reachable from `path`. */
+export function walk(path: string[] = []): CommandDoc[] {
+  const parsed = sections(help(path));
+  const cmdEntries = entries(parsed.sections.get("Commands") ?? []);
+  const children = cmdEntries
+    .map((e) => e.term.split(/\s+/)[0]!)
+    .filter((name) => name !== "help");
+
+  const doc: CommandDoc = {
+    path,
+    description: "",
+    usage: parsed.usage,
+    args: entries(parsed.sections.get("Arguments") ?? []).map((e) => ({
+      name: e.term,
+      description: e.description,
+    })),
+    options: entries(parsed.sections.get("Options") ?? [])
+      .map((e) => ({ flags: e.term, description: e.description }))
+      .filter((o) => !/^-h, --help/.test(o.flags)),
+    children,
+  };
+
+  const results: CommandDoc[] = path.length ? [doc] : [];
+  // The root's own description lives above `Usage:`; subcommand descriptions
+  // come from the parent's Commands table, so backfill them during recursion.
+  for (const child of children) {
+    const sub = walk([...path, child]);
+    const own = sub.find((s) => s.path.join(" ") === [...path, child].join(" "));
+    if (own) {
+      own.description =
+        cmdEntries.find((e) => e.term.split(/\s+/)[0] === child)?.description ?? "";
+    }
+    results.push(...sub);
+  }
+  return results;
+}
+
+function cell(text: string): string {
+  return text.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+export function render(docs: CommandDoc[]): string {
+  const leaves = docs.filter((d) => d.children.length === 0);
+  const groups = docs.filter((d) => d.children.length > 0);
+
+  const out: string[] = [];
+  out.push(`_${leaves.length} commands, generated from \`--help\`. Do not edit by hand — run \`bun run gen:cli-quickref\`._`);
+  out.push("");
+  out.push("### Command groups");
+  out.push("");
+  out.push("| Group | Subcommands |");
+  out.push("|-------|-------------|");
+  for (const g of groups) {
+    out.push(`| \`${g.path.join(" ")}\` | ${g.children.map((c) => `\`${c}\``).join(", ")} |`);
+  }
+  out.push("");
+  out.push("### Commands");
+  out.push("");
+
+  for (const d of leaves) {
+    out.push(`#### \`${d.path.join(" ")}\``);
+    out.push("");
+    if (d.description) out.push(d.description);
+    out.push("");
+    out.push("```");
+    out.push(d.usage);
+    out.push("```");
+    out.push("");
+    if (d.args.length) {
+      out.push("| Positional | Meaning |");
+      out.push("|------------|---------|");
+      for (const a of d.args) out.push(`| \`${cell(a.name)}\` | ${cell(a.description)} |`);
+      out.push("");
+    }
+    if (d.options.length) {
+      out.push("| Flag | Meaning |");
+      out.push("|------|---------|");
+      for (const o of d.options) out.push(`| \`${cell(o.flags)}\` | ${cell(o.description)} |`);
+      out.push("");
+    }
+  }
+  return out.join("\n").trimEnd();
+}
+
+/** Replaces the generated block in `doc`, leaving hand-written prose intact. */
+export function spliceGenerated(doc: string, generated: string): string {
+  const begin = doc.indexOf(BEGIN_MARKER);
+  const end = doc.indexOf(END_MARKER);
+  if (begin === -1 || end === -1 || end < begin) {
+    throw new Error(`docs/CLI-QUICKREF.md is missing the generated-block markers`);
+  }
+  return (
+    doc.slice(0, begin + BEGIN_MARKER.length) + "\n\n" + generated + "\n\n" + doc.slice(end)
+  );
+}
+
+if (import.meta.main) {
+  const check = process.argv.includes("--check");
+  const current = readFileSync(DOC_PATH, "utf8");
+  const next = spliceGenerated(current, render(walk()));
+  if (current === next) {
+    console.log("✓ docs/CLI-QUICKREF.md is up to date");
+    process.exit(0);
+  }
+  if (check) {
+    console.error("✗ docs/CLI-QUICKREF.md is stale. Run: bun run gen:cli-quickref");
+    process.exit(1);
+  }
+  writeFileSync(DOC_PATH, next);
+  console.log("✓ regenerated docs/CLI-QUICKREF.md");
+}

--- a/scripts/roadmap-lint.ts
+++ b/scripts/roadmap-lint.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env bun
+/**
+ * Structural lint for ROADMAP.md.
+ *
+ * The roadmap is hand-edited every time an issue is filed or closed, and it has
+ * already shipped two defects of exactly this shape: an issue row duplicated into
+ * two sprints, and a row inserted out of score order. Both are mechanical and both
+ * are cheap to detect, so they are detected here instead of in review.
+ *
+ *   bun run scripts/roadmap-lint.ts            # lint ROADMAP.md
+ *   bun run scripts/roadmap-lint.ts <file>...  # lint specific files
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface LintIssue {
+  line: number;
+  rule: string;
+  message: string;
+}
+
+export interface Row {
+  line: number;
+  issue: number;
+  item: string;
+  score: number;
+  priority: string;
+  table: string;
+}
+
+const PRIORITIES = new Set(["P0", "P1", "P2", "P3"]);
+/** `| [#12](../../issues/12) | …` — display number and link target must agree. */
+const ISSUE_CELL = /^\[#(\d+)\]\((?:\.\.\/)*(?:\.\.\/)?issues\/(\d+)\)$/;
+
+function cells(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((c) => c.trim());
+}
+
+const isDivider = (line: string) => /^\|[\s:|-]+\|$/.test(line.trim());
+const isRow = (line: string) => line.trim().startsWith("|");
+
+/**
+ * Parses every scored issue table. A table qualifies when its header carries both
+ * a `#` column and a `Score` column, which excludes prose tables like the
+ * "Existing work already in the repo" listing.
+ */
+export function parseTables(text: string): { rows: Row[]; issues: LintIssue[] } {
+  const lines = text.split("\n");
+  const rows: Row[] = [];
+  const issues: LintIssue[] = [];
+  let table: string | null = null;
+  let heading = "(top of file)";
+  let columns: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.startsWith("#")) {
+      heading = line.replace(/^#+\s*/, "").trim();
+      table = null;
+      continue;
+    }
+    if (!isRow(line)) {
+      table = null;
+      continue;
+    }
+    if (isDivider(line)) continue;
+
+    const c = cells(line);
+    // Header row: opens a table if it is a scored issue table.
+    if (c[0] === "#" && isDivider(lines[i + 1] ?? "")) {
+      const scored = c.some((h) => h.toLowerCase() === "score");
+      table = scored ? heading : null;
+      columns = c;
+      continue;
+    }
+    if (table === null) continue;
+
+    const link = ISSUE_CELL.exec(c[0] ?? "");
+    if (!link) {
+      issues.push({
+        line: i + 1,
+        rule: "issue-link",
+        message: `first cell is not an issue link: ${c[0]}`,
+      });
+      continue;
+    }
+    if (link[1] !== link[2]) {
+      issues.push({
+        line: i + 1,
+        rule: "issue-link",
+        message: `link text #${link[1]} points at issue ${link[2]}`,
+      });
+    }
+    if (c.length !== columns.length) {
+      issues.push({
+        line: i + 1,
+        rule: "column-count",
+        message: `row has ${c.length} cells, header has ${columns.length}`,
+      });
+    }
+
+    const scoreIdx = columns.findIndex((h) => h.toLowerCase() === "score");
+    const priIdx = columns.findIndex((h) => h.toLowerCase() === "pri");
+    const raw = c[scoreIdx] ?? "";
+    const score = Number(raw);
+    if (!/^\d+$/.test(raw)) {
+      issues.push({ line: i + 1, rule: "score", message: `score is not an integer: ${raw}` });
+    }
+    const priority = c[priIdx] ?? "";
+    if (priIdx !== -1 && !PRIORITIES.has(priority)) {
+      issues.push({ line: i + 1, rule: "priority", message: `unknown priority: ${priority}` });
+    }
+
+    rows.push({
+      line: i + 1,
+      issue: Number(link[1]),
+      item: c[1] ?? "",
+      score: Number.isNaN(score) ? -1 : score,
+      priority,
+      table,
+    });
+  }
+  return { rows, issues };
+}
+
+export function lintRoadmap(text: string): LintIssue[] {
+  const { rows, issues } = parseTables(text);
+
+  // An issue belongs to exactly one table. A duplicate means a row was copied
+  // during a re-prioritization and the original never removed.
+  const seen = new Map<number, Row>();
+  for (const row of rows) {
+    const prior = seen.get(row.issue);
+    if (prior) {
+      issues.push({
+        line: row.line,
+        rule: "duplicate-issue",
+        message: `#${row.issue} already listed at line ${prior.line} (${prior.table})`,
+      });
+      continue;
+    }
+    seen.set(row.issue, row);
+  }
+
+  // Score orders work within a table, so a table that is not descending is
+  // telling a reader the wrong thing about what to pick up next.
+  const byTable = new Map<string, Row[]>();
+  for (const row of rows) {
+    if (!byTable.has(row.table)) byTable.set(row.table, []);
+    byTable.get(row.table)!.push(row);
+  }
+  for (const [table, group] of byTable) {
+    for (let i = 1; i < group.length; i++) {
+      const prev = group[i - 1]!;
+      const curr = group[i]!;
+      if (curr.score > prev.score) {
+        issues.push({
+          line: curr.line,
+          rule: "score-order",
+          message: `${table}: #${curr.issue} (${curr.score}) is listed after #${prev.issue} (${prev.score}) — tables sort by descending score`,
+        });
+      }
+    }
+  }
+
+  return issues.sort((a, b) => a.line - b.line);
+}
+
+if (import.meta.main) {
+  const files = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+  const targets = files.length ? files : [join(import.meta.dir, "..", "ROADMAP.md")];
+  let failed = false;
+  for (const file of targets) {
+    const found = lintRoadmap(readFileSync(file, "utf8"));
+    for (const issue of found) {
+      failed = true;
+      console.error(`${file}:${issue.line}  [${issue.rule}] ${issue.message}`);
+    }
+    if (!found.length) console.log(`✓ ${file}`);
+  }
+  process.exit(failed ? 1 : 0);
+}

--- a/scripts/roadmap-lint.ts
+++ b/scripts/roadmap-lint.ts
@@ -29,6 +29,8 @@ export interface Row {
 }
 
 const PRIORITIES = new Set(["P0", "P1", "P2", "P3"]);
+/** Accepted spellings of the priority column header, lowercased. */
+const PRIORITY_HEADERS = new Set(["pri", "priority"]);
 /** `| [#12](../../issues/12) | …` — display number and link target must agree. */
 const ISSUE_CELL = /^\[#(\d+)\]\((?:\.\.\/)*(?:\.\.\/)?issues\/(\d+)\)$/;
 
@@ -76,6 +78,17 @@ export function parseTables(text: string): { rows: Row[]; issues: LintIssue[] } 
       const scored = c.some((h) => h.toLowerCase() === "score");
       table = scored ? heading : null;
       columns = c;
+      // Every per-row rule below is keyed off a header name, so a renamed or
+      // dropped header turns its rule into a silent no-op — the table still
+      // lints clean while nothing about it is actually checked. Require the
+      // headers the rules depend on.
+      if (scored && !columns.some((h) => PRIORITY_HEADERS.has(h.toLowerCase()))) {
+        issues.push({
+          line: i + 1,
+          rule: "missing-column",
+          message: `scored table '${heading}' has no priority column (expected one of: ${[...PRIORITY_HEADERS].join(", ")}) — priority validation would be skipped`,
+        });
+      }
       continue;
     }
     if (table === null) continue;
@@ -105,7 +118,7 @@ export function parseTables(text: string): { rows: Row[]; issues: LintIssue[] } 
     }
 
     const scoreIdx = columns.findIndex((h) => h.toLowerCase() === "score");
-    const priIdx = columns.findIndex((h) => h.toLowerCase() === "pri");
+    const priIdx = columns.findIndex((h) => PRIORITY_HEADERS.has(h.toLowerCase()));
     const raw = c[scoreIdx] ?? "";
     const score = Number(raw);
     if (!/^\d+$/.test(raw)) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -742,14 +742,18 @@ telCmd
     const limit = parseIntFlag(opts.limit, "--limit", 20);
     if (typeof limit === "object") return usageError(limit.error);
     const events = readEvents(limit);
-    finish(events);
+    // A telemetry event's `success` field describes the operation it recorded,
+    // not this query. Letting `finish` infer the code turns "your log contains a
+    // failure" into "the query failed" (exit 2). Reads that complete are exit 0.
+    finish(events, ExitCode.OK);
   });
 
 telCmd
   .command("summary")
   .description("Show telemetry summary")
   .action(() => {
-    finish(summary());
+    // Read-only query: see the note on `telemetry show`.
+    finish(summary(), ExitCode.OK);
   });
 
 telCmd
@@ -760,7 +764,8 @@ telCmd
   .action((opts) => {
     const window = parseIntFlag(opts.window, "--window", 7);
     if (typeof window === "object") return usageError(window.error);
-    finish(opts.trend ? healthTrend(window) : health(window));
+    // Read-only query: see the note on `telemetry show`.
+    finish(opts.trend ? healthTrend(window) : health(window), ExitCode.OK);
   });
 
 telCmd
@@ -776,7 +781,8 @@ telCmd
   .description("List session summaries")
   .action(() => {
     const sessions = listSessions();
-    finish(sessions);
+    // Read-only query: see the note on `telemetry show`.
+    finish(sessions, ExitCode.OK);
   });
 
 telCmd

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -197,6 +197,9 @@ export function readEvents(limit: number = 100): TelemetryEvent[] {
     if (!existsSync(LOG_FILE)) return [];
     const content = readFileSync(LOG_FILE, "utf-8");
     const lines = content.trim().split("\n").filter(Boolean);
+    // `slice(-0)` is `slice(0)` — a request for zero events would return the
+    // entire log. Asking for none means none.
+    if (limit <= 0) return [];
     return lines.slice(-limit).map((l) => JSON.parse(l));
   } catch {
     return [];

--- a/tests/cli-contract.test.ts
+++ b/tests/cli-contract.test.ts
@@ -46,6 +46,13 @@ describe("documented invocation shapes", () => {
     expect(run(["telemetry", "show", "-n", "1"]).code).toBe(0);
     expect(run(["telemetry", "recent"]).code).toBe(1);
   });
+
+  test("`telemetry show -n 0` returns no events, not the whole log", () => {
+    // `slice(-0)` is `slice(0)`: asking for zero used to dump everything.
+    const res = run(["telemetry", "show", "-n", "0"]);
+    expect(res.code).toBe(0);
+    expect(JSON.parse(res.stdout)).toEqual([]);
+  });
 });
 
 describe("documented output shapes", () => {
@@ -132,6 +139,15 @@ describe("docs/CLI-QUICKREF.md", () => {
     expect(commands.length).toBeGreaterThan(10);
     for (const cmd of commands) {
       expect(doc).toContain(`structured-edit ${cmd}`);
+    }
+  });
+
+  test("documents the global flags, including the write-boundary ones", () => {
+    // An agent that has to guess `--allowed-root` guesses wrong, and the flags
+    // it guesses at are the ones governing where the tool may write.
+    const doc = readFileSync(QUICKREF, "utf8");
+    for (const flag of ["--allowed-root", "--allow-outside-root", "--no-telemetry", "--version"]) {
+      expect(doc).toContain(flag);
     }
   });
 

--- a/tests/cli-contract.test.ts
+++ b/tests/cli-contract.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { render, spliceGenerated, walk } from "../scripts/gen-cli-quickref";
+
+/**
+ * Executable version of docs/CLI-QUICKREF.md's "Gotchas" section. Every claim the
+ * quickref makes about invocation shape, output shape, or exit code is asserted
+ * here, so the doc cannot quietly become folklore.
+ */
+
+const ROOT = join(import.meta.dir, "..");
+const CLI = join(ROOT, "src", "cli.ts");
+const QUICKREF = join(ROOT, "docs", "CLI-QUICKREF.md");
+
+function run(args: string[], cwd = ROOT) {
+  const res = spawnSync("bun", ["run", CLI, ...args], {
+    encoding: "utf8",
+    cwd,
+    // Keep contract runs out of the developer's real telemetry log.
+    env: { ...process.env, HASHPILOT_TELEMETRY: "0" },
+  });
+  return { code: res.status ?? -1, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+describe("documented invocation shapes", () => {
+  test("grep-many takes pattern and paths positionally", () => {
+    const ok = run(["grep-many", "hashpilot", "package.json"]);
+    expect(ok.code).toBe(0);
+    expect(JSON.parse(ok.stdout).results.length).toBeGreaterThan(0);
+  });
+
+  test("grep-many rejects the --pattern/--paths flags an agent might guess", () => {
+    const bad = run(["grep-many", "--pattern", "hashpilot", "--paths", "package.json"]);
+    expect(bad.code).toBe(1);
+  });
+
+  test("symbol-lookup-many takes paths positionally but names via --names", () => {
+    const res = run(["symbol-lookup-many", "src/core/exit-codes.ts", "--names", "exitCodeFor"]);
+    expect(res.code).toBe(0);
+  });
+
+  test("the telemetry subcommand is `show`, and `recent` does not exist", () => {
+    expect(run(["telemetry", "show", "-n", "1"]).code).toBe(0);
+    expect(run(["telemetry", "recent"]).code).toBe(1);
+  });
+});
+
+describe("documented output shapes", () => {
+  test("read-many returns a bare top-level array", () => {
+    const res = run(["read-many", "package.json"]);
+    expect(res.code).toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0]).toHaveProperty("hash");
+    expect(parsed[0]).toHaveProperty("content");
+  });
+
+  test("grep-many returns an object keyed by pattern and results", () => {
+    const parsed = JSON.parse(run(["grep-many", "hashpilot", "package.json"]).stdout);
+    expect(Array.isArray(parsed)).toBe(false);
+    expect(parsed).toHaveProperty("pattern");
+    expect(Array.isArray(parsed.results)).toBe(true);
+  });
+
+  test("doctor returns an object with a checks array", () => {
+    const parsed = JSON.parse(run(["doctor"]).stdout);
+    expect(Array.isArray(parsed.checks)).toBe(true);
+  });
+});
+
+describe("documented exit codes", () => {
+  test("success is 0", () => {
+    expect(run(["read-many", "package.json"]).code).toBe(0);
+  });
+
+  test("a usage error is 1", () => {
+    expect(run(["telemetry", "show", "--limit", "abc"]).code).toBe(1);
+    expect(run(["telemetry", "health", "--window", "abc"]).code).toBe(1);
+  });
+
+  test("a stale anchor is 3 (retryable), not 0", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hashpilot-contract-"));
+    try {
+      const file = join(dir, "sample.ts");
+      writeFileSync(file, "export const a = 1;\n");
+      // A hash that matches nothing in the file: the anchor is stale, which is
+      // the one failure an agent is expected to retry after a fresh read.
+      const res = run(["replace-hash", file, "0".repeat(64), "export const a = 2;"], dir);
+      expect(res.code).toBe(3);
+      // And refusing must not have touched the file.
+      expect(readFileSync(file, "utf8")).toBe("export const a = 1;\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an unknown command is 1", () => {
+    expect(run(["definitely-not-a-command"]).code).toBe(1);
+  });
+
+  test("no documented command exits 70 on ordinary bad input", () => {
+    // Exit 70 means "HashPilot bug, file a report". Reaching it from a plain
+    // missing path is the regression this guards.
+    for (const args of [
+      ["read-many", "/nonexistent/definitely/missing.ts"],
+      ["ast", "find-symbols", "/nonexistent/definitely/missing.ts"],
+      ["read-hash", "/nonexistent/definitely/missing.ts", "1"],
+    ]) {
+      expect(run(args).code).not.toBe(70);
+    }
+  });
+});
+
+describe("docs/CLI-QUICKREF.md", () => {
+  test("is in sync with the CLI's own --help output", () => {
+    const current = readFileSync(QUICKREF, "utf8");
+    expect(spliceGenerated(current, render(walk()))).toBe(current);
+  }, 60_000);
+
+  test("documents every top-level command", () => {
+    const doc = readFileSync(QUICKREF, "utf8");
+    const help = run(["--help"]).stdout;
+    const commands = help
+      .slice(help.indexOf("Commands:"))
+      .split("\n")
+      .slice(1)
+      .map((l) => l.trim().split(/\s+/)[0])
+      .filter((c): c is string => Boolean(c) && c !== "help");
+    expect(commands.length).toBeGreaterThan(10);
+    for (const cmd of commands) {
+      expect(doc).toContain(`structured-edit ${cmd}`);
+    }
+  });
+
+  test("keeps its hand-written gotchas outside the generated block", () => {
+    const doc = readFileSync(QUICKREF, "utf8");
+    const prose = doc.slice(0, doc.indexOf("<!-- BEGIN GENERATED"));
+    for (const claim of ["## Gotchas", "bare top-level array", "telemetry show", "exit code"]) {
+      expect(prose.toLowerCase()).toContain(claim.toLowerCase());
+    }
+  });
+});

--- a/tests/roadmap-lint.test.ts
+++ b/tests/roadmap-lint.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { lintRoadmap, parseTables } from "../scripts/roadmap-lint";
+
+const ROOT = join(import.meta.dir, "..");
+
+/** A minimal roadmap with one scored table; tests mutate copies of this. */
+function roadmap(rows: string[], header = "| # | Item | Score | Pri | Evidence | Area |"): string {
+  return [
+    "# Roadmap",
+    "",
+    "## Sprint 2 — Foundations",
+    "",
+    header,
+    "|---|------|-------|-----|----------|------|",
+    ...rows,
+    "",
+    "Some prose after the table.",
+  ].join("\n");
+}
+
+const row = (issue: number, score: number, pri = "P1") =>
+  `| [#${issue}](../../issues/${issue}) | B${issue} — a thing | ${score} | ${pri} | verified | correctness |`;
+
+describe("lintRoadmap", () => {
+  test("accepts a well-formed descending table", () => {
+    expect(lintRoadmap(roadmap([row(1, 60), row(2, 55), row(3, 55), row(4, 40)]))).toEqual([]);
+  });
+
+  // Regression: shipped twice during the 2026-08 audit work.
+  test("flags a row duplicated into a second table", () => {
+    const text = [
+      "# Roadmap",
+      "",
+      "## Sprint 1",
+      "",
+      "| # | Item | Score | Pri | Evidence | Area |",
+      "|---|------|-------|-----|----------|------|",
+      row(55, 60),
+      "",
+      "## Sprint 2",
+      "",
+      "| # | Item | Score | Pri | Evidence | Area |",
+      "|---|------|-------|-----|----------|------|",
+      row(55, 60),
+    ].join("\n");
+    const found = lintRoadmap(text);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.rule).toBe("duplicate-issue");
+    expect(found[0]!.message).toContain("#55");
+  });
+
+  test("flags a duplicate within a single table", () => {
+    const found = lintRoadmap(roadmap([row(7, 50), row(7, 50)]));
+    expect(found.map((f) => f.rule)).toEqual(["duplicate-issue"]);
+  });
+
+  // Regression: the ROADMAP.md backlog table shipped with #57 (38) below #47 (36).
+  test("flags a row inserted out of score order", () => {
+    const found = lintRoadmap(roadmap([row(1, 60), row(2, 36), row(3, 38)]));
+    expect(found).toHaveLength(1);
+    expect(found[0]!.rule).toBe("score-order");
+    expect(found[0]!.message).toContain("#3 (38)");
+  });
+
+  test("scores order independently per table", () => {
+    const text = [
+      "# Roadmap",
+      "",
+      "## Sprint 1",
+      "",
+      "| # | Item | Score | Pri | Evidence | Area |",
+      "|---|------|-------|-----|----------|------|",
+      row(1, 40),
+      "",
+      "## Sprint 2",
+      "",
+      "| # | Item | Score | Pri | Evidence | Area |",
+      "|---|------|-------|-----|----------|------|",
+      // 90 > 40, but it opens a new table so it is not a regression.
+      row(2, 90),
+    ].join("\n");
+    expect(lintRoadmap(text)).toEqual([]);
+  });
+
+  test("flags a link whose text and target disagree", () => {
+    const text = roadmap([
+      "| [#12](../../issues/21) | B12 — a thing | 50 | P1 | verified | correctness |",
+    ]);
+    const found = lintRoadmap(text);
+    expect(found.map((f) => f.rule)).toEqual(["issue-link"]);
+    expect(found[0]!.message).toContain("points at issue 21");
+  });
+
+  test("flags a non-integer score and an unknown priority", () => {
+    const text = roadmap([
+      "| [#12](../../issues/12) | B12 — a thing | high | P9 | verified | correctness |",
+    ]);
+    expect(lintRoadmap(text).map((f) => f.rule).sort()).toEqual(["priority", "score"]);
+  });
+
+  test("flags a row with the wrong number of columns", () => {
+    const text = roadmap(["| [#12](../../issues/12) | B12 — a thing | 50 | P1 |"]);
+    expect(lintRoadmap(text).map((f) => f.rule)).toContain("column-count");
+  });
+
+  test("ignores tables that carry no Score column", () => {
+    const text = [
+      "# Roadmap",
+      "",
+      "## Existing work",
+      "",
+      "| Doc | Status | Relationship |",
+      "|-----|--------|--------------|",
+      "| [`M5_PLAN.md`](M5_PLAN.md) | Partially shipped | see [#36](../../issues/36) |",
+    ].join("\n");
+    expect(lintRoadmap(text)).toEqual([]);
+  });
+
+  test("tolerates the Sprint 1 table's extra Status column", () => {
+    const header = "| # | Item | Score | Pri | Evidence | Area | Status |";
+    const rows = [
+      "| [#3](../../issues/3) | B1 — a thing | 64 | P0 | verified | correctness | ✅ done |",
+      "| [#4](../../issues/4) | B2 — a thing | 61 | P0 | verified | cli | ⏭ deferred |",
+    ];
+    expect(lintRoadmap(roadmap(rows, header))).toEqual([]);
+  });
+
+  test("parses every scored row in the real ROADMAP.md", () => {
+    const { rows, issues } = parseTables(readFileSync(join(ROOT, "ROADMAP.md"), "utf8"));
+    expect(issues).toEqual([]);
+    expect(rows.length).toBeGreaterThan(40);
+    expect(new Set(rows.map((r) => r.table)).size).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe("ROADMAP.md", () => {
+  test("is clean", () => {
+    expect(lintRoadmap(readFileSync(join(ROOT, "ROADMAP.md"), "utf8"))).toEqual([]);
+  });
+});

--- a/tests/roadmap-lint.test.ts
+++ b/tests/roadmap-lint.test.ts
@@ -135,6 +135,40 @@ describe("lintRoadmap", () => {
   });
 });
 
+describe("rules cannot be silently disabled", () => {
+  // Every per-row rule is keyed off a header name, so renaming a header used to
+  // turn its rule into a no-op while the file still linted clean.
+  test("a scored table with no priority column is an error, not a skipped check", () => {
+    const doc = roadmap(
+      ["| [#3](../../issues/3) | B1 — a thing | 64 | nonsense | verified | correctness |"],
+      "| # | Item | Score | Whatever | Evidence | Area |",
+    );
+    const found = lintRoadmap(doc);
+    expect(found.map((i) => i.rule)).toContain("missing-column");
+  });
+
+  test("`Priority` is accepted as a spelling of `Pri` and still validates values", () => {
+    const header = "| # | Item | Score | Priority | Evidence | Area |";
+    expect(
+      lintRoadmap(
+        roadmap(["| [#3](../../issues/3) | B1 — a thing | 64 | P0 | verified | cli |"], header),
+      ),
+    ).toEqual([]);
+    expect(
+      lintRoadmap(
+        roadmap(["| [#3](../../issues/3) | B1 — a thing | 64 | P9 | verified | cli |"], header),
+      ).map((i) => i.rule),
+    ).toContain("priority");
+  });
+
+  test("renaming every real ROADMAP.md priority header does not lint clean", () => {
+    const real = readFileSync(join(ROOT, "ROADMAP.md"), "utf8");
+    const mutated = real.replaceAll("| Pri |", "| Nope |");
+    expect(mutated).not.toBe(real);
+    expect(lintRoadmap(mutated).length).toBeGreaterThan(0);
+  });
+});
+
 describe("ROADMAP.md", () => {
   test("is clean", () => {
     expect(lintRoadmap(readFileSync(join(ROOT, "ROADMAP.md"), "utf8"))).toEqual([]);


### PR DESCRIPTION
Two agent-ergonomics gaps, each measured rather than asserted.

## 1 — `docs/CLI-QUICKREF.md`: kill the guess-and-retry loop

One page an agent reads before invoking the CLI: every command, flag, output shape, and exit code.

The command reference is **generated** by `scripts/gen-cli-quickref.ts`, which walks the CLI's own `--help` recursively (31 commands; groups `ast`, `diff`, `telemetry`, `provenance`). `src/cli.ts` calls `program.parse()` at module load and cannot be imported, so shelling out to `--help` is both the only option and the better one — the doc describes what the shipped binary actually accepts.

The hand-written **Gotchas** section is the part a generator can't produce, so every claim in it is an assertion in `tests/cli-contract.test.ts`:

| Documented claim | Test |
|---|---|
| `grep-many '<pattern>' <path>...` is positional; `--pattern`/`--paths` do not exist | passes 0, guessed flags exit 1 |
| `symbol-lookup-many` takes paths positionally but names via `--names` | exit 0 |
| `read-many` returns a bare array; `grep-many` returns `{pattern, results}`; `doctor` returns `{checks}` | shape assertions |
| The subcommand is `telemetry show`, not `recent` | `show` → 0, `recent` → 1 |
| A stale anchor is exit **3** (retryable), and the file is untouched | asserted on both counts |
| No documented command exits 70 on ordinary bad input | loop over three commands |

Drift is a **test failure**, not a review finding: `--check` mode compares the generated block against the committed file, and runs in CI (`Docs Verify`) and in `bun test`.

## 2 — `scripts/roadmap-lint.ts` + `/backlog` skill: kill a shipped bug class

Backlog items live in a GitHub issue *and* a `ROADMAP.md` row. Editing one and not the other has already produced a duplicated row and an out-of-order table — twice, in this repo, during the audit work.

Rules: `issue-link` (link text agrees with target), `column-count`, `score`, `priority`, `duplicate-issue` (file-wide), `score-order` (descending, per table). Tables without a `Score` column are skipped, and the Sprint 1 table's extra `Status` column is tolerated.

Both real bugs are **named regression tests**. The lint found the `#57` (38) / `#47` (36) inversion on its first run; that row is corrected here.

`.claude/skills/backlog/SKILL.md` carries what a linter cannot check — the score formula, what `verified` vs. `reported` means, the label/milestone set, a self-contained issue-body template for memoryless agents, and move-don't-copy — and defers every mechanical check to `bun run lint:roadmap`.

## Bug fixed along the way

The contract tests surfaced a genuine product bug: `telemetry show`, `summary`, `health`, and `sessions` let `finish()` infer their exit code from the payload, so a logged `success: false` event made a *successful query* exit 2. They now pass `ExitCode.OK` explicitly.

## Verification

- `bun test` → **451 pass / 0 fail** (baseline 424, +27 new: 15 contract, 12 roadmap-lint)
- `bun run build` → clean
- `bun run lint:docs` → exit 0

## Notes

- `.gitignore` narrows `.claude/` to `.claude/*` + `!.claude/skills/` so shared project skills ship while local state stays untracked.
- The `docs-verify` CI job gains a Bun setup and `bun run lint:docs`; timeout 3 → 5 min.
- No JSON output shape changed, so `docs/ADAPTER-CONTRACT.md` is untouched. The exit-code change makes the four telemetry reads match their documented contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)