### PR TITLE
fix: atomic writes, pre-edit snapshots, and undo (#12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Use Bun 1.2 or newer. There is no separate formatter or linter configured; keep 
 
 ## Gotchas
 
-- **tree-sitter is a native module.** Run `bun install` before anything else. Without `node_modules/`, the AST test files abort with `error: Cannot find package 'tree-sitter'` while the rest of the suite passes, so the failure looks unrelated to your change. The green baseline is 515 pass / 0 fail.
+- **tree-sitter is a native module.** Run `bun install` before anything else. Without `node_modules/`, the AST test files abort with `error: Cannot find package 'tree-sitter'` while the rest of the suite passes, so the failure looks unrelated to your change. The green baseline is 537 pass / 0 fail.
 - **AST load failures are silent.** `getParser()` (`src/core/ast-edit.ts:31-60`) catches parser-init errors and returns `null`; the router then falls back to hash/diff with no warning. If AST edits mysteriously route to diff, check that the tree-sitter bindings actually built.
 - **Route precedence** (`chooseRoute`, `src/core/router.ts:36`) is policy override → AST (language supported *and* AST operation) → hash operation → diff fallback. First match wins.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,8 @@ All core modules live in `src/core/` (paths below are relative to it).
 | `plan-executor.ts` | **M5** — Executes `EditPlan` steps through the router with dry-run, verify, and revert-on-failure support. `executeIntent()` is the top-level entry point: parse → resolve → plan → execute. |
 | `provenance.ts` | **M6** — Edit history tracking with changeSet IDs. `provenanceQuery(file, line?)` shows who changed what and why (like `git blame` for agent edits). |
 | `config.ts` | Configuration loading with merge priority: env var > CLI arg > project `.hashpilot.json` > global `~/.config/hashpilot/config.json` > defaults. |
-| `paths.ts` | Write boundary. `assertWritable`/`safeWrite` confine every write to the project root (widened by `allowedRoots`), with a hard deny-list (`~/.ssh`, `~/.aws`, `/etc`, shell rc files, the telemetry log) that no flag overrides. Symlinks are resolved on both sides before comparison. |
+| `paths.ts` | Write boundary. `assertWritable`/`safeWrite` confine every write to the project root (widened by `allowedRoots`), with a hard deny-list (`~/.ssh`, `~/.aws`, `/etc`, shell rc files, the telemetry log) that no flag overrides. Symlinks are resolved on both sides before comparison. Writes are atomic: temp file → fsync → rename, with the target's mode preserved. |
+| `snapshot.ts` | **#12** — pre-edit snapshot store (`~/.agentic-tools/snapshots/`, content-addressed, keyed by changeSet) plus `undoChangeSet`, `listChangeSets`, and retention pruning. Backs the `changesets` and `undo` commands. |
 | `exit-codes.ts` | Maps `ErrorCode` to process exit codes (0 ok · 1 usage · 2 edit failed · 3 stale/retryable · 4 verify failed · 5 I/O · 70 internal). `finish()` prints JSON and sets the code. |
 | `redact.ts` | Credential scrubbing for anything written to the telemetry log: `redactSecrets`, `isSensitiveFile`, `redactEvent`. |
 | `batch-edit.ts` | Batch editing — applies the same edit to multiple files in parallel (`editMany`) or serially (`editManySerial`). |
@@ -94,7 +95,7 @@ Route policies can override routing per language or per operation, with configur
 
 ### Gotchas
 
-- **tree-sitter is a native module.** Run `bun install` before anything else — without `node_modules/`, the AST test files abort with `error: Cannot find package 'tree-sitter'` while the rest of the suite passes, so the failure looks unrelated. Green baseline is 515 pass / 0 fail.
+- **tree-sitter is a native module.** Run `bun install` before anything else — without `node_modules/`, the AST test files abort with `error: Cannot find package 'tree-sitter'` while the rest of the suite passes, so the failure looks unrelated. Green baseline is 537 pass / 0 fail.
 - **AST load failures are silent.** `getParser()` (`src/core/ast-edit.ts:31-60`) catches parser-init errors and returns `null`. The router then falls back to hash/diff with no warning. If AST edits mysteriously route to diff, check that the tree-sitter bindings actually built.
 
 ### Adapter integrations

--- a/README.md
+++ b/README.md
@@ -189,6 +189,24 @@ The router auto-selects. A single `route-edit` command tries AST first, falls ba
 |---------|-------------|
 | `replace-hash <file> <hash> <content>` | Replace content identified by SHA-256 hash (auto-recovers on stale anchor) |
 
+### Undo
+
+| Command | What It Does |
+|---------|-------------|
+| `changesets [--limit N]` | List undoable changeSets, newest first |
+| `undo <changeSetId>` | Restore every file in a changeSet to its pre-edit contents |
+| `undo --last` | Undo the most recent changeSet |
+
+Every write goes to a sibling temp file, is `fsync`ed, and is renamed over the
+target, so an interrupted write can never leave a truncated source file — a reader
+sees either the whole old file or the whole new one, and the target's permissions
+are preserved. Before the write, the file's original bytes are stored in a
+content-addressed snapshot store under `~/.agentic-tools/snapshots/`, keyed by the
+changeSet the invocation belongs to. `undo` refuses any file that changed after the
+edit was applied unless `--force` is passed, and `--dry-run` reports without writing.
+Retention defaults to 200 changeSets / 7 days, configurable under `snapshots` in
+`.hashpilot.json`.
+
 ### Edit — AST Route
 
 | Command | What It Does |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,7 @@ Correctness of the edit engine itself, plus the output contract everything downs
 | [#60](../../issues/60) | B53 — `read-hash` emits an 8-char `lineHash` that `replace-hash` rejects as stale ✅ shipped | 61 | P1 | verified | correctness |
 | [#55](../../issues/55) | B50 — AST tier is non-functional on any file larger than 32KB ✅ shipped | 60 | P1 | verified | correctness |
 | [#13](../../issues/13) | B8 — No `hasError` parse-validity gate; AST edits write garbage ✅ shipped | 59 | P1 | verified | correctness |
-| [#12](../../issues/12) | B4 — No atomic writes, no backups, no undo | 56 | P0 | reported | correctness · data-loss |
+| [#12](../../issues/12) | B4 — No atomic writes, no backups, no undo ✅ shipped | 56 | P0 | verified | correctness · data-loss |
 | [#16](../../issues/16) | B12 — Plans inject C-style `/* TODO */` comments into Python/Go/Rust | 52 | P1 | reported | correctness |
 | [#18](../../issues/18) | B15 — Uniform JSON envelope with `error.code` and `error.recovery` ✅ shipped | 52 | P1 | verified | cli |
 | [#23](../../issues/23) | B31 — `--no-default-config` inverted; `--config` never reaches routing | 51 | P2 | verified | correctness |

--- a/docs/ADAPTER-CONTRACT.md
+++ b/docs/ADAPTER-CONTRACT.md
@@ -59,6 +59,23 @@ Languages with no tree-sitter grammar (and `.d.ts`) are never gated.
 There is no file-size limit on AST edits. Through v3.0.0 sources over 32KB threw
 inside the tree-sitter binding and fell back to the diff route.
 
+## Atomic writes and undo
+
+Every write is temp-file + `fsync` + `rename`, so a crash mid-edit leaves the original
+file byte-identical rather than truncated. Before each write the original bytes are
+snapshotted under `~/.agentic-tools/snapshots/`, keyed by a changeSet ID minted once
+per CLI invocation.
+
+| Command | Success shape | Failure |
+|---------|---------------|---------|
+| `changesets [--limit N]` | `data.changeSets: [{changeSetId, timestamp, files[]}]`, newest first | — |
+| `undo <id>` / `undo --last` | `data: {success, changeSetId, files[], message}` | `HASH_MISMATCH`, exit 3, when a file changed after the edit |
+
+`undo` never partially clobbers: a file that fails its check is left exactly as found
+and reported in `data.files[]` with a `reason`. `--force` overrides the check;
+`--dry-run` reports without touching disk. An undo is not itself snapshotted, so
+`undo --last` cannot ping-pong between two states.
+
 ## Command Reference
 
 ### Configuration

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,7 +151,23 @@ HashPilot has two complementary docs that must always be kept in sync with the c
   `/etc`, shell startup files, and HashPilot's own telemetry log. Deny targets are
   themselves realpath-resolved (on macOS `/etc` is a symlink to `/private/etc`).
 - Widened by `allowedRoots` in config or `--allowed-root`; disabled by `--allow-outside-root`.
-- `safeWrite` is the single write path used by every edit route.
+- `safeWrite` is the single write path used by every edit route. It snapshots the
+  file's pre-edit bytes, then writes atomically: sibling temp file → `fsync` →
+  `rename` over the target → `fsync` of the directory, with the target's mode
+  preserved. A crash mid-write leaves the original byte-identical, and orphaned
+  `.hashpilot-tmp-*` files older than an hour are swept after each write.
+
+#### `src/snapshot.ts` — Pre-Edit Snapshots and Undo (#12)
+- Content-addressed store at `~/.agentic-tools/snapshots/` (`objects/<sha256>` +
+  `index.jsonl`), outside the project tree so it never appears in `git status`.
+- Keyed by changeSet ID — the CLI mints one per invocation via `createChangeSet()`,
+  so every write in one command undoes as a unit.
+- `undoChangeSet(id, {force, dryRun})` restores the pre-*first*-edit bytes per file,
+  removes files the changeSet created, and refuses any file whose current hash no
+  longer matches what the edit wrote (`HASH_MISMATCH`, exit 3) unless `--force`.
+- An undo is not itself snapshotted, so `undo --last` cannot ping-pong.
+- Retention: 200 changeSets / 7 days by default, pruned on every invocation;
+  configurable under `snapshots` in `.hashpilot.json`.
 
 #### `src/exit-codes.ts` — Agent-Facing Exit Contract
 - Maps `ErrorCode` → process exit code: `0` ok, `1` usage, `2` edit failed,
@@ -474,4 +490,4 @@ The CI check `docs-verify` enforces rule 5 — if `src/` files change but neithe
 
 ---
 
-_Last updated: 2026-08-11 — Sprint 1 (safety hardening: write boundary, exit codes, telemetry opt-out, anchor relocation) · agent ergonomics ([CLI quickref](CLI-QUICKREF.md) generated from `--help`, roadmap consistency lint). Telemetry queries are reads: they exit 0 on success regardless of the `success` field of the events they return, and `readEvents(0)` returns nothing rather than the whole log. A log that exists but cannot be read now raises `READ_FAILED` (exit 5) instead of reporting a broken store as an empty one, and malformed JSONL lines are counted and warned about on stderr rather than silently dropped ([#59](../../issues/59)). `read-hash` now emits a 12-character `lineHash` — the same width `replace-hash` compares against — so the read → write round-trip no longer fails with a retryable `STALE_ANCHOR` ([#60](../../issues/60)). **Breaking (apiVersion 1):** every command now writes one envelope — `{ apiVersion, ok, command, data, error, warnings }` — validated against [`schema/hashpilot-envelope.schema.json`](../schema/hashpilot-envelope.schema.json) by a sweep over every leaf command; `ok` is derived from the exit code so the two cannot disagree, and route fallbacks, relocated anchors, and corrupt telemetry lines ride `warnings` instead of being invisible ([#18](../../issues/18), [#56](../../issues/56)). The AST tier no longer has a 32KB ceiling — sources are streamed to tree-sitter in chunks rather than marshalled through the binding's fixed string buffer, which used to throw `Invalid argument` and silently demote every large file to the diff route ([#55](../../issues/55)) — and all three tiers now run a parse-validity gate: a file that does not parse is refused before any offsets are computed, and every edit is reparsed before the write so a corrupting edit is discarded rather than saved ([#13](../../issues/13))._
+_Last updated: 2026-08-11 — Sprint 1 (safety hardening: write boundary, exit codes, telemetry opt-out, anchor relocation) · agent ergonomics ([CLI quickref](CLI-QUICKREF.md) generated from `--help`, roadmap consistency lint). Telemetry queries are reads: they exit 0 on success regardless of the `success` field of the events they return, and `readEvents(0)` returns nothing rather than the whole log. A log that exists but cannot be read now raises `READ_FAILED` (exit 5) instead of reporting a broken store as an empty one, and malformed JSONL lines are counted and warned about on stderr rather than silently dropped ([#59](../../issues/59)). `read-hash` now emits a 12-character `lineHash` — the same width `replace-hash` compares against — so the read → write round-trip no longer fails with a retryable `STALE_ANCHOR` ([#60](../../issues/60)). **Breaking (apiVersion 1):** every command now writes one envelope — `{ apiVersion, ok, command, data, error, warnings }` — validated against [`schema/hashpilot-envelope.schema.json`](../schema/hashpilot-envelope.schema.json) by a sweep over every leaf command; `ok` is derived from the exit code so the two cannot disagree, and route fallbacks, relocated anchors, and corrupt telemetry lines ride `warnings` instead of being invisible ([#18](../../issues/18), [#56](../../issues/56)). The AST tier no longer has a 32KB ceiling — sources are streamed to tree-sitter in chunks rather than marshalled through the binding's fixed string buffer, which used to throw `Invalid argument` and silently demote every large file to the diff route ([#55](../../issues/55)) — and all three tiers now run a parse-validity gate: a file that does not parse is refused before any offsets are computed, and every edit is reparsed before the write so a corrupting edit is discarded rather than saved ([#13](../../issues/13)). Every write is now atomic (temp file → fsync → rename, mode preserved) and pre-edit bytes are snapshotted to a content-addressed store, so `changesets` lists undoable units and `undo <id>` / `undo --last` restores them — refusing files changed since the edit unless `--force` ([#12](../../issues/12))._

--- a/docs/CLI-QUICKREF.md
+++ b/docs/CLI-QUICKREF.md
@@ -112,7 +112,7 @@ looks unrelated to AST. Green baseline is `bun test` fully passing (515 pass / 0
 
 <!-- BEGIN GENERATED: command reference -->
 
-_31 commands, generated from `--help`. Do not edit by hand — run `bun run gen:cli-quickref`._
+_33 commands, generated from `--help`. Do not edit by hand — run `bun run gen:cli-quickref`._
 
 ### Global options
 
@@ -657,6 +657,36 @@ structured-edit provenance changeset [options] <changeSetId>
 | Flag | Meaning |
 |------|---------|
 | `--human` | Human-readable output |
+
+#### `changesets`
+
+List undoable changeSets, newest first
+
+```
+structured-edit changesets [options]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--limit <n>` | Max changeSets to list (default 20) |
+
+#### `undo`
+
+Restore every file in a changeSet to its pre-edit contents
+
+```
+structured-edit undo [options] [changeSetId]
+```
+
+| Positional | Meaning |
+|------------|---------|
+| `changeSetId` | ChangeSet to undo; omit with --last |
+
+| Flag | Meaning |
+|------|---------|
+| `--last` | Undo the most recent changeSet |
+| `--force` | Restore even files modified since the edit was applied |
+| `--dry-run` | Report what would be restored without touching the disk |
 
 #### `doctor`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,12 @@ import {
   exportEvents,
   pruneEvents,
   createChangeSet,
+  configureSnapshots,
+  setCurrentChangeSet,
+  listChangeSets,
+  lastChangeSetId,
+  undoChangeSet,
+  pruneSnapshots,
   buildProvenanceFields,
   provenanceQuery,
   changeSetQuery,
@@ -121,6 +127,12 @@ program
     configureTelemetry(config.telemetry);
     enableTelemetry(resolveTelemetryEnabled(config.telemetry, globals.telemetry === false));
     setAllowParseErrors(Boolean(globals.allowParseErrors));
+
+    // Every write this invocation makes belongs to one changeSet, so `undo`
+    // has a unit to work in even for commands that never mint one themselves.
+    configureSnapshots(config.snapshots);
+    setCurrentChangeSet(config.snapshots?.enabled === false ? null : createChangeSet());
+    pruneSnapshots();
   });
 
 program
@@ -908,6 +920,40 @@ provCmd
     } else {
       finish(result);
     }
+  });
+
+program
+  .command("changesets")
+  .description("List undoable changeSets, newest first")
+  .option("--limit <n>", "Max changeSets to list (default 20)")
+  .action((opts) => {
+    const limit = parseIntFlag(opts.limit, "--limit", 20);
+    if (typeof limit === "object") return usageError(limit.error);
+    finish({ changeSets: listChangeSets(limit) }, ExitCode.OK);
+  });
+
+program
+  .command("undo")
+  .description("Restore every file in a changeSet to its pre-edit contents")
+  .argument("[changeSetId]", "ChangeSet to undo; omit with --last")
+  .option("--last", "Undo the most recent changeSet")
+  .option("--force", "Restore even files modified since the edit was applied")
+  .option("--dry-run", "Report what would be restored without touching the disk")
+  .action((changeSetId, opts) => {
+    const id = opts.last ? lastChangeSetId() : changeSetId;
+    if (!id) {
+      return usageError(
+        opts.last
+          ? "No changeSets have been recorded yet."
+          : "Provide a changeSet ID, or pass --last.",
+        { recovery: "structured-edit changesets" },
+      );
+    }
+    // The undo's own write must not be snapshotted as a new changeSet — that
+    // would make `undo --last` toggle between two states forever.
+    setCurrentChangeSet(null);
+    const result = undoChangeSet(id, { force: Boolean(opts.force), dryRun: Boolean(opts.dryRun) });
+    finish(result, result.success ? ExitCode.OK : ExitCode.PRECONDITION);
   });
 
 program

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -31,10 +31,20 @@ export interface ProvenanceConfig {
   captureDiffs?: boolean;
 }
 
+export interface SnapshotConfig {
+  /** Take a pre-edit snapshot of every written file so `undo` can restore it. Default true. */
+  enabled?: boolean;
+  /** Keep at most this many changeSets, default 200. */
+  maxChangeSets?: number;
+  /** Drop changeSets older than this many days, default 7. */
+  maxAgeDays?: number;
+}
+
 export interface HashPilotConfig {
   routePolicy?: RoutePolicy;
   telemetry?: TelemetryConfig;
   provenance?: ProvenanceConfig;
+  snapshots?: SnapshotConfig;
   /** Extra directories writes may target, beyond the project root. Relative entries resolve against cwd. */
   allowedRoots?: string[];
 }
@@ -126,6 +136,9 @@ function mergeConfig(base: HashPilotConfig, override: Partial<HashPilotConfig>):
   }
   if (override.provenance) {
     base.provenance = { ...base.provenance, ...override.provenance };
+  }
+  if (override.snapshots) {
+    base.snapshots = { ...base.snapshots, ...override.snapshots };
   }
   if (override.allowedRoots) {
     base.allowedRoots = [...(base.allowedRoots || []), ...override.allowedRoots];

--- a/src/core/hash-edit.ts
+++ b/src/core/hash-edit.ts
@@ -1,7 +1,8 @@
 import { computeHash } from "./read";
 import { ErrorCode } from "./telemetry";
 import { addWarning } from "./envelope";
-import { assertWritable, PathDeniedError, type AssertWritableOptions } from "./paths";
+import { assertWritable, atomicWrite, PathDeniedError, type AssertWritableOptions } from "./paths";
+import { recordSnapshot } from "./snapshot";
 import { firstParseError } from "./ast-edit";
 
 /**
@@ -299,7 +300,11 @@ async function applyReplacement(
   }
 
   if (!dryRun) {
-    await Bun.write(writePath ?? filePath, newFullContent);
+    // `writePath` is already boundary-resolved by the caller. Atomic, and
+    // snapshotted, for the same reasons every other write is (#12).
+    const target = writePath ?? filePath;
+    recordSnapshot(target, newFullContent);
+    atomicWrite(target, newFullContent);
   }
 
   const action = dryRun ? "Dry run: would replace" : "Replaced";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -70,7 +70,22 @@ export type {
 export { executeIntent, executePlan } from "./plan-executor";
 export type { StepResult, PlanResult, IntentResult } from "./plan-executor";
 export { loadConfig, policyForce } from "./config";
-export type { HashPilotConfig, RoutePolicy, TelemetryConfig, ProvenanceConfig } from "./config";
+export type { HashPilotConfig, RoutePolicy, TelemetryConfig, ProvenanceConfig, SnapshotConfig } from "./config";
+export {
+  recordSnapshot,
+  listChangeSets,
+  lastChangeSetId,
+  undoChangeSet,
+  pruneSnapshots,
+  cleanOrphanTempFiles,
+  configureSnapshots,
+  resetSnapshots,
+  setCurrentChangeSet,
+  getCurrentChangeSet,
+  snapshotRoot,
+  DEFAULT_RETENTION,
+} from "./snapshot";
+export type { SnapshotRecord, ChangeSetSummary, UndoResult, UndoFileResult, SnapshotRetention } from "./snapshot";
 export { createChangeSet, buildProvenanceFields, provenanceQuery, changeSetQuery, formatProvenanceHuman } from "./provenance";
 export type { ProvenanceInput, ProvenanceEntry, ChangeSetResult } from "./provenance";
 export { doctor } from "./doctor";
@@ -80,6 +95,8 @@ export {
   assertWritable,
   assertAllWritable,
   safeWrite,
+  atomicWrite,
+  simulateCrashAfterTempWrite,
   findProjectRoot,
   configureWriteBoundary,
   resetWriteBoundary,

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,7 +1,11 @@
-import { existsSync, realpathSync } from "node:fs";
+import {
+  existsSync, realpathSync, writeFileSync, renameSync, unlinkSync,
+  statSync, openSync, fsyncSync, closeSync,
+} from "node:fs";
 import { homedir, platform } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { ErrorCode } from "./telemetry";
+import { recordSnapshot, cleanOrphanTempFiles } from "./snapshot";
 
 /**
  * Filesystem write boundary.
@@ -219,8 +223,70 @@ export async function safeWrite(
   options: AssertWritableOptions = {},
 ): Promise<string> {
   const resolved = assertWritable(target, options);
-  await Bun.write(resolved, content);
+  recordSnapshot(resolved, content);
+  atomicWrite(resolved, content);
   return resolved;
+}
+
+/** Injectable failure point, so a test can simulate a crash mid-write. */
+let crashAfterTempWrite = false;
+
+/** Make the next atomic write throw between the temp write and the rename. For tests. */
+export function simulateCrashAfterTempWrite(value: boolean): void {
+  crashAfterTempWrite = value;
+}
+
+/**
+ * Replace `target`'s contents without ever exposing a partial file.
+ *
+ * A bare truncating write that is interrupted — SIGINT, a crash, a full disk —
+ * leaves the source file permanently truncated and the original content gone
+ * (#12). Writing to a sibling temp file and renaming over the target avoids
+ * that: `rename(2)` within a filesystem is atomic, so a concurrent reader sees
+ * either the whole old file or the whole new one.
+ *
+ * The temp file must live in the target's own directory. In `/tmp` the rename
+ * would usually cross a device boundary and degrade into a copy, which is
+ * exactly the non-atomic write this replaces.
+ */
+export function atomicWrite(resolved: string, content: string): void {
+  const dir = dirname(resolved);
+  const tmp = join(dir, `.hashpilot-tmp-${process.pid}-${Math.random().toString(36).slice(2)}`);
+
+  // Carry the target's permissions onto the replacement, or every edit
+  // silently resets the file to the default mode.
+  let mode = 0o644;
+  try {
+    if (existsSync(resolved)) mode = statSync(resolved).mode & 0o777;
+  } catch { /* unreadable target: fall back to the default mode */ }
+
+  let fd: number | undefined;
+  try {
+    writeFileSync(tmp, content, { mode });
+    // fsync the data before the rename; otherwise a power loss can land the
+    // rename in the journal while the file's blocks are still unwritten.
+    fd = openSync(tmp, "r+");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+
+    if (crashAfterTempWrite) throw new Error("simulated crash after temp write");
+
+    renameSync(tmp, resolved);
+  } catch (err) {
+    if (fd !== undefined) { try { closeSync(fd); } catch { /* already closed */ } }
+    try { unlinkSync(tmp); } catch { /* nothing to clean up */ }
+    throw err;
+  }
+
+  // fsync the directory so the rename itself is durable.
+  try {
+    const dirFd = openSync(dir, "r");
+    fsyncSync(dirFd);
+    closeSync(dirFd);
+  } catch { /* not supported on every platform; the rename still applied */ }
+
+  cleanOrphanTempFiles(dir);
 }
 
 export const PATH_SEPARATOR = sep;

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -1,0 +1,346 @@
+import {
+  existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync,
+  readdirSync, statSync, unlinkSync, renameSync,
+} from "node:fs";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+
+/**
+ * Pre-edit snapshots, so an edit can be undone.
+ *
+ * Every write that goes through `safeWrite` first stores the file's original
+ * bytes in a content-addressed object store keyed by changeSet ID. Without
+ * this an agent that made a wrong-but-successful edit had nothing to roll back
+ * to — and neither did the human watching (#12).
+ *
+ * The store lives beside the telemetry log rather than in the project tree:
+ * a snapshot directory inside the repo would show up in `git status` and in
+ * the agent's own file listings, and the tool must work in non-git trees.
+ */
+
+// Resolved per call rather than at import: `HOME` is what isolates a test run
+// (and a sandboxed agent) from the real store, and it is not set yet when this
+// module is first imported.
+function root(): string {
+  return join(process.env.HOME || "/root", ".agentic-tools", "snapshots");
+}
+function objectsDir(): string {
+  return join(root(), "objects");
+}
+function indexFile(): string {
+  return join(root(), "index.jsonl");
+}
+
+/** One file's pre-image within a changeSet. */
+export interface SnapshotRecord {
+  changeSetId: string;
+  /** ISO-8601, when the snapshot was taken. */
+  timestamp: string;
+  /** Absolute, symlink-resolved path — the same path that was written. */
+  file: string;
+  /** SHA-256 of the original bytes, or null when the file did not exist yet. */
+  beforeHash: string | null;
+  /** SHA-256 of the bytes we wrote, so `undo` can detect later external edits. */
+  afterHash: string;
+}
+
+export interface ChangeSetSummary {
+  changeSetId: string;
+  timestamp: string;
+  files: string[];
+}
+
+export interface SnapshotRetention {
+  /** Keep at most this many changeSets. */
+  maxChangeSets: number;
+  /** Drop changeSets older than this. */
+  maxAgeDays: number;
+}
+
+export const DEFAULT_RETENTION: SnapshotRetention = { maxChangeSets: 200, maxAgeDays: 7 };
+
+let retention: SnapshotRetention = { ...DEFAULT_RETENTION };
+let enabled = true;
+/** ChangeSet the current command's writes belong to. Set by the CLI bootstrap. */
+let currentChangeSet: string | null = null;
+
+export function configureSnapshots(options: Partial<SnapshotRetention> & { enabled?: boolean } = {}): void {
+  if (options.enabled !== undefined) enabled = options.enabled;
+  if (options.maxChangeSets !== undefined) retention.maxChangeSets = options.maxChangeSets;
+  if (options.maxAgeDays !== undefined) retention.maxAgeDays = options.maxAgeDays;
+}
+
+/** Reset to built-in defaults. For tests. */
+export function resetSnapshots(): void {
+  retention = { ...DEFAULT_RETENTION };
+  enabled = true;
+  currentChangeSet = null;
+}
+
+export function setCurrentChangeSet(id: string | null): void {
+  currentChangeSet = id;
+}
+
+export function getCurrentChangeSet(): string | null {
+  return currentChangeSet;
+}
+
+export function sha256(content: string | Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function ensureDirs(): void {
+  if (!existsSync(objectsDir())) mkdirSync(objectsDir(), { recursive: true, mode: 0o700 });
+}
+
+export function snapshotRoot(): string {
+  return root();
+}
+
+/**
+ * Record `file`'s current bytes before it is overwritten with `newContent`.
+ *
+ * A no-op when snapshots are off or no changeSet is active — a library caller
+ * that never opts in pays nothing. Failures here never propagate: losing a
+ * snapshot must not turn a good edit into a failed one.
+ */
+export function recordSnapshot(file: string, newContent: string): void {
+  if (!enabled || !currentChangeSet) return;
+  try {
+    ensureDirs();
+    let beforeHash: string | null = null;
+    if (existsSync(file)) {
+      const original = readFileSync(file);
+      beforeHash = sha256(original);
+      const objectPath = join(objectsDir(), beforeHash);
+      // Content-addressed: identical bytes are stored once, so re-editing the
+      // same file across many changeSets does not multiply storage.
+      if (!existsSync(objectPath)) writeFileSync(objectPath, original, { mode: 0o600 });
+    }
+    const record: SnapshotRecord = {
+      changeSetId: currentChangeSet,
+      timestamp: new Date().toISOString(),
+      file,
+      beforeHash,
+      afterHash: sha256(newContent),
+    };
+    appendFileSync(indexFile(), JSON.stringify(record) + "\n", { mode: 0o600 });
+  } catch {
+    // Snapshotting is best-effort by design; see the doc comment.
+  }
+}
+
+export function readIndex(): SnapshotRecord[] {
+  if (!existsSync(indexFile())) return [];
+  return readFileSync(indexFile(), "utf8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => {
+      try { return JSON.parse(l) as SnapshotRecord; } catch { return null; }
+    })
+    .filter((r): r is SnapshotRecord => r !== null);
+}
+
+/** Newest changeSet first. */
+export function listChangeSets(limit = 20): ChangeSetSummary[] {
+  const byId = new Map<string, ChangeSetSummary>();
+  // Append order breaks timestamp ties: two writes inside the same millisecond
+  // carry identical ISO timestamps, and "newest first" must still be the order
+  // they actually happened in.
+  const order = new Map<string, number>();
+  for (const r of readIndex()) {
+    if (!order.has(r.changeSetId)) order.set(r.changeSetId, order.size);
+    const existing = byId.get(r.changeSetId);
+    if (existing) {
+      if (!existing.files.includes(r.file)) existing.files.push(r.file);
+      // Keep the latest write in the set as the set's timestamp.
+      if (r.timestamp > existing.timestamp) existing.timestamp = r.timestamp;
+    } else {
+      byId.set(r.changeSetId, { changeSetId: r.changeSetId, timestamp: r.timestamp, files: [r.file] });
+    }
+  }
+  return [...byId.values()]
+    .sort((a, b) =>
+      b.timestamp.localeCompare(a.timestamp) ||
+      (order.get(b.changeSetId)! - order.get(a.changeSetId)!),
+    )
+    .slice(0, limit);
+}
+
+export function lastChangeSetId(): string | null {
+  return listChangeSets(1)[0]?.changeSetId ?? null;
+}
+
+export interface UndoFileResult {
+  file: string;
+  restored: boolean;
+  /** Why it was skipped, when `restored` is false. */
+  reason?: string;
+}
+
+export interface UndoResult {
+  success: boolean;
+  changeSetId: string;
+  files: UndoFileResult[];
+  message: string;
+  errorCode?: string;
+}
+
+/**
+ * Restore every file in a changeSet to its pre-edit bytes.
+ *
+ * Refuses any file whose current content no longer matches what the edit
+ * wrote: something else has touched it since, and clobbering that would be a
+ * second data loss on top of the one undo exists to fix. `force` overrides.
+ */
+export function undoChangeSet(changeSetId: string, options: { force?: boolean; dryRun?: boolean } = {}): UndoResult {
+  const records = readIndex().filter((r) => r.changeSetId === changeSetId);
+  if (records.length === 0) {
+    return {
+      success: false,
+      changeSetId,
+      files: [],
+      message: `No snapshots recorded for changeSet ${changeSetId}.`,
+      errorCode: "FILE_NOT_FOUND",
+    };
+  }
+
+  // Oldest snapshot per file wins: it holds the bytes from before the *first*
+  // write in the set, which is what "undo the whole changeSet" means.
+  const firstPerFile = new Map<string, SnapshotRecord>();
+  const lastPerFile = new Map<string, SnapshotRecord>();
+  for (const r of records) {
+    if (!firstPerFile.has(r.file)) firstPerFile.set(r.file, r);
+    lastPerFile.set(r.file, r);
+  }
+
+  const files: UndoFileResult[] = [];
+  for (const [file, first] of firstPerFile) {
+    const last = lastPerFile.get(file)!;
+    const exists = existsSync(file);
+    if (exists) {
+      const current = sha256(readFileSync(file));
+      if (current !== last.afterHash && !options.force) {
+        files.push({
+          file,
+          restored: false,
+          reason: "modified since the edit was applied; pass --force to restore anyway",
+        });
+        continue;
+      }
+    }
+
+    if (first.beforeHash === null) {
+      // The changeSet created this file, so undoing it means removing it.
+      if (!options.dryRun && exists) {
+        try { unlinkSync(file); } catch (e: unknown) {
+          files.push({ file, restored: false, reason: `could not remove: ${(e as Error).message}` });
+          continue;
+        }
+      }
+      files.push({ file, restored: true, reason: "created by this changeSet; removed" });
+      continue;
+    }
+
+    const objectPath = join(objectsDir(), first.beforeHash);
+    if (!existsSync(objectPath)) {
+      files.push({ file, restored: false, reason: "snapshot object was pruned; nothing to restore from" });
+      continue;
+    }
+    if (!options.dryRun) {
+      try {
+        atomicWriteSync(file, readFileSync(objectPath));
+      } catch (e: unknown) {
+        files.push({ file, restored: false, reason: `restore failed: ${(e as Error).message}` });
+        continue;
+      }
+    }
+    files.push({ file, restored: true });
+  }
+
+  const failed = files.filter((f) => !f.restored);
+  return {
+    success: failed.length === 0,
+    changeSetId,
+    files,
+    // HASH_MISMATCH, not a bespoke code: the refusal is exactly the anchor
+    // check the hash route already exits 3 for, and adapters branch on it.
+    errorCode: failed.length ? "HASH_MISMATCH" : undefined,
+    message: failed.length
+      ? `Restored ${files.length - failed.length}/${files.length} file(s); ${failed.length} refused.`
+      : `Restored ${files.length} file(s) from changeSet ${changeSetId}.`,
+  };
+}
+
+/**
+ * Synchronous atomic replace, used by `undo`. The async write path lives in
+ * `paths.ts`; both go temp-file → rename so a crash can never leave a
+ * half-written file on disk.
+ */
+function atomicWriteSync(target: string, content: Buffer): void {
+  const dir = join(target, "..");
+  const tmp = join(dir, `.hashpilot-tmp-${process.pid}-${Math.random().toString(36).slice(2)}`);
+  let mode = 0o644;
+  try { mode = statSync(target).mode & 0o777; } catch { /* new file: default mode */ }
+  writeFileSync(tmp, content, { mode });
+  try {
+    renameSync(tmp, target);
+  } catch (e) {
+    try { unlinkSync(tmp); } catch { /* nothing to clean */ }
+    throw e;
+  }
+}
+
+/**
+ * Drop changeSets past the retention limits, then any object no live record
+ * still references. Called after each snapshot batch, so the store cannot grow
+ * without bound in a long-running agent session.
+ */
+export function pruneSnapshots(now: number = Date.now()): { changeSetsRemoved: number; objectsRemoved: number } {
+  if (!existsSync(indexFile())) return { changeSetsRemoved: 0, objectsRemoved: 0 };
+  const records = readIndex();
+  const sets = listChangeSets(Number.MAX_SAFE_INTEGER);
+  const cutoff = now - retention.maxAgeDays * 24 * 60 * 60 * 1000;
+
+  const keep = new Set(
+    sets
+      .filter((s, i) => i < retention.maxChangeSets && Date.parse(s.timestamp) >= cutoff)
+      .map((s) => s.changeSetId),
+  );
+  const changeSetsRemoved = sets.length - keep.size;
+  if (changeSetsRemoved === 0) return { changeSetsRemoved: 0, objectsRemoved: 0 };
+
+  const kept = records.filter((r) => keep.has(r.changeSetId));
+  writeFileSync(indexFile(), kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""), { mode: 0o600 });
+
+  const live = new Set(kept.map((r) => r.beforeHash).filter((h): h is string => h !== null));
+  let objectsRemoved = 0;
+  if (existsSync(objectsDir())) {
+    for (const name of readdirSync(objectsDir())) {
+      if (live.has(name)) continue;
+      try { unlinkSync(join(objectsDir(), name)); objectsRemoved++; } catch { /* already gone */ }
+    }
+  }
+  return { changeSetsRemoved, objectsRemoved };
+}
+
+/**
+ * Remove stale `.hashpilot-tmp-*` files in `dir`. A crash between temp-write
+ * and rename leaves one behind; without this they accumulate in the user's
+ * source tree forever.
+ */
+export function cleanOrphanTempFiles(dir: string, maxAgeMs = 60 * 60 * 1000, now: number = Date.now()): number {
+  let removed = 0;
+  try {
+    for (const name of readdirSync(dir)) {
+      if (!name.startsWith(".hashpilot-tmp-")) continue;
+      const p = join(dir, name);
+      try {
+        if (now - statSync(p).mtimeMs < maxAgeMs) continue;
+        unlinkSync(p);
+        removed++;
+      } catch { /* raced with another process */ }
+    }
+  } catch { /* unreadable directory is not our problem here */ }
+  return removed;
+}

--- a/tests/envelope.test.ts
+++ b/tests/envelope.test.ts
@@ -93,6 +93,8 @@ const INVOCATIONS: Array<[name: string, args: string[]]> = [
   ["telemetry clear", ["telemetry", "clear"]],
   ["provenance query", ["provenance", "query", "sample.ts"]],
   ["provenance changeset", ["provenance", "changeset", "nonexistent-id"]],
+  ["changesets", ["changesets"]],
+  ["undo", ["undo", "nonexistent-changeset"]],
   ["doctor", ["doctor"]],
   ["config", ["config"]],
 ];

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, utimesSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { safeWrite, atomicWrite, simulateCrashAfterTempWrite, resetWriteBoundary, configureWriteBoundary } from "../src/core/paths";
+import {
+  setCurrentChangeSet, resetSnapshots, listChangeSets, lastChangeSetId,
+  undoChangeSet, pruneSnapshots, configureSnapshots, cleanOrphanTempFiles, snapshotRoot,
+} from "../src/core/snapshot";
+
+/**
+ * #12 — atomic writes and undo. Before this, every write truncated the target
+ * in place, so an interrupted write destroyed the original, and a
+ * wrong-but-successful edit could not be rolled back at all.
+ */
+
+let dir = "";
+let home = "";
+let priorHome: string | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "hashpilot-snap-"));
+  home = mkdtempSync(join(tmpdir(), "hashpilot-snaphome-"));
+  priorHome = process.env.HOME;
+  // The store's location is read at import time from HOME, so point the whole
+  // suite at a scratch tree by re-importing under it.
+  process.env.HOME = home;
+  resetSnapshots();
+  resetWriteBoundary();
+  configureWriteBoundary({ allowOutsideRoot: true, quiet: true });
+});
+
+afterEach(() => {
+  simulateCrashAfterTempWrite(false);
+  setCurrentChangeSet(null);
+  resetSnapshots();
+  resetWriteBoundary();
+  if (priorHome === undefined) delete process.env.HOME; else process.env.HOME = priorHome;
+  rmSync(dir, { recursive: true, force: true });
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("atomic writes", () => {
+  test("a crash between the temp write and the rename leaves the original intact", async () => {
+    const file = join(dir, "a.txt");
+    writeFileSync(file, "original\n");
+    simulateCrashAfterTempWrite(true);
+
+    await expect(safeWrite(file, "replacement\n")).rejects.toThrow(/simulated crash/);
+
+    expect(readFileSync(file, "utf8")).toBe("original\n");
+    // And the temp file is cleaned up rather than left in the source tree.
+    expect(readdirSync(dir).filter((f) => f.startsWith(".hashpilot-tmp-"))).toEqual([]);
+  });
+
+  test("the target's permissions survive the write", async () => {
+    const file = join(dir, "exec.sh");
+    writeFileSync(file, "#!/bin/sh\n", { mode: 0o755 });
+    await safeWrite(file, "#!/bin/sh\necho hi\n");
+    expect(statSync(file).mode & 0o777).toBe(0o755);
+  });
+
+  test("the temp file is a sibling of the target, never in /tmp", () => {
+    // A cross-device rename degrades to a copy and loses atomicity, so the
+    // temp file's location is part of the contract.
+    const file = join(dir, "b.txt");
+    let seen: string[] = [];
+    simulateCrashAfterTempWrite(true);
+    try { atomicWrite(file, "x"); } catch { seen = readdirSync(dir); }
+    // Cleanup already removed it, so assert on the observable outcome instead:
+    // nothing leaked, and no partial target was created.
+    expect(existsSync(file)).toBe(false);
+    expect(seen.filter((f) => f.startsWith(".hashpilot-tmp-"))).toEqual([]);
+  });
+
+  test("content is written correctly on the happy path", async () => {
+    const file = join(dir, "c.txt");
+    await safeWrite(file, "hello\n");
+    expect(readFileSync(file, "utf8")).toBe("hello\n");
+  });
+
+  test("orphaned temp files older than the cutoff are swept", () => {
+    const orphan = join(dir, ".hashpilot-tmp-123-abc");
+    writeFileSync(orphan, "junk");
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    utimesSync(orphan, old, old);
+    expect(cleanOrphanTempFiles(dir)).toBe(1);
+    expect(existsSync(orphan)).toBe(false);
+  });
+
+  test("a fresh temp file from a concurrent process is left alone", () => {
+    const other = join(dir, ".hashpilot-tmp-999-xyz");
+    writeFileSync(other, "in flight");
+    expect(cleanOrphanTempFiles(dir)).toBe(0);
+    expect(existsSync(other)).toBe(true);
+  });
+});
+
+describe("undo", () => {
+  test("edit → undo restores the file byte-identical, CRLF and trailing newline included", async () => {
+    const file = join(dir, "d.txt");
+    const original = "line one\r\nline two\r\n";
+    writeFileSync(file, original);
+
+    setCurrentChangeSet("cs-1");
+    await safeWrite(file, "clobbered");
+    expect(readFileSync(file, "utf8")).toBe("clobbered");
+
+    setCurrentChangeSet(null);
+    const result = undoChangeSet("cs-1");
+    expect(result.success).toBe(true);
+    expect(readFileSync(file, "utf8")).toBe(original);
+  });
+
+  test("a file the changeSet created is removed, not restored to nothing", async () => {
+    const file = join(dir, "new.txt");
+    setCurrentChangeSet("cs-new");
+    await safeWrite(file, "brand new\n");
+    expect(existsSync(file)).toBe(true);
+
+    const result = undoChangeSet("cs-new");
+    expect(result.success).toBe(true);
+    expect(existsSync(file)).toBe(false);
+  });
+
+  test("every file in a multi-file changeSet is restored together", async () => {
+    const a = join(dir, "a.ts");
+    const b = join(dir, "b.ts");
+    writeFileSync(a, "A\n");
+    writeFileSync(b, "B\n");
+
+    setCurrentChangeSet("cs-multi");
+    await safeWrite(a, "A2\n");
+    await safeWrite(b, "B2\n");
+
+    const result = undoChangeSet("cs-multi");
+    expect(result.success).toBe(true);
+    expect(result.files).toHaveLength(2);
+    expect(readFileSync(a, "utf8")).toBe("A\n");
+    expect(readFileSync(b, "utf8")).toBe("B\n");
+  });
+
+  test("a file modified since the edit is refused, and left untouched", async () => {
+    const file = join(dir, "e.txt");
+    writeFileSync(file, "original\n");
+    setCurrentChangeSet("cs-2");
+    await safeWrite(file, "edited\n");
+    setCurrentChangeSet(null);
+
+    writeFileSync(file, "someone else edited this\n");
+    const result = undoChangeSet("cs-2");
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("HASH_MISMATCH");
+    expect(result.files[0]!.reason).toContain("modified since");
+    expect(readFileSync(file, "utf8")).toBe("someone else edited this\n");
+  });
+
+  test("--force restores over an external modification", async () => {
+    const file = join(dir, "f.txt");
+    writeFileSync(file, "original\n");
+    setCurrentChangeSet("cs-3");
+    await safeWrite(file, "edited\n");
+    setCurrentChangeSet(null);
+    writeFileSync(file, "external\n");
+
+    expect(undoChangeSet("cs-3", { force: true }).success).toBe(true);
+    expect(readFileSync(file, "utf8")).toBe("original\n");
+  });
+
+  test("--dry-run reports the restore without touching the disk", async () => {
+    const file = join(dir, "g.txt");
+    writeFileSync(file, "original\n");
+    setCurrentChangeSet("cs-4");
+    await safeWrite(file, "edited\n");
+    setCurrentChangeSet(null);
+
+    const result = undoChangeSet("cs-4", { dryRun: true });
+    expect(result.success).toBe(true);
+    expect(readFileSync(file, "utf8")).toBe("edited\n");
+  });
+
+  test("undoing a changeSet edited twice restores the pre-first-edit bytes", async () => {
+    const file = join(dir, "h.txt");
+    writeFileSync(file, "v0\n");
+    setCurrentChangeSet("cs-5");
+    await safeWrite(file, "v1\n");
+    await safeWrite(file, "v2\n");
+    setCurrentChangeSet(null);
+
+    expect(undoChangeSet("cs-5").success).toBe(true);
+    expect(readFileSync(file, "utf8")).toBe("v0\n");
+  });
+
+  test("an unknown changeSet fails rather than silently succeeding", () => {
+    const result = undoChangeSet("nope");
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("FILE_NOT_FOUND");
+  });
+});
+
+describe("the changeSet index", () => {
+  test("changeSets list newest first with their files", async () => {
+    writeFileSync(join(dir, "i.txt"), "x\n");
+    setCurrentChangeSet("cs-old");
+    await safeWrite(join(dir, "i.txt"), "y\n");
+    setCurrentChangeSet("cs-new");
+    await safeWrite(join(dir, "i.txt"), "z\n");
+    setCurrentChangeSet(null);
+
+    const sets = listChangeSets();
+    expect(sets.map((s) => s.changeSetId)).toContain("cs-old");
+    expect(sets[0]!.changeSetId).toBe("cs-new");
+    expect(lastChangeSetId()).toBe("cs-new");
+  });
+
+  test("nothing is snapshotted when no changeSet is active", async () => {
+    writeFileSync(join(dir, "j.txt"), "x\n");
+    setCurrentChangeSet(null);
+    await safeWrite(join(dir, "j.txt"), "y\n");
+    expect(listChangeSets()).toEqual([]);
+  });
+
+  test("snapshots can be switched off entirely", async () => {
+    configureSnapshots({ enabled: false });
+    writeFileSync(join(dir, "k.txt"), "x\n");
+    setCurrentChangeSet("cs-off");
+    await safeWrite(join(dir, "k.txt"), "y\n");
+    expect(listChangeSets()).toEqual([]);
+  });
+
+  test("retention drops the oldest changeSets past the cap", async () => {
+    configureSnapshots({ maxChangeSets: 2 });
+    const file = join(dir, "l.txt");
+    writeFileSync(file, "0\n");
+    for (const id of ["r1", "r2", "r3"]) {
+      setCurrentChangeSet(id);
+      await safeWrite(file, `${id}\n`);
+      // Distinct timestamps, so the ordering the cap relies on is well-defined.
+      await Bun.sleep(2);
+    }
+    setCurrentChangeSet(null);
+
+    const removed = pruneSnapshots();
+    expect(removed.changeSetsRemoved).toBe(1);
+    const ids = listChangeSets().map((s) => s.changeSetId);
+    expect(ids).toEqual(["r3", "r2"]);
+  });
+
+  test("pruning removes objects nothing references any more", async () => {
+    configureSnapshots({ maxChangeSets: 1 });
+    const file = join(dir, "m.txt");
+    writeFileSync(file, "first\n");
+    setCurrentChangeSet("p1");
+    await safeWrite(file, "second\n");
+    await Bun.sleep(2);
+    setCurrentChangeSet("p2");
+    await safeWrite(file, "third\n");
+    setCurrentChangeSet(null);
+
+    const before = readdirSync(join(snapshotRoot(), "objects")).length;
+    const result = pruneSnapshots();
+    expect(result.objectsRemoved).toBeGreaterThan(0);
+    expect(readdirSync(join(snapshotRoot(), "objects")).length).toBeLessThan(before);
+  });
+
+  test("age-based retention drops changeSets past the window", async () => {
+    configureSnapshots({ maxAgeDays: 1 });
+    const file = join(dir, "n.txt");
+    writeFileSync(file, "x\n");
+    setCurrentChangeSet("aged");
+    await safeWrite(file, "y\n");
+    setCurrentChangeSet(null);
+
+    // Two days on: the set is past the window.
+    const result = pruneSnapshots(Date.now() + 2 * 24 * 60 * 60 * 1000);
+    expect(result.changeSetsRemoved).toBe(1);
+    expect(listChangeSets()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #12 (B4 — no atomic writes, no backups, no undo · P0 · data-loss).

## What was broken
Every write truncated its target in place: an interrupted write left a half-written source file, and a wrong-but-successful edit had nothing to roll back to.

## What changed
- **Atomic writes** at the single write path (`safeWrite`/`atomicWrite`): sibling temp file → `fsync` → `rename` → `fsync` of the directory, target mode preserved. The temp file is deliberately a sibling and not in `/tmp`, since a cross-device rename degrades to a copy and loses atomicity. Orphaned `.hashpilot-tmp-*` files older than an hour are swept after each write.
- **Pre-edit snapshots** (`src/core/snapshot.ts`): content-addressed store at `~/.agentic-tools/snapshots/` (`objects/<sha256>` + `index.jsonl`), outside the project tree so it never shows in `git status`. Keyed by a changeSet ID minted once per CLI invocation, reusing `createChangeSet()` rather than inventing a second identifier. Retention 200 changeSets / 7 days, pruned every run.
- **New commands**: `changesets [--limit N]`, `undo <changeSetId>`, `undo --last`, with `--force` and `--dry-run`. A file changed since the edit is refused with `HASH_MISMATCH` (exit 3) and left exactly as found. An undo is not itself snapshotted, so `undo --last` cannot ping-pong.

Only two write sites needed touching — earlier work had already funnelled everything through `safeWrite` except `hash-edit.ts`; the router, batch, plan-executor, diff-engine and verify paths inherit atomicity for free.

## Verification
- 537 pass / 0 fail (was 515), 20 new tests in `tests/snapshot.test.ts`: simulated crash between temp-write and rename leaves the original byte-identical, mode preservation, CRLF round-trip, created-file removal, multi-file sets, external-modification refusal, `--force`, `--dry-run`, double-edit, retention by count and by age, object GC, orphan sweeping.
- Dogfooded end to end in a throwaway repo: `ast rename-symbol` → `changesets` → `undo <id>`, SHA-256 of the restored file matched the pre-edit hash.
- Docs synced: README, `docs/ADAPTER-CONTRACT.md`, `docs/ARCHITECTURE.md` (+ footer), `CLAUDE.md`/`AGENTS.md` module map, ROADMAP row → shipped, `CLI-QUICKREF.md` regenerated. `lint:docs` and `lint:roadmap` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)