### PR TITLE
feat!: rename CLI from structured-edit to hashpilot + add uninstall command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Assert actionable message, not a stack trace
         run: |
           set +e
-          out=$(structured-edit doctor 2>&1)
+          out=$(hashpilot doctor 2>&1)
           code=$?
           set -e
           echo "$out"
@@ -89,7 +89,7 @@ jobs:
           bun-version: latest
 
       - name: Doctor runs from the packed install once Bun is present
-        run: structured-edit doctor
+        run: hashpilot doctor
 
   docs-verify:
     name: Docs Verify

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,13 @@ logs/
 
 # Advisory lock files — process-local, never shared.
 .hashpilot/
+
+# Playwright MCP artifacts
+.playwright-mcp/
+
+# Local screenshot artifacts
+desktop-*.png
+mobile-*.png
+
+# Local task tracking
+tasks/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ bun test tests/hash-edit.test.ts     # Single test file
 bun test -t "test name pattern"      # Filter by test name
 ```
 
-The smoke test (`bash tests/smoke.sh`) requires the CLI to be installed (`structured-edit` on PATH); run it whenever CLI behavior changes. CI uses semantic-release for automated versioning and publishing, so commits must use Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`) — the prefix drives the release.
+The smoke test (`bash tests/smoke.sh`) requires the CLI to be installed (`hashpilot` on PATH); run it whenever CLI behavior changes. CI uses semantic-release for automated versioning and publishing, so commits must use Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`) — the prefix drives the release.
 
 Style: strict TypeScript, ES modules, two-space indent; camelCase values, PascalCase types, kebab-case CLI subcommands.
 
@@ -37,7 +37,7 @@ Style: strict TypeScript, ES modules, two-space indent; camelCase values, Pascal
 
 ## Architecture
 
-HashPilot is a global, tool-agnostic structured editing core for coding agents. It exposes a single CLI binary (`structured-edit`) that agents invoke for safe, syntax-aware file edits.
+HashPilot is a global, tool-agnostic structured editing core for coding agents. It exposes a single CLI binary (`hashpilot`) that agents invoke for safe, syntax-aware file edits.
 
 ### Three-tier edit hierarchy
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ hashpilot upgrade          # upgrade to latest from main
 hashpilot upgrade --dry-run  # preview what would happen
 ```
 
+### Uninstall
+
+```bash
+hashpilot uninstall              # remove everything (prompts for confirmation)
+hashpilot uninstall --keep-config  # remove binaries, keep config + telemetry
+hashpilot uninstall --dry-run    # preview what would be removed
+hashpilot uninstall --force      # skip confirmation prompt
+```
+
 ### Runtime support matrix
 
 HashPilot is Bun-only today. The core uses Bun APIs and ships as TypeScript source, so

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Every edit is anchored by a SHA-256 hash — not a fragile line number or a fuzz
 
 ## What This Is
 
-HashPilot is a CLI (`structured-edit`) and editing protocol that replaces fuzzy text editing with precision operations:
+HashPilot is a CLI (`hashpilot`) and editing protocol that replaces fuzzy text editing with precision operations:
 
 - **Hash-anchored replacement** — target content by its cryptographic fingerprint
 - **AST-aware refactoring** — rename symbols, replace function bodies, manage imports (TypeScript, JS, Python, Go, Rust)
@@ -125,8 +125,8 @@ curl -fsSL https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/ins
 ### Upgrade
 
 ```bash
-structured-edit upgrade          # upgrade to latest from main
-structured-edit upgrade --dry-run  # preview what would happen
+hashpilot upgrade          # upgrade to latest from main
+hashpilot upgrade --dry-run  # preview what would happen
 ```
 
 ### Runtime support matrix
@@ -138,32 +138,32 @@ there is no Node-compatible build yet.
 |---------|-----------|-------|
 | Bun ≥ 1.2 | ✅ | The only supported runtime. Enforced by `engines.bun`. |
 | Bun < 1.2 | ❌ | `npm`/`bun` warn at install time via `engines`. |
-| Node.js (any version) | ❌ | `structured-edit` exits **127** with an install message pointing at https://bun.sh. |
+| Node.js (any version) | ❌ | `hashpilot` exits **127** with an install message pointing at https://bun.sh. |
 
-The `structured-edit` binary is a small CommonJS shim (`src/cli-node.cjs`) that any Node can
+The `hashpilot` binary is a small CommonJS shim (`src/cli-node.cjs`) that any Node can
 parse. It hands off to Bun and forwards Bun's exit status unchanged, so a Node-only machine
 gets one actionable line instead of a syntax-error stack trace.
 
 ```bash
 # Verify it works
-structured-edit doctor
+hashpilot doctor
 
 # See your merged config
-structured-edit config
+hashpilot config
 ```
 
 ### Your First Edit
 
 ```bash
 # 1. Read a file — get its content hash
-structured-edit read-many src/main.ts
+hashpilot read-many src/main.ts
 
 # 2. Edit by hash — target the exact content
 HASH="abc123..."  # from read-many output
-structured-edit replace-hash src/main.ts "$HASH" "  port: 8080" --range 5:5
+hashpilot replace-hash src/main.ts "$HASH" "  port: 8080" --range 5:5
 
 # 3. Verify nothing broke
-structured-edit verify-changes src/main.ts --auto-detect
+hashpilot verify-changes src/main.ts --auto-detect
 ```
 
 ---
@@ -384,8 +384,8 @@ By default HashPilot only writes inside the project root (the nearest ancestor
 containing `.git`). Anything else fails with `PATH_DENIED` and exit code `1`.
 
 ```bash
-structured-edit --allowed-root /srv/generated ast rename-symbol ...   # widen for one run
-structured-edit --allow-outside-root ...                              # disable containment
+hashpilot --allowed-root /srv/generated ast rename-symbol ...   # widen for one run
+hashpilot --allow-outside-root ...                              # disable containment
 ```
 
 ```json
@@ -408,7 +408,7 @@ ever sent off the machine.
 **Turning it off** — highest priority first:
 
 ```bash
-structured-edit --no-telemetry ast rename-symbol ...   # one invocation
+hashpilot --no-telemetry ast rename-symbol ...   # one invocation
 export HASHPILOT_TELEMETRY=0                           # whole shell (also: false, off, no)
 ```
 
@@ -447,7 +447,7 @@ HashPilot installs adapters for the three major coding agent platforms:
 
 | Platform | What Gets Installed |
 |----------|-------------------|
-| **Claude Code** | HashPilot section injected into `~/.claude/CLAUDE.md` teaching Claude to use `structured-edit` commands |
+| **Claude Code** | HashPilot section injected into `~/.claude/CLAUDE.md` teaching Claude to use `hashpilot` commands |
 | **OpenCode** | Skill at `~/.config/opencode/skills/hashpilot/` + subagent at `~/.config/opencode/agent/hashpilot.md` |
 | **Pi** | Native extension at `~/.pi/agent/extensions/hashpilot.ts` with 7 custom tools and `/hp` slash command |
 
@@ -459,7 +459,7 @@ All adapters follow the [Adapter Contract](docs/ADAPTER-CONTRACT.md) — a machi
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│                   structured-edit CLI                         │
+│                   hashpilot CLI                         │
 │                  (Commander-based, Bun)                       │
 ├─────────┬──────────┬──────────┬──────────┬───────────────────┤
 │   Read  │   AST    │   Hash   │   Diff   │  Verify + Batch   │

--- a/docs/ADAPTER-CONTRACT.md
+++ b/docs/ADAPTER-CONTRACT.md
@@ -1,6 +1,6 @@
 # HashPilot — Adapter Contract
 
-This document defines the machine-readable contract that coding agents use to interact with HashPilot. All commands are invoked via the `structured-edit` CLI and return JSON on stdout.
+This document defines the machine-readable contract that coding agents use to interact with HashPilot. All commands are invoked via the `hashpilot` CLI and return JSON on stdout.
 
 ## Response envelope (apiVersion 1)
 
@@ -135,7 +135,7 @@ Read multiple files with content hashes.
 
 **Invocation:**
 ```
-structured-edit read-many <file1> [file2] ...
+hashpilot read-many <file1> [file2] ...
 ```
 
 **Output:**
@@ -161,7 +161,7 @@ Read a specific line with its hash and surrounding context.
 
 **Invocation:**
 ```
-structured-edit read-hash <file> <line-number> [-c <context-lines>]
+hashpilot read-hash <file> <line-number> [-c <context-lines>]
 ```
 
 **Output:**
@@ -193,7 +193,7 @@ Search a regex pattern across paths.
 
 **Invocation:**
 ```
-structured-edit grep-many <pattern> <path1> [path2] ... [-i] [--file-pattern <glob>] [--max-results <n>]
+hashpilot grep-many <pattern> <path1> [path2] ... [-i] [--file-pattern <glob>] [--max-results <n>]
 ```
 
 **Output:**
@@ -222,7 +222,7 @@ Look up symbol definitions across paths.
 
 **Invocation:**
 ```
-structured-edit symbol-lookup-many <path1> [path2] ... --names name1,name2
+hashpilot symbol-lookup-many <path1> [path2] ... --names name1,name2
 ```
 
 **Output:**
@@ -245,7 +245,7 @@ Replace file content identified by hash anchor.
 
 **Invocation:**
 ```
-structured-edit replace-hash <file> <old-hash> <new-content> [--range start:end] [--dry-run]
+hashpilot replace-hash <file> <old-hash> <new-content> [--range start:end] [--dry-run]
 ```
 
 - `<new-content>` can be `@filepath` to read from a file
@@ -328,7 +328,7 @@ Show all supported AST languages, operations per language, and known limitations
 
 **Invocation:**
 ```
-structured-edit ast capabilities
+hashpilot ast capabilities
 ```
 
 **Output:**
@@ -351,7 +351,7 @@ List symbols in a file.
 
 **Invocation:**
 ```
-structured-edit ast find-symbols <file>
+hashpilot ast find-symbols <file>
 ```
 
 **Output:**
@@ -376,7 +376,7 @@ Rename all references to a symbol.
 
 **Invocation:**
 ```
-structured-edit ast rename-symbol <file> <old-name> <new-name> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
+hashpilot ast rename-symbol <file> <old-name> <new-name> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
 ```
 
 **Output:**
@@ -398,7 +398,7 @@ Replace a function/method body.
 
 **Invocation:**
 ```
-structured-edit ast replace-body <file> <symbol-name> <new-body> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
+hashpilot ast replace-body <file> <symbol-name> <new-body> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
 ```
 
 `<new-body>` can be `@filepath` to read from a file.
@@ -422,7 +422,7 @@ Add an import statement.
 
 **Invocation:**
 ```
-structured-edit ast add-import <file> <import-spec> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
+hashpilot ast add-import <file> <import-spec> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
 ```
 
 `<import-spec>` examples: `'{ Foo } from ./bar'`, `'* as React from react'`
@@ -435,7 +435,7 @@ Remove an import line.
 
 **Invocation:**
 ```
-structured-edit ast remove-import <file> <import-spec> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
+hashpilot ast remove-import <file> <import-spec> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
 ```
 
 ---
@@ -446,8 +446,8 @@ Insert content before or after a named symbol.
 
 **Invocation:**
 ```
-structured-edit ast insert-before <file> <symbol-name> <content> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
-structured-edit ast insert-after <file> <symbol-name> <content> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
+hashpilot ast insert-before <file> <symbol-name> <content> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
+hashpilot ast insert-after <file> <symbol-name> <content> [--dry-run] [--actor <name>] [--task-id <id>] [--reason <text>]
 ```
 
 ---
@@ -458,7 +458,7 @@ Generate a unified diff between old and new content.
 
 **Invocation:**
 ```
-structured-edit diff generate <file> <old-content> <new-content> [-c <context-lines>]
+hashpilot diff generate <file> <old-content> <new-content> [-c <context-lines>]
 ```
 
 `<old-content>` and `<new-content>` can be `@filepath` to read from files.
@@ -473,7 +473,7 @@ Apply a unified diff patch to a file.
 
 **Invocation:**
 ```
-structured-edit diff apply <file> [--patch <file>] [--dry-run] [-f <fuzzy>] [--actor <name>] [--task-id <id>] [--reason <text>]
+hashpilot diff apply <file> [--patch <file>] [--dry-run] [-f <fuzzy>] [--actor <name>] [--task-id <id>] [--reason <text>]
 ```
 
 - `--patch <file>` — patch file to apply (use `-` for stdin)
@@ -498,7 +498,7 @@ Run formatter, linter, typechecker, and tests on changed files. Supports auto-de
 
 **Invocation:**
 ```
-structured-edit verify-changes <file1> [file2] ... [--formatter <cmd>] [--linter <cmd>] [--typecheck <cmd>] [--test-filter <pattern>] [--test-runner <runner>] [--auto-detect] [--revert-on-failure] [--timeout <ms>] [--formatter-args ...] [--linter-args ...] [--test-args ...]
+hashpilot verify-changes <file1> [file2] ... [--formatter <cmd>] [--linter <cmd>] [--typecheck <cmd>] [--test-filter <pattern>] [--test-runner <runner>] [--auto-detect] [--revert-on-failure] [--timeout <ms>] [--formatter-args ...] [--linter-args ...] [--test-args ...]
 ```
 
 **Options:**
@@ -537,7 +537,7 @@ Auto-routed structured edit through AST → Hash → Diff pipeline. One command 
 
 **Invocation:**
 ```
-structured-edit route-edit <file> <operation> [options...]
+hashpilot route-edit <file> <operation> [options...]
 ```
 
 **Operations:** `rename-symbol`, `replace-body`, `add-import`, `remove-import`, `insert-before`, `insert-after`, `replace-hash`, `replace-content`
@@ -561,7 +561,7 @@ Apply the same edit to multiple files in parallel (or serial with `--serial`).
 
 **Invocation:**
 ```
-structured-edit batch <operation> <files...> [options...]
+hashpilot batch <operation> <files...> [options...]
 ```
 
 Accepts the same options as `route-edit`, plus `--serial` for sequential execution.
@@ -602,7 +602,7 @@ Execute an editing intent — one command, full blast radius. Parses a structure
 
 **Invocation:**
 ```
-structured-edit intent '<json>' [--project-root <dir>] [--dry-run] [--yes] [--no-verify] [--no-revert] [--timeout <ms>] [--actor <name>] [--task-id <id>] [--reason <text>] [--context <text>]
+hashpilot intent '<json>' [--project-root <dir>] [--dry-run] [--yes] [--no-verify] [--no-revert] [--timeout <ms>] [--actor <name>] [--task-id <id>] [--reason <text>] [--context <text>]
 ```
 
 **Intent format (JSON):**
@@ -657,7 +657,7 @@ Show edit history for a file — like `git blame` for agent edits.
 
 **Invocation:**
 ```
-structured-edit provenance query <file> [<line-number>] [--human] [--fuzzy] [--limit <n>]
+hashpilot provenance query <file> [<line-number>] [--human] [--fuzzy] [--limit <n>]
 ```
 
 - `--human` — human-readable table format
@@ -687,7 +687,7 @@ Show all edits belonging to a changeSet (multi-step edit group).
 
 **Invocation:**
 ```
-structured-edit provenance changeset <changeSetId> [--human]
+hashpilot provenance changeset <changeSetId> [--human]
 ```
 
 ---
@@ -698,13 +698,13 @@ View or manage telemetry.
 
 **Invocation:**
 ```
-structured-edit telemetry show [-n <limit>]
-structured-edit telemetry summary
-structured-edit telemetry health [-w <days>] [--trend]
-structured-edit telemetry sessions
-structured-edit telemetry export [--from <date>] [--to <date>] [--session <id>]
-structured-edit telemetry prune [--older-than <days>]
-structured-edit telemetry clear
+hashpilot telemetry show [-n <limit>]
+hashpilot telemetry summary
+hashpilot telemetry health [-w <days>] [--trend]
+hashpilot telemetry sessions
+hashpilot telemetry export [--from <date>] [--to <date>] [--session <id>]
+hashpilot telemetry prune [--older-than <days>]
+hashpilot telemetry clear
 ```
 
 **`telemetry show`** — Show recent telemetry events (default 20).
@@ -725,7 +725,7 @@ Show which edit route would be chosen, with detailed explanation including polic
 
 **Invocation:**
 ```
-structured-edit route <file> <operation> [--policy <json>] [--no-default-config]
+hashpilot route <file> <operation> [--policy <json>] [--no-default-config]
 ```
 
 **`--policy <json>`** — inline policy JSON for testing override behavior.
@@ -771,7 +771,7 @@ Show the current HashPilot configuration after merging global, project, CLI, and
 
 **Invocation:**
 ```
-structured-edit config [--config <path>]
+hashpilot config [--config <path>]
 ```
 
 **Output:**
@@ -793,7 +793,7 @@ Verify the full user-scope HashPilot installation. Checks core files, CLI on PAT
 
 **Invocation:**
 ```
-structured-edit doctor
+hashpilot doctor
 ```
 
 **Output (JSON):**
@@ -830,9 +830,9 @@ View or manage telemetry.
 
 **Invocation:**
 ```
-structured-edit telemetry show [-n <limit>]
-structured-edit telemetry summary
-structured-edit telemetry clear
+hashpilot telemetry show [-n <limit>]
+hashpilot telemetry summary
+hashpilot telemetry clear
 ```
 
 **Event schema:**
@@ -862,7 +862,7 @@ Show an operational health report with per-language stats, failure breakdowns, a
 
 **Invocation:**
 ```
-structured-edit telemetry health [-w <days>] [--trend]
+hashpilot telemetry health [-w <days>] [--trend]
 ```
 
 - `-w, --window <days>` — time window in days (default 7)

--- a/docs/ADAPTER-CONTRACT.md
+++ b/docs/ADAPTER-CONTRACT.md
@@ -823,6 +823,45 @@ A standalone version is also available: `scripts/doctor.sh` (works without CLI o
 
 ---
 
+### upgrade
+
+Upgrade HashPilot to the latest version from GitHub. Downloads and runs `scripts/install.sh` from the specified release channel.
+
+**Invocation:**
+```
+hashpilot upgrade [--channel <channel>] [--target <dir>] [--keep-telemetry] [--force] [--dry-run]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--channel <channel>` | Release channel (default: `main`) |
+| `--target <dir>` | Install target directory (default: `~/.agentic-tools`) |
+| `--keep-telemetry` | Preserve existing telemetry on upgrade |
+| `--force` | Skip confirmation prompt |
+| `--dry-run` | Show what would be done without executing |
+
+**Exit code:** `0` on success, `70` on failure.
+
+### uninstall
+
+Remove HashPilot and all its components from the system. Downloads and runs `scripts/uninstall.sh`.
+
+**Invocation:**
+```
+hashpilot uninstall [--keep-config] [--force] [--dry-run] [--target <dir>]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--keep-config` | Preserve config and telemetry data |
+| `--force` | Skip confirmation prompt (auto-detected when piped) |
+| `--dry-run` | Show what would be removed without deleting anything |
+| `--target <dir>` | Install target directory (default: `~/.agentic-tools`) |
+
+**Output (dry-run):** JSON object with `components` array listing what would be removed (or preserved with `--keep-config`).
+
+**Exit code:** `0` on success, `70` on failure.
+
 
 ### telemetry
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,7 @@ HashPilot has two complementary docs that must always be kept in sync with the c
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│                        structured-edit CLI                        │
+│                        hashpilot CLI                        │
 │                    (Commander-based, Bun runtime)                  │
 ├───────────┬───────────┬──────────┬──────────┬────────────────────┤
 │   Read    │    AST    │   Hash   │   Diff   │  Verify + Batch    │
@@ -301,7 +301,7 @@ sequenceDiagram
 - Verifies: core files exist, CLI is on PATH, config is valid
 - Checks adapter integrations: Claude Code, OpenCode, Pi
 - Reports: installation status, missing components, version info
-- Single command: `structured-edit doctor`
+- Single command: `hashpilot doctor`
 
 #### `src/batch-edit.ts` — Batch Editing
 - `editMany(operation, files)`: Same edit applied to many files in parallel
@@ -464,7 +464,7 @@ HashPilot integrates with three coding agent platforms via the [Adapter Contract
 | **OpenCode** | Skill + subagent | `~/.config/opencode/skills/hashpilot/` + `~/.config/opencode/agent/hashpilot.md` |
 | **Pi** | Native extension | `~/.pi/agent/extensions/hashpilot.ts` + 7 custom tools |
 
-Each adapter teaches the agent to use `structured-edit` commands instead of raw file editing.
+Each adapter teaches the agent to use `hashpilot` commands instead of raw file editing.
 
 ---
 

--- a/docs/CLI-QUICKREF.md
+++ b/docs/CLI-QUICKREF.md
@@ -1,6 +1,6 @@
 # CLI Quick Reference
 
-Copy-paste reference for `structured-edit`, aimed at agents driving the CLI without
+Copy-paste reference for `hashpilot`, aimed at agents driving the CLI without
 prior context. The command tables below are **generated from the CLI's own `--help`**,
 so they cannot drift from what the binary accepts.
 
@@ -22,8 +22,8 @@ Each of these cost a real agent a wasted round-trip. Every claim has a test in
 ### Positionals are positional — there is no `--pattern` or `--paths`
 
 ```bash
-structured-edit grep-many '<pattern>' <path>...      # ✅
-structured-edit grep-many --pattern x --paths src    # ❌ unknown option, exit 1
+hashpilot grep-many '<pattern>' <path>...      # ✅
+hashpilot grep-many --pattern x --paths src    # ❌ unknown option, exit 1
 ```
 
 `symbol-lookup-many` is the exception in the search family: paths are positional but
@@ -57,14 +57,14 @@ returning `[]`. Malformed lines are skipped, counted, and reported on stderr
 
 ### The telemetry subcommand is `show`, not `recent`
 
-`structured-edit telemetry show -n 50`. Siblings: `summary`, `health`, `clear`,
+`hashpilot telemetry show -n 50`. Siblings: `summary`, `health`, `clear`,
 `sessions`, `export`, `prune`.
 
 ### Never read an exit code through a pipe
 
 ```bash
-structured-edit doctor | head        # $? is head's status — always 0
-structured-edit doctor >/dev/null 2>&1; echo $?   # ✅ the real code
+hashpilot doctor | head        # $? is head's status — always 0
+hashpilot doctor >/dev/null 2>&1; echo $?   # ✅ the real code
 ```
 
 This masked a genuine exit-70 during review and made a broken build look green.
@@ -112,14 +112,14 @@ looks unrelated to AST. Green baseline is `bun test` fully passing (515 pass / 0
 
 <!-- BEGIN GENERATED: command reference -->
 
-_34 commands, generated from `--help`. Do not edit by hand — run `bun run gen:cli-quickref`._
+_35 commands, generated from `--help`. Do not edit by hand — run `bun run gen:cli-quickref`._
 
 ### Global options
 
-Accepted before the subcommand, e.g. `structured-edit --allowed-root /srv/app read-many f.ts`.
+Accepted before the subcommand, e.g. `hashpilot --allowed-root /srv/app read-many f.ts`.
 
 ```
-structured-edit [options] [command]
+hashpilot [options] [command]
 ```
 
 | Flag | Meaning |
@@ -146,7 +146,7 @@ structured-edit [options] [command]
 Read multiple files, return content + hashes
 
 ```
-structured-edit read-many [options] <files...>
+hashpilot read-many [options] <files...>
 ```
 
 | Positional | Meaning |
@@ -162,7 +162,7 @@ structured-edit read-many [options] <files...>
 Read a line with hash and context
 
 ```
-structured-edit read-hash [options] <file> <line>
+hashpilot read-hash [options] <file> <line>
 ```
 
 | Positional | Meaning |
@@ -180,7 +180,7 @@ structured-edit read-hash [options] <file> <line>
 Search pattern across multiple paths
 
 ```
-structured-edit grep-many [options] <pattern> <paths...>
+hashpilot grep-many [options] <pattern> <paths...>
 ```
 
 | Positional | Meaning |
@@ -200,7 +200,7 @@ structured-edit grep-many [options] <pattern> <paths...>
 Find symbol definitions. Usage: symbol-lookup-many <paths...> --names n1,n2
 
 ```
-structured-edit symbol-lookup-many [options] <paths...>
+hashpilot symbol-lookup-many [options] <paths...>
 ```
 
 | Positional | Meaning |
@@ -217,7 +217,7 @@ structured-edit symbol-lookup-many [options] <paths...>
 Replace content identified by hash anchor
 
 ```
-structured-edit replace-hash [options] <file> <old-hash> <new-content>
+hashpilot replace-hash [options] <file> <old-hash> <new-content>
 ```
 
 | Positional | Meaning |
@@ -241,7 +241,7 @@ structured-edit replace-hash [options] <file> <old-hash> <new-content>
 Show supported AST languages, operations, and limitations
 
 ```
-structured-edit ast capabilities [options]
+hashpilot ast capabilities [options]
 ```
 
 #### `ast find-symbols`
@@ -249,7 +249,7 @@ structured-edit ast capabilities [options]
 List symbols in a file
 
 ```
-structured-edit ast find-symbols [options] <file>
+hashpilot ast find-symbols [options] <file>
 ```
 
 | Positional | Meaning |
@@ -261,7 +261,7 @@ structured-edit ast find-symbols [options] <file>
 Rename a symbol across a file
 
 ```
-structured-edit ast rename-symbol [options] <file> <old-name> <new-name>
+hashpilot ast rename-symbol [options] <file> <old-name> <new-name>
 ```
 
 | Positional | Meaning |
@@ -283,7 +283,7 @@ structured-edit ast rename-symbol [options] <file> <old-name> <new-name>
 Replace function/method body
 
 ```
-structured-edit ast replace-body [options] <file> <symbol> <new-body>
+hashpilot ast replace-body [options] <file> <symbol> <new-body>
 ```
 
 | Positional | Meaning |
@@ -305,7 +305,7 @@ structured-edit ast replace-body [options] <file> <symbol> <new-body>
 Add an import statement
 
 ```
-structured-edit ast add-import [options] <file> <import-spec>
+hashpilot ast add-import [options] <file> <import-spec>
 ```
 
 | Positional | Meaning |
@@ -326,7 +326,7 @@ structured-edit ast add-import [options] <file> <import-spec>
 Remove an import statement
 
 ```
-structured-edit ast remove-import [options] <file> <import-spec>
+hashpilot ast remove-import [options] <file> <import-spec>
 ```
 
 | Positional | Meaning |
@@ -347,7 +347,7 @@ structured-edit ast remove-import [options] <file> <import-spec>
 Insert content before a symbol
 
 ```
-structured-edit ast insert-before [options] <file> <symbol> <content>
+hashpilot ast insert-before [options] <file> <symbol> <content>
 ```
 
 | Positional | Meaning |
@@ -369,7 +369,7 @@ structured-edit ast insert-before [options] <file> <symbol> <content>
 Insert content after a symbol
 
 ```
-structured-edit ast insert-after [options] <file> <symbol> <content>
+hashpilot ast insert-after [options] <file> <symbol> <content>
 ```
 
 | Positional | Meaning |
@@ -391,7 +391,7 @@ structured-edit ast insert-after [options] <file> <symbol> <content>
 Auto-routed structured edit through AST → Hash → Diff pipeline
 
 ```
-structured-edit route-edit [options] <file> <operation>
+hashpilot route-edit [options] <file> <operation>
 ```
 
 | Positional | Meaning |
@@ -424,7 +424,7 @@ structured-edit route-edit [options] <file> <operation>
 Apply the same edit to multiple files in parallel
 
 ```
-structured-edit batch [options] <operation> <files...>
+hashpilot batch [options] <operation> <files...>
 ```
 
 | Positional | Meaning |
@@ -458,7 +458,7 @@ structured-edit batch [options] <operation> <files...>
 Execute an editing intent — one command, full blast radius
 
 ```
-structured-edit intent [options] <intent>
+hashpilot intent [options] <intent>
 ```
 
 | Positional | Meaning |
@@ -484,7 +484,7 @@ structured-edit intent [options] <intent>
 Generate a unified diff between old and new content
 
 ```
-structured-edit diff generate [options] <file> <old-content> <new-content>
+hashpilot diff generate [options] <file> <old-content> <new-content>
 ```
 
 | Positional | Meaning |
@@ -503,7 +503,7 @@ structured-edit diff generate [options] <file> <old-content> <new-content>
 Apply a unified diff patch to a file
 
 ```
-structured-edit diff apply [options] <file>
+hashpilot diff apply [options] <file>
 ```
 
 | Positional | Meaning |
@@ -525,7 +525,7 @@ structured-edit diff apply [options] <file>
 Run formatter, linter, typechecker, and tests on changed files
 
 ```
-structured-edit verify-changes [options] <files...>
+hashpilot verify-changes [options] <files...>
 ```
 
 | Positional | Meaning |
@@ -553,7 +553,7 @@ structured-edit verify-changes [options] <files...>
 Show recent telemetry events
 
 ```
-structured-edit telemetry show [options]
+hashpilot telemetry show [options]
 ```
 
 | Flag | Meaning |
@@ -565,7 +565,7 @@ structured-edit telemetry show [options]
 Show telemetry summary
 
 ```
-structured-edit telemetry summary [options]
+hashpilot telemetry summary [options]
 ```
 
 #### `telemetry health`
@@ -573,7 +573,7 @@ structured-edit telemetry summary [options]
 Show telemetry health report with per-language stats and threshold warnings
 
 ```
-structured-edit telemetry health [options]
+hashpilot telemetry health [options]
 ```
 
 | Flag | Meaning |
@@ -586,7 +586,7 @@ structured-edit telemetry health [options]
 Clear telemetry log
 
 ```
-structured-edit telemetry clear [options]
+hashpilot telemetry clear [options]
 ```
 
 #### `telemetry sessions`
@@ -594,7 +594,7 @@ structured-edit telemetry clear [options]
 List session summaries
 
 ```
-structured-edit telemetry sessions [options]
+hashpilot telemetry sessions [options]
 ```
 
 #### `telemetry export`
@@ -602,7 +602,7 @@ structured-edit telemetry sessions [options]
 Export telemetry events as NDJSON
 
 ```
-structured-edit telemetry export [options]
+hashpilot telemetry export [options]
 ```
 
 | Flag | Meaning |
@@ -617,7 +617,7 @@ structured-edit telemetry export [options]
 Delete old rotated telemetry files
 
 ```
-structured-edit telemetry prune [options]
+hashpilot telemetry prune [options]
 ```
 
 | Flag | Meaning |
@@ -629,7 +629,7 @@ structured-edit telemetry prune [options]
 Show edit history for a file (like git blame for agent edits)
 
 ```
-structured-edit provenance query [options] <file> [line]
+hashpilot provenance query [options] <file> [line]
 ```
 
 | Positional | Meaning |
@@ -649,7 +649,7 @@ structured-edit provenance query [options] <file> [line]
 Show all edits in a changeSet
 
 ```
-structured-edit provenance changeset [options] <changeSetId>
+hashpilot provenance changeset [options] <changeSetId>
 ```
 
 | Positional | Meaning |
@@ -665,7 +665,7 @@ structured-edit provenance changeset [options] <changeSetId>
 List undoable changeSets, newest first
 
 ```
-structured-edit changesets [options]
+hashpilot changesets [options]
 ```
 
 | Flag | Meaning |
@@ -677,7 +677,7 @@ structured-edit changesets [options]
 Restore every file in a changeSet to its pre-edit contents
 
 ```
-structured-edit undo [options] [changeSetId]
+hashpilot undo [options] [changeSetId]
 ```
 
 | Positional | Meaning |
@@ -695,7 +695,7 @@ structured-edit undo [options] [changeSetId]
 Verify HashPilot installation health
 
 ```
-structured-edit doctor [options]
+hashpilot doctor [options]
 ```
 
 #### `upgrade`
@@ -703,7 +703,7 @@ structured-edit doctor [options]
 Upgrade HashPilot to the latest version from GitHub
 
 ```
-structured-edit upgrade [options]
+hashpilot upgrade [options]
 ```
 
 | Flag | Meaning |
@@ -714,12 +714,28 @@ structured-edit upgrade [options]
 | `--force` | Skip confirmation prompt |
 | `--dry-run` | Show what would be done without executing |
 
+#### `uninstall`
+
+Remove HashPilot and all its components from the system
+
+```
+hashpilot uninstall [options]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--keep-config` | Preserve config and telemetry data |
+| `--force` | Skip confirmation prompt (auto-detected when piped) |
+| `--dry-run` | Show what would be removed without deleting anything |
+| `--target <dir>` | Install target directory (default: ~/.agentic-tools) |
+| `--json` | Output as JSON (default: true) |
+
 #### `route`
 
 Show which edit route would be chosen (with detailed explanation)
 
 ```
-structured-edit route [options] <file> <operation>
+hashpilot route [options] <file> <operation>
 ```
 
 | Positional | Meaning |
@@ -737,7 +753,7 @@ structured-edit route [options] <file> <operation>
 Show current HashPilot configuration
 
 ```
-structured-edit config [options]
+hashpilot config [options]
 ```
 
 | Flag | Meaning |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -88,7 +88,7 @@ bash scripts/install.sh
 The installer handles all of these automatically:
 - Copies HashPilot Core to `~/.agentic-tools/structured-editing`
 - Installs dependencies via `bun install`
-- Creates the `structured-edit` CLI launcher
+- Creates the `hashpilot` CLI launcher
 - Adds `~/.agentic-tools/bin` to your PATH (via shell rc file)
 - Installs Claude Code integration (appends to `~/.claude/CLAUDE.md`)
 - Installs OpenCode skill + agent
@@ -101,7 +101,7 @@ The installer handles all of these automatically:
 After installation, verify with:
 
 ```bash
-structured-edit doctor
+hashpilot doctor
 ```
 
 This checks core files, CLI, PATH, config, and all adapter integrations.
@@ -145,82 +145,82 @@ Override priority (highest wins): `HASHPILOT_ROUTE_POLICY` env var > `--config` 
 
 View current config:
 ```bash
-structured-edit config
+hashpilot config
 ```
 
 ## Quick Start
 
 ```bash
 # Read files with hashes
-structured-edit read-many src/core/read.ts src/core/hash-edit.ts
+hashpilot read-many src/core/read.ts src/core/hash-edit.ts
 
 # Read a specific line with hash and context
-structured-edit read-hash src/core/read.ts 10
+hashpilot read-hash src/core/read.ts 10
 
 # Search across paths
-structured-edit grep-many "function\\s+\\w+" src/
+hashpilot grep-many "function\\s+\\w+" src/
 
 # Replace content using hash anchor
 # First read the hash, then replace
-HASH=$(structured-edit read-many myfile.ts | jq -r '.[0].hash')
-structured-edit replace-hash myfile.ts "$HASH" "// new content"
+HASH=$(hashpilot read-many myfile.ts | jq -r '.[0].hash')
+hashpilot replace-hash myfile.ts "$HASH" "// new content"
 
 # Replace a specific line range
-structured-edit replace-hash myfile.ts "$HASH" "new content" --range 5:10
+hashpilot replace-hash myfile.ts "$HASH" "new content" --range 5:10
 
 # Rename a symbol (TypeScript/TSX)
-structured-edit ast rename-symbol myfile.ts oldName newName
+hashpilot ast rename-symbol myfile.ts oldName newName
 
 # Replace a function body
-structured-edit ast replace-body myfile.ts myFunction "return 42;"
+hashpilot ast replace-body myfile.ts myFunction "return 42;"
 
 # Add/remove imports
-structured-edit ast add-import myfile.ts "{ Foo } from './bar'"
-structured-edit ast remove-import myfile.ts './bar'
+hashpilot ast add-import myfile.ts "{ Foo } from './bar'"
+hashpilot ast remove-import myfile.ts './bar'
 
 # Find symbols
-structured-edit ast find-symbols myfile.ts
+hashpilot ast find-symbols myfile.ts
 
 # Show supported AST languages, operations, and limitations
-structured-edit ast capabilities
+hashpilot ast capabilities
 
 # Verify changes (run formatter + linter + tests)
-structured-edit verify-changes myfile.ts --formatter prettier --linter eslint
+hashpilot verify-changes myfile.ts --formatter prettier --linter eslint
 
 # Check routing decision with detailed explanation
-structured-edit route myfile.ts rename-symbol
-structured-edit route myfile.ts add-import --policy '{"operationOverrides":{"add-import":"diff"}}'
+hashpilot route myfile.ts rename-symbol
+hashpilot route myfile.ts add-import --policy '{"operationOverrides":{"add-import":"diff"}}'
 
 # View or test policy config
-structured-edit config
+hashpilot config
 
 # View telemetry
-structured-edit telemetry summary
-structured-edit telemetry show -n 50
-structured-edit telemetry health -w 7
-structured-edit telemetry sessions
-structured-edit telemetry export --from 2026-01-01
+hashpilot telemetry summary
+hashpilot telemetry show -n 50
+hashpilot telemetry health -w 7
+hashpilot telemetry sessions
+hashpilot telemetry export --from 2026-01-01
 
 # Telemetry health with trend comparison
-structured-edit telemetry health -w 7 --trend
+hashpilot telemetry health -w 7 --trend
 
 # Generate and apply unified diffs
-structured-edit diff generate myfile.ts "$(cat old.ts)" "$(cat new.ts)"
-structured-edit diff apply myfile.ts --patch changes.patch
+hashpilot diff generate myfile.ts "$(cat old.ts)" "$(cat new.ts)"
+hashpilot diff apply myfile.ts --patch changes.patch
 
 # Batch edit across files
-structured-edit batch add-import src/*.ts --import-spec "{ z } from zod"
+hashpilot batch add-import src/*.ts --import-spec "{ z } from zod"
 
 # Route decisions and config
-structured-edit route myfile.ts add-import --policy '{"operationOverrides":{"add-import":"diff"}}'
-structured-edit config
+hashpilot route myfile.ts add-import --policy '{"operationOverrides":{"add-import":"diff"}}'
+hashpilot config
 
 # Edit history (provenance)
-structured-edit provenance query myfile.ts --human
-structured-edit provenance changeset <changeSetId> --human
+hashpilot provenance query myfile.ts --human
+hashpilot provenance changeset <changeSetId> --human
 
 # Intent-based multi-step editing
-structured-edit intent '{"operation":"add-parameter","symbol":"myFunc","param":{"name":"x"}}' --dry-run
+hashpilot intent '{"operation":"add-parameter","symbol":"myFunc","param":{"name":"x"}}' --dry-run
 ```
 
 ## Running Tests
@@ -262,7 +262,7 @@ bash scripts/uninstall.sh
 
 This removes:
 - HashPilot Core (`~/.agentic-tools/structured-editing`)
-- CLI launcher (`~/.agentic-tools/bin/structured-edit`)
+- CLI launcher (`~/.agentic-tools/bin/hashpilot`)
 - Claude integration (removes section from `~/.claude/CLAUDE.md`)
 - OpenCode skill and agent
 - Pi extension and skill
@@ -293,7 +293,7 @@ bash scripts/uninstall.sh --force
 ~/.agentic-tools/
   manifest.json             # Managed file inventory (installer writes, uninstaller reads)
   bin/
-    structured-edit         # CLI launcher (bash script)
+    hashpilot         # CLI launcher (bash script)
   structured-editing/       # Core source + dependencies
     package.json
     tsconfig.json
@@ -380,7 +380,7 @@ HashPilot maintains a manifest at `~/.agentic-tools/manifest.json`. This JSON fi
 
 ## Troubleshooting
 
-- **"command not found"**: Ensure `~/.agentic-tools/bin` is in your PATH (run `structured-edit doctor` to check)
+- **"command not found"**: Ensure `~/.agentic-tools/bin` is in your PATH (run `hashpilot doctor` to check)
 - **"Module not found"**: Run `cd ~/.agentic-tools/structured-editing && bun install`
 - **Installer fails**: Verify bun is installed (`bun --version`), check `~/.agentic-tools/` is writable
 - **Tree-sitter errors**:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -251,6 +251,15 @@ The installer detects the existing install, upgrades core files, preserves your 
 To completely remove HashPilot:
 
 ```bash
+hashpilot uninstall              # prompts for confirmation
+hashpilot uninstall --force      # skip prompt (non-interactive auto-detected)
+hashpilot uninstall --keep-config  # keep config + telemetry
+hashpilot uninstall --dry-run    # preview only
+```
+
+Or via the standalone script:
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/uninstall.sh | sh -s -- -f
 ```
 

--- a/docs/INTEGRATION-CLAUDE.md
+++ b/docs/INTEGRATION-CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Integration Pattern
 
-Claude Code can call `structured-edit` as a shell command, capturing JSON output for structured editing operations.
+Claude Code can call `hashpilot` as a shell command, capturing JSON output for structured editing operations.
 
 ## Setup
 
@@ -11,7 +11,7 @@ Add to your project's `CLAUDE.md` or `~/.claude/CLAUDE.md`:
 ```markdown
 ## HashPilot Structured Editing
 
-Use `structured-edit` for file operations instead of raw text editing when available.
+Use `hashpilot` for file operations instead of raw text editing when available.
 
 ### Routing Rules
 1. For supported AST languages (TypeScript, TSX, JavaScript, Python, Go, Rust), prefer AST commands (`ast rename-symbol`, `ast replace-body`, etc.)
@@ -20,31 +20,31 @@ Use `structured-edit` for file operations instead of raw text editing when avail
 4. Use `verify-changes` after editing to run formatter + linter + tests
 
 ### Key Commands
-- `structured-edit read-many <files>` — batch read with hashes
-- `structured-edit read-hash <file> <line>` — read line with context hash
-- `structured-edit replace-hash <file> <hash> <content> [--range start:end] [--actor] [--task-id] [--reason]` — hash-anchored edit
-- `structured-edit ast capabilities` — show supported languages and limitations
-- `structured-edit ast find-symbols <file>` — list symbols
-- `structured-edit ast rename-symbol <file> <old> <new> [--actor] [--task-id] [--reason]` — rename
-- `structured-edit ast replace-body <file> <symbol> <body> [--actor] [--task-id] [--reason]` — replace function body
-- `structured-edit ast add-import <file> <spec> [--actor] [--task-id] [--reason]` — add import
-- `structured-edit ast remove-import <file> <spec> [--actor] [--task-id] [--reason]` — remove import
-- `structured-edit ast insert-before/insert-after <file> <symbol> <content> [--actor]` — insert around a symbol
-- `structured-edit diff generate <file> <old> <new>` — generate unified diff
-- `structured-edit diff apply <file> --patch <file>` — apply unified diff patch
-- `structured-edit route <file> <op> [--policy <json>]` — detailed route explanation with policy testing
-- `structured-edit route-edit <file> <op> [options]` — auto-routed edit via AST→hash→diff
-- `structured-edit batch <op> <files...>` — apply same edit to multiple files
-- `structured-edit intent '<json>'` — intent-based multi-step editing (auto-discovers references)
-- `structured-edit config` — show current merged configuration
-- `structured-edit verify-changes <files> [--auto-detect] [--revert-on-failure]` — run formatter + linter + typecheck + tests
-- `structured-edit provenance query <file> [--human]` — edit history (like `git blame` for agent edits)
-- `structured-edit provenance changeset <id> [--human]` — show all edits in a changeSet
-- `structured-edit telemetry summary` — check usage stats
-- `structured-edit telemetry health [-w <days>] [--trend]` — health report with per-language stats and trend comparison
-- `structured-edit telemetry sessions` — list session summaries
-- `structured-edit telemetry export [--from <date>] [--to <date>]` — export events as NDJSON
-- `structured-edit telemetry prune [--older-than <days>]` — delete old rotated files
+- `hashpilot read-many <files>` — batch read with hashes
+- `hashpilot read-hash <file> <line>` — read line with context hash
+- `hashpilot replace-hash <file> <hash> <content> [--range start:end] [--actor] [--task-id] [--reason]` — hash-anchored edit
+- `hashpilot ast capabilities` — show supported languages and limitations
+- `hashpilot ast find-symbols <file>` — list symbols
+- `hashpilot ast rename-symbol <file> <old> <new> [--actor] [--task-id] [--reason]` — rename
+- `hashpilot ast replace-body <file> <symbol> <body> [--actor] [--task-id] [--reason]` — replace function body
+- `hashpilot ast add-import <file> <spec> [--actor] [--task-id] [--reason]` — add import
+- `hashpilot ast remove-import <file> <spec> [--actor] [--task-id] [--reason]` — remove import
+- `hashpilot ast insert-before/insert-after <file> <symbol> <content> [--actor]` — insert around a symbol
+- `hashpilot diff generate <file> <old> <new>` — generate unified diff
+- `hashpilot diff apply <file> --patch <file>` — apply unified diff patch
+- `hashpilot route <file> <op> [--policy <json>]` — detailed route explanation with policy testing
+- `hashpilot route-edit <file> <op> [options]` — auto-routed edit via AST→hash→diff
+- `hashpilot batch <op> <files...>` — apply same edit to multiple files
+- `hashpilot intent '<json>'` — intent-based multi-step editing (auto-discovers references)
+- `hashpilot config` — show current merged configuration
+- `hashpilot verify-changes <files> [--auto-detect] [--revert-on-failure]` — run formatter + linter + typecheck + tests
+- `hashpilot provenance query <file> [--human]` — edit history (like `git blame` for agent edits)
+- `hashpilot provenance changeset <id> [--human]` — show all edits in a changeSet
+- `hashpilot telemetry summary` — check usage stats
+- `hashpilot telemetry health [-w <days>] [--trend]` — health report with per-language stats and trend comparison
+- `hashpilot telemetry sessions` — list session summaries
+- `hashpilot telemetry export [--from <date>] [--to <date>]` — export events as NDJSON
+- `hashpilot telemetry prune [--older-than <days>]` — delete old rotated files
 
 ### Config file
 
@@ -65,31 +65,31 @@ Create `~/.config/hashpilot/config.json` or `.hashpilot.json` in your project to
 ### Edit a TypeScript function body
 ```bash
 # 1. Find the symbol
-structured-edit ast find-symbols src/utils.ts
+hashpilot ast find-symbols src/utils.ts
 # → find "formatDate" at line 15
 
 # 2. Replace its body
-structured-edit ast replace-body src/utils.ts formatDate 'return new Date(d).toISOString();'
+hashpilot ast replace-body src/utils.ts formatDate 'return new Date(d).toISOString();'
 # → success, body replaced
 
 # 3. Verify (auto-detect tools from package.json)
-structured-edit verify-changes src/utils.ts --auto-detect
+hashpilot verify-changes src/utils.ts --auto-detect
 ```
 
 ### Hash-anchored edit for a non-TS file
 ```bash
 # 1. Read file with hash
-HASH=$(structured-edit read-many config.yaml | jq -r '.[0].hash')
+HASH=$(hashpilot read-many config.yaml | jq -r '.[0].hash')
 
 # 2. Replace entire file via hash
-structured-edit replace-hash config.yaml "$HASH" "new: content\nhere: true"
+hashpilot replace-hash config.yaml "$HASH" "new: content\nhere: true"
 
 # 3. Or read a line range with hash
-structured-edit read-hash config.yaml 5 -c 2
+hashpilot read-hash config.yaml 5 -c 2
 # → get contextHash for line 5
 
 # 4. Replace a specific range
-structured-edit replace-hash config.yaml "$HASH" "  port: 8080" --range 5:6
+hashpilot replace-hash config.yaml "$HASH" "  port: 8080" --range 5:6
 ```
 
 ## When to Use HashPilot vs Direct Editing
@@ -121,6 +121,6 @@ structured-edit replace-hash config.yaml "$HASH" "  port: 8080" --range 5:6
 ## Error Recovery
 
 When `replace-hash` returns `"stale": true`:
-1. Re-read the file: `structured-edit read-many <file>`
+1. Re-read the file: `hashpilot read-many <file>`
 2. Get the new hash from the response
 3. Retry `replace-hash` with the new hash

--- a/docs/INTEGRATION-OPENCODE.md
+++ b/docs/INTEGRATION-OPENCODE.md
@@ -47,15 +47,15 @@ export PATH="$HOME/.agentic-tools/bin:$PATH"
 
 ### Inline skill usage
 
-When OpenCode detects file editing tasks, it will reference the hashpilot skill and use `structured-edit` commands directly via bash tool:
+When OpenCode detects file editing tasks, it will reference the hashpilot skill and use `hashpilot` commands directly via bash tool:
 
 ```bash
 # OpenCode agent using hash-anchored edit
-HASH=$(structured-edit read-many src/config.ts | jq -r '.[0].hash')
-structured-edit replace-hash src/config.ts "$HASH" "new content"
+HASH=$(hashpilot read-many src/config.ts | jq -r '.[0].hash')
+hashpilot replace-hash src/config.ts "$HASH" "new content"
 
 # OpenCode agent using AST edit for TypeScript
-structured-edit ast rename-symbol src/api.ts oldFunc newFunc
+hashpilot ast rename-symbol src/api.ts oldFunc newFunc
 ```
 
 ### Subagent delegation
@@ -107,30 +107,30 @@ The subagent will:
 ## Reference: Complete Command List
 
 ```
-structured-edit read-many <files...>
-structured-edit read-hash <file> <line> [-c <context>]
-structured-edit grep-many <pattern> <paths...>
-structured-edit symbol-lookup-many <paths...> --names n1,n2
-structured-edit replace-hash <file> <hash> <content> [--range s:e] [--dry-run] [--actor] [--task-id] [--reason]
-structured-edit ast find-symbols <file>
-structured-edit ast capabilities
-structured-edit ast rename-symbol <file> <old> <new> [--actor] [--task-id] [--reason]
-structured-edit ast replace-body <file> <symbol> <body> [--actor] [--task-id] [--reason]
-structured-edit ast add-import <file> '<spec>' [--actor] [--task-id] [--reason]
-structured-edit ast remove-import <file> '<spec>' [--actor] [--task-id] [--reason]
-structured-edit ast insert-before <file> <symbol> <content> [--actor] [--task-id] [--reason]
-structured-edit ast insert-after <file> <symbol> <content> [--actor] [--task-id] [--reason]
-structured-edit diff generate <file> <old> <new>
-structured-edit diff apply <file> --patch <file> [--dry-run]
-structured-edit route <file> <op> [--policy <json>]
-structured-edit route-edit <file> <op> [--method <route>] [--dry-run]
-structured-edit batch <op> <files...> [--serial] [--dry-run]
-structured-edit intent '<json>' [--project-root <dir>] [--dry-run]
-structured-edit config
-structured-edit doctor
-structured-edit verify-changes <files...> [--formatter] [--linter] [--typecheck] [--test-filter] [--auto-detect]
-structured-edit provenance query <file> [<line>] [--human]
-structured-edit provenance changeset <changeSetId> [--human]
-structured-edit telemetry [show|summary|health|clear|sessions|export|prune]
-structured-edit telemetry health [-w <days>] [--trend]
+hashpilot read-many <files...>
+hashpilot read-hash <file> <line> [-c <context>]
+hashpilot grep-many <pattern> <paths...>
+hashpilot symbol-lookup-many <paths...> --names n1,n2
+hashpilot replace-hash <file> <hash> <content> [--range s:e] [--dry-run] [--actor] [--task-id] [--reason]
+hashpilot ast find-symbols <file>
+hashpilot ast capabilities
+hashpilot ast rename-symbol <file> <old> <new> [--actor] [--task-id] [--reason]
+hashpilot ast replace-body <file> <symbol> <body> [--actor] [--task-id] [--reason]
+hashpilot ast add-import <file> '<spec>' [--actor] [--task-id] [--reason]
+hashpilot ast remove-import <file> '<spec>' [--actor] [--task-id] [--reason]
+hashpilot ast insert-before <file> <symbol> <content> [--actor] [--task-id] [--reason]
+hashpilot ast insert-after <file> <symbol> <content> [--actor] [--task-id] [--reason]
+hashpilot diff generate <file> <old> <new>
+hashpilot diff apply <file> --patch <file> [--dry-run]
+hashpilot route <file> <op> [--policy <json>]
+hashpilot route-edit <file> <op> [--method <route>] [--dry-run]
+hashpilot batch <op> <files...> [--serial] [--dry-run]
+hashpilot intent '<json>' [--project-root <dir>] [--dry-run]
+hashpilot config
+hashpilot doctor
+hashpilot verify-changes <files...> [--formatter] [--linter] [--typecheck] [--test-filter] [--auto-detect]
+hashpilot provenance query <file> [<line>] [--human]
+hashpilot provenance changeset <changeSetId> [--human]
+hashpilot telemetry [show|summary|health|clear|sessions|export|prune]
+hashpilot telemetry health [-w <days>] [--trend]
 ```

--- a/docs/INTEGRATION-PI.md
+++ b/docs/INTEGRATION-PI.md
@@ -5,7 +5,7 @@
 HashPilot integrates with Pi in two ways:
 
 1. **Native Extension** (recommended) — Custom tools registered in Pi's tool system, available in every session
-2. **CLI Mode** — Direct shell commands via `structured-edit`
+2. **CLI Mode** — Direct shell commands via `hashpilot`
 
 ## Mode 1: Native Pi Extension (Recommended)
 
@@ -35,9 +35,9 @@ The `hashpilot` skill at `~/.pi/agent/skills/hashpilot/SKILL.md` provides routin
 
 ### How It Works
 
-The extension calls `structured-edit` CLI under the hood via `pi.exec()`. Each tool:
+The extension calls `hashpilot` CLI under the hood via `pi.exec()`. Each tool:
 1. Validates parameters using TypeBox schemas
-2. Calls the appropriate `structured-edit` command
+2. Calls the appropriate `hashpilot` command
 3. Parses JSON output
 4. Returns structured results to the LLM
 
@@ -49,42 +49,42 @@ The `hashpilot_enabled` flag controls whether tools appear in Pi's Available Too
 
 ## Mode 2: CLI Direct Usage
 
-If the extension isn't loaded, Pi can call `structured-edit` directly via shell:
+If the extension isn't loaded, Pi can call `hashpilot` directly via shell:
 
 ```bash
 # Read files with hashes
-structured-edit read-many src/main.ts src/worker.ts
+hashpilot read-many src/main.ts src/worker.ts
 
 # Read a line with context
-structured-edit read-hash src/main.ts 42
+hashpilot read-hash src/main.ts 42
 
 # Hash-anchored replacement
-HASH=$(structured-edit read-many src/config.py | jq -r '.[0].hash')
-structured-edit replace-hash src/config.py "$HASH" "new content"
+HASH=$(hashpilot read-many src/config.py | jq -r '.[0].hash')
+hashpilot replace-hash src/config.py "$HASH" "new content"
 
 # AST operations (TypeScript, TSX, JavaScript, Python, Go, Rust)
-structured-edit ast find-symbols src/main.ts
-structured-edit ast rename-symbol src/main.ts oldFunc newFunc
-structured-edit ast replace-body src/main.ts myFunc 'return 42;'
-structured-edit ast add-import src/app.ts '{ Router } from express'
-structured-edit ast remove-import src/app.ts './bar'
+hashpilot ast find-symbols src/main.ts
+hashpilot ast rename-symbol src/main.ts oldFunc newFunc
+hashpilot ast replace-body src/main.ts myFunc 'return 42;'
+hashpilot ast add-import src/app.ts '{ Router } from express'
+hashpilot ast remove-import src/app.ts './bar'
 
 # Generate and apply unified diffs
-structured-edit diff generate src/main.ts "$(cat old.ts)" "$(cat new.ts)"
-structured-edit diff apply src/main.ts --patch changes.patch
+hashpilot diff generate src/main.ts "$(cat old.ts)" "$(cat new.ts)"
+hashpilot diff apply src/main.ts --patch changes.patch
 
 # Route decisions and config
-structured-edit route src/main.ts rename-symbol
-structured-edit config
+hashpilot route src/main.ts rename-symbol
+hashpilot config
 
 # Batch edit across files
-structured-edit batch add-import src/*.ts --import-spec "{ z } from zod" --dry-run
+hashpilot batch add-import src/*.ts --import-spec "{ z } from zod" --dry-run
 
 # Edit provenance
-structured-edit provenance query src/main.ts --human
+hashpilot provenance query src/main.ts --human
 
 # Verify changes (with auto-detection)
-structured-edit verify-changes src/main.ts --auto-detect
+hashpilot verify-changes src/main.ts --auto-detect
 ```
 
 ## Routing Strategy
@@ -95,15 +95,15 @@ HashPilot uses a strict priority for edit method selection:
 2. **Hash** — For hash-anchored content identification (any file type)
 3. **Diff** — Fallback for unsupported operations
 
-Check routing: `structured-edit route <file> <operation> [--policy <json>]`
+Check routing: `hashpilot route <file> <operation> [--policy <json>]`
 
 For detailed explanation with policy matches, use `--policy` to test override behavior:
 
 ```bash
-structured-edit route src/main.ts rename-symbol
+hashpilot route src/main.ts rename-symbol
 # → { route: "ast", explanation: { reasons: ["Language 'typescript' supports AST operations"], ... } }
 
-structured-edit route src/main.py rename-symbol --policy '{"languageOverrides":{"python":"hash"}}'
+hashpilot route src/main.py rename-symbol --policy '{"languageOverrides":{"python":"hash"}}'
 # → { route: "hash", explanation: { policyApplied: true, ... } }
 ```
 
@@ -129,14 +129,14 @@ Example project config (`.hashpilot.json`):
 }
 ```
 
-View current merged config: `structured-edit config`
+View current merged config: `hashpilot config`
 
 ## Stale Anchor Recovery
 
 HashPilot has **auto-recovery** for stale anchors. When the file has changed since the hash was computed, `replace-hash` auto-recovers by applying the edit to the current content and returning `"retries": 1`. This is always safe for full-file replaces.
 
 If auto-recovery fails or is disabled:
-1. Re-read the file: `structured-edit read-many <file>`
+1. Re-read the file: `hashpilot read-many <file>`
 2. Get the new hash from the response
 3. Retry `replace-hash` with the updated hash
 
@@ -147,14 +147,14 @@ The native `hashpilot_replace_hash` tool surfaces stale-anchor status in its res
 All operations are logged to `~/.agentic-tools/logs/telemetry.jsonl`.
 
 ```bash
-structured-edit telemetry summary       # Operation counts and timing
-structured-edit telemetry show -n 50    # Last 50 events
-structured-edit telemetry health -w 7   # Health report with per-language stats and warnings
-structured-edit telemetry health -w 7 --trend  # Compare to previous window
-structured-edit telemetry sessions      # List session-level summaries
-structured-edit telemetry export --from 2026-01-01  # Export events as NDJSON
-structured-edit telemetry prune --older-than 30  # Delete old rotated files
-structured-edit telemetry clear         # Clear log
+hashpilot telemetry summary       # Operation counts and timing
+hashpilot telemetry show -n 50    # Last 50 events
+hashpilot telemetry health -w 7   # Health report with per-language stats and warnings
+hashpilot telemetry health -w 7 --trend  # Compare to previous window
+hashpilot telemetry sessions      # List session-level summaries
+hashpilot telemetry export --from 2026-01-01  # Export events as NDJSON
+hashpilot telemetry prune --older-than 30  # Delete old rotated files
+hashpilot telemetry clear         # Clear log
 ```
 
 ## When to Use HashPilot Tools vs Raw Commands
@@ -187,7 +187,7 @@ structured-edit telemetry clear         # Clear log
 
 | Issue | Solution |
 |-------|----------|
-| `structured-edit: command not found` | Add `~/.agentic-tools/bin` to PATH in `~/.bashrc` |
+| `hashpilot: command not found` | Add `~/.agentic-tools/bin` to PATH in `~/.bashrc` |
 | `Module not found` errors | Run `bun install` in `~/.agentic-tools/structured-editing/` |
 | Tree-sitter errors | `bun add tree-sitter tree-sitter-typescript` in the structured-editing dir |
 | Pi extension not loading | Check `~/.pi/agent/extensions/hashpilot.ts` exists and has no syntax errors |

--- a/index.html
+++ b/index.html
@@ -531,7 +531,7 @@ body { overflow-x: hidden; }
       <img src="https://img.shields.io/badge/tests-96%25_coverage-brightgreen" alt="Tests">
     </div>
     <h1>HashPilot</h1>
-    <div class="tagline">structured-edit CLI · v1.3.1</div>
+    <div class="tagline">hashpilot CLI · v1.3.1</div>
     <p class="sub">
       <strong>AI agents edit code blind.</strong> HashPilot gives them cryptographic certainty.
       Every edit anchored by SHA-256 hash — not a line number or fuzzy text match.
@@ -707,14 +707,14 @@ body { overflow-x: hidden; }
 
   <h3 style="font-size: 1.2rem; font-weight: 600; margin-bottom: 16px; margin-top: 32px;">Your First Edit</h3>
 <pre><code># 1. Read a file — get its content hash
-<span style="color: var(--accent);">structured-edit read-many src/main.ts</span>
+<span style="color: var(--accent);">hashpilot read-many src/main.ts</span>
 
 # 2. Edit by hash — target the exact content
 HASH="abc123..."  <span style="color: var(--text-dim);"># from read-many output</span>
-<span style="color: var(--accent);">structured-edit replace-hash src/main.ts "$HASH" "  port: 8080" --range 5:5</span>
+<span style="color: var(--accent);">hashpilot replace-hash src/main.ts "$HASH" "  port: 8080" --range 5:5</span>
 
 # 3. Verify nothing broke
-<span style="color: var(--accent);">structured-edit verify-changes src/main.ts --auto-detect</span></code></pre>
+<span style="color: var(--accent);">hashpilot verify-changes src/main.ts --auto-detect</span></code></pre>
 </div>
 </section>
 
@@ -809,7 +809,7 @@ HASH="abc123..."  <span style="color: var(--text-dim);"># from read-many output<
   <div class="feature-grid integrations-grid">
     <div class="feature-card">
       <h3>Claude Code</h3>
-      <p>HashPilot section injected into <code style="font-size: 0.8rem;">~/.claude/CLAUDE.md</code>. Claude uses <code style="font-size: 0.8rem;">structured-edit</code> commands as shell tools.</p>
+      <p>HashPilot section injected into <code style="font-size: 0.8rem;">~/.claude/CLAUDE.md</code>. Claude uses <code style="font-size: 0.8rem;">hashpilot</code> commands as shell tools.</p>
     </div>
     <div class="feature-card">
       <h3>OpenCode</h3>

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "bun": ">=1.2.0"
   },
   "bin": {
-    "structured-edit": "./src/cli-node.cjs"
+    "hashpilot": "./src/cli-node.cjs"
   },
   "scripts": {
     "test": "bun test",
     "build": "bun build src/cli.ts --outdir dist --target bun",
-    "install-cli": "mkdir -p ~/.agentic-tools/bin && ln -sf $(pwd)/src/cli-node.cjs ~/.agentic-tools/bin/structured-edit",
+    "install-cli": "mkdir -p ~/.agentic-tools/bin && ln -sf $(pwd)/src/cli-node.cjs ~/.agentic-tools/bin/hashpilot",
     "semantic-release": "semantic-release",
     "gen:cli-quickref": "bun run scripts/gen-cli-quickref.ts",
     "gen:cli-quickref:check": "bun run scripts/gen-cli-quickref.ts --check",

--- a/schema/hashpilot-envelope.schema.json
+++ b/schema/hashpilot-envelope.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/bigknoxy/HashPilot/schema/hashpilot-envelope.schema.json",
   "title": "HashPilot CLI envelope",
-  "description": "The single JSON shape every structured-edit command writes to stdout.",
+  "description": "The single JSON shape every hashpilot command writes to stdout.",
   "type": "object",
   "required": ["apiVersion", "ok", "command", "data", "error", "warnings"],
   "additionalProperties": false,

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -56,30 +56,30 @@ else
 fi
 
 # 4. CLI launcher
-if [[ -x "$TARGET_DIR/bin/structured-edit" ]]; then
-  pass "cli-launcher" "Found: $TARGET_DIR/bin/structured-edit"
+if [[ -x "$TARGET_DIR/bin/hashpilot" ]]; then
+  pass "cli-launcher" "Found: $TARGET_DIR/bin/hashpilot"
 else
-  fail "cli-launcher" "Missing: $TARGET_DIR/bin/structured-edit"
+  fail "cli-launcher" "Missing: $TARGET_DIR/bin/hashpilot"
 fi
 
 # 5. CLI on PATH
-if command -v structured-edit &>/dev/null; then
-  CLI_PATH=$(command -v structured-edit)
+if command -v hashpilot &>/dev/null; then
+  CLI_PATH=$(command -v hashpilot)
   pass "cli-on-path" "Found at: $CLI_PATH"
 else
-  warn "cli-on-path" "structured-edit not on PATH — add $TARGET_DIR/bin to PATH"
+  warn "cli-on-path" "hashpilot not on PATH — add $TARGET_DIR/bin to PATH"
 fi
 
 # 6. CLI executable
-if command -v structured-edit &>/dev/null; then
-  VER=$(structured-edit --version 2>/dev/null || echo "error")
+if command -v hashpilot &>/dev/null; then
+  VER=$(hashpilot --version 2>/dev/null || echo "error")
   if [[ "$VER" != "error" ]]; then
     pass "cli-executable" "CLI works: $VER"
   else
     fail "cli-executable" "CLI failed to run"
   fi
-elif [[ -x "$TARGET_DIR/bin/structured-edit" ]]; then
-  VER=$("$TARGET_DIR/bin/structured-edit" --version 2>/dev/null || echo "error")
+elif [[ -x "$TARGET_DIR/bin/hashpilot" ]]; then
+  VER=$("$TARGET_DIR/bin/hashpilot" --version 2>/dev/null || echo "error")
   if [[ "$VER" != "error" ]]; then
     pass "cli-executable" "CLI works: $VER"
   else

--- a/scripts/gen-cli-quickref.ts
+++ b/scripts/gen-cli-quickref.ts
@@ -156,7 +156,7 @@ export function render(docs: CommandDoc[]): string {
   if (root) {
     out.push("### Global options");
     out.push("");
-    out.push("Accepted before the subcommand, e.g. `structured-edit --allowed-root /srv/app read-many f.ts`.");
+    out.push("Accepted before the subcommand, e.g. `hashpilot --allowed-root /srv/app read-many f.ts`.");
     out.push("");
     out.push("```");
     out.push(root.usage);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -193,6 +193,12 @@ LAUNCHER
 chmod +x "$TARGET_DIR/bin/hashpilot"
 detail "Launcher created at $TARGET_DIR/bin/hashpilot"
 
+# Remove stale symlink from the old binary name (pre-3.1 installs).
+if [ -L "$TARGET_DIR/bin/structured-edit" ]; then
+  rm -f "$TARGET_DIR/bin/structured-edit"
+  detail "Removed stale symlink: $TARGET_DIR/bin/structured-edit"
+fi
+
 # ── Configure PATH ───────────────────────────────────────────────────────
 log "Adding PATH entry..."
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -186,12 +186,12 @@ detail "Dependencies installed"
 # ── Create CLI launcher ──────────────────────────────────────────────────
 log "Creating CLI launcher..."
 mkdir -p "$TARGET_DIR/bin"
-cat > "$TARGET_DIR/bin/structured-edit" << 'LAUNCHER'
+cat > "$TARGET_DIR/bin/hashpilot" << 'LAUNCHER'
 #!/bin/bash
 exec bun run "$HOME/.agentic-tools/structured-editing/src/cli.ts" "$@"
 LAUNCHER
-chmod +x "$TARGET_DIR/bin/structured-edit"
-detail "Launcher created at $TARGET_DIR/bin/structured-edit"
+chmod +x "$TARGET_DIR/bin/hashpilot"
+detail "Launcher created at $TARGET_DIR/bin/hashpilot"
 
 # ── Configure PATH ───────────────────────────────────────────────────────
 log "Adding PATH entry..."
@@ -346,7 +346,7 @@ cat > "$MANIFEST_FILE" << MANIFEST
       "source": "${TARGET_DIR}/structured-editing"
     },
     "bin": [
-      "${TARGET_DIR}/bin/structured-edit"
+      "${TARGET_DIR}/bin/hashpilot"
     ],
     "config": [
       "${CONFIG_FILE}"
@@ -381,7 +381,7 @@ fi
 
 # ── Verify ───────────────────────────────────────────────────────────────
 log "Verifying installation..."
-if [ -f "$TARGET_DIR/bin/structured-edit" ]; then
+if [ -f "$TARGET_DIR/bin/hashpilot" ]; then
   detail "CLI launcher: OK"
 else
   err "CLI launcher missing!"
@@ -396,8 +396,8 @@ else
 fi
 
 # Quick smoke test
-if command -v structured-edit &>/dev/null || [ -x "$TARGET_DIR/bin/structured-edit" ]; then
-  VER=$("$TARGET_DIR/bin/structured-edit" --version 2>/dev/null || echo "unknown")
+if command -v hashpilot &>/dev/null || [ -x "$TARGET_DIR/bin/hashpilot" ]; then
+  VER=$("$TARGET_DIR/bin/hashpilot" --version 2>/dev/null || echo "unknown")
   detail "CLI version: ${VER}"
 fi
 
@@ -407,10 +407,10 @@ printf "${GREEN} HashPilot v${HASHPILOT_VERSION} installed successfully${NC}\n"
 printf "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
 echo ""
 echo "  Core:     $TARGET_DIR/structured-editing"
-echo "  CLI:      structured-edit"
+echo "  CLI:      hashpilot"
 echo "  Config:   ${CONFIG_FILE}"
 echo "  Manifest: $MANIFEST_FILE"
 echo ""
-echo "  Run 'structured-edit doctor' to verify the installation."
+echo "  Run 'hashpilot doctor' to verify the installation."
 echo "  Restart your shell or run: source $RC_FILE"
 echo ""

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -139,6 +139,8 @@ rmdir "${HOME}/.pi/agent/skills" 2>/dev/null || true
 # ── Core, bin, telemetry ─────────────────────────────────────────────────
 log "Removing Core files..."
 remove_file "$TARGET_DIR/bin/hashpilot" "CLI launcher"
+# Also remove stale symlink from old binary name (pre-3.1 installs).
+remove_file "$TARGET_DIR/bin/structured-edit" "stale CLI launcher (old name)"
 rmdir "$TARGET_DIR/bin" 2>/dev/null || true
 
 if [[ "$KEEP_CONFIG" == "true" ]]; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -138,7 +138,7 @@ rmdir "${HOME}/.pi/agent/skills" 2>/dev/null || true
 
 # ── Core, bin, telemetry ─────────────────────────────────────────────────
 log "Removing Core files..."
-remove_file "$TARGET_DIR/bin/structured-edit" "CLI launcher"
+remove_file "$TARGET_DIR/bin/hashpilot" "CLI launcher"
 rmdir "$TARGET_DIR/bin" 2>/dev/null || true
 
 if [[ "$KEEP_CONFIG" == "true" ]]; then

--- a/src/cli-node.cjs
+++ b/src/cli-node.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Node-parseable entry point for the `structured-edit` binary.
+// Node-parseable entry point for the `hashpilot` binary.
 //
 // HashPilot runs on Bun (src/cli.ts has a `#!/usr/bin/env bun` shebang and uses
 // Bun-only APIs). Pointing `bin` straight at the TypeScript source means
@@ -26,7 +26,7 @@ var res = spawnSync("bun", ["run", CLI].concat(process.argv.slice(2)), {
 
 if (res.error && res.error.code === "ENOENT") {
   process.stderr.write(
-    "structured-edit requires Bun (>= 1.2.0), which was not found on your PATH.\n" +
+    "hashpilot requires Bun (>= 1.2.0), which was not found on your PATH.\n" +
       "\n" +
       "  Install it:  curl -fsSL https://bun.sh/install | bash\n" +
       "  Then reopen your shell and re-run this command.\n" +
@@ -37,7 +37,7 @@ if (res.error && res.error.code === "ENOENT") {
 }
 
 if (res.error) {
-  process.stderr.write("structured-edit: failed to launch Bun: " + res.error.message + "\n");
+  process.stderr.write("hashpilot: failed to launch Bun: " + res.error.message + "\n");
   process.exit(70);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { Command } from "commander";
 // time, so dist/ carries the real version instead of a hardcoded literal.
 import pkg from "../package.json" with { type: "json" };
 import { join } from "path";
-import { writeFileSync, rmSync } from "fs";
+import { writeFileSync, rmSync, existsSync } from "fs";
 import {
   readMany,
   readHash,
@@ -105,7 +105,7 @@ function parseIntFlag(raw: string | undefined, name: string, fallback: number): 
 }
 
 program
-  .name("structured-edit")
+  .name("hashpilot")
   .description("HashPilot — Structured Editing Core for Coding Agents")
   .version(VERSION)
   .option("--allow-outside-root", "Permit writes outside the project root (credentials and system paths stay blocked)")
@@ -915,7 +915,7 @@ provCmd
           errorCode: ErrorCode.FILE_NOT_FOUND,
           changeSetId,
           message: `No edits found for changeSet: ${changeSetId}`,
-          recovery: "structured-edit telemetry sessions",
+          recovery: "hashpilot telemetry sessions",
         },
         ExitCode.USAGE,
       );
@@ -958,7 +958,7 @@ program
         opts.last
           ? "No changeSets have been recorded yet."
           : "Provide a changeSet ID, or pass --last.",
-        { recovery: "structured-edit changesets" },
+        { recovery: "hashpilot changesets" },
       );
     }
     // The undo's own write must not be snapshotted as a new changeSet — that
@@ -1057,6 +1057,102 @@ program
   });
 
 program
+  .command("uninstall")
+  .description("Remove HashPilot and all its components from the system")
+  .option("--keep-config", "Preserve config and telemetry data")
+  .option("--force", "Skip confirmation prompt (auto-detected when piped)")
+  .option("--dry-run", "Show what would be removed without deleting anything")
+  .option("--target <dir>", "Install target directory (default: ~/.agentic-tools)")
+  .option("--json", "Output as JSON", true)
+  .action(async (opts) => {
+    const targetDir = opts.target || join(process.env.HOME || "/root", ".agentic-tools");
+
+    if (opts.dryRun) {
+      const components: string[] = [];
+      if (existsSync(join(targetDir, "bin", "hashpilot"))) components.push(`CLI launcher: ${targetDir}/bin/hashpilot`);
+      if (existsSync(join(targetDir, "structured-editing"))) components.push(`Core source: ${targetDir}/structured-editing`);
+      if (existsSync(join(targetDir, "logs"))) components.push(`Telemetry logs: ${targetDir}/logs`);
+      if (existsSync(join(targetDir, "manifest.json"))) components.push(`Manifest: ${targetDir}/manifest.json`);
+      if (existsSync(join(process.env.HOME || "/root", ".config", "hashpilot", "config.json")))
+        components.push("Config: ~/.config/hashpilot/config.json");
+      if (existsSync(join(process.env.HOME || "/root", ".claude", "CLAUDE.md")))
+        components.push("Claude integration: ~/.claude/CLAUDE.md (section removal)");
+      if (existsSync(join(process.env.HOME || "/root", ".config", "opencode", "skills", "hashpilot", "SKILL.md")))
+        components.push("OpenCode skill: ~/.config/opencode/skills/hashpilot/SKILL.md");
+      if (existsSync(join(process.env.HOME || "/root", ".config", "opencode", "agent", "hashpilot.md")))
+        components.push("OpenCode agent: ~/.config/opencode/agent/hashpilot.md");
+      if (existsSync(join(process.env.HOME || "/root", ".pi", "agent", "extensions", "hashpilot.ts")))
+        components.push("Pi extension: ~/.pi/agent/extensions/hashpilot.ts");
+      if (existsSync(join(process.env.HOME || "/root", ".pi", "agent", "skills", "hashpilot", "SKILL.md")))
+        components.push("Pi skill: ~/.pi/agent/skills/hashpilot/SKILL.md");
+      finish({
+        success: true,
+        dryRun: true,
+        keepConfig: Boolean(opts.keepConfig),
+        targetDir,
+        components: components.length > 0 ? components : ["Nothing to remove — no HashPilot installation detected."],
+      });
+      return;
+    }
+
+    const uninstallUrl = `https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/uninstall.sh`;
+    console.error(`Uninstalling HashPilot from ${targetDir}...`);
+
+    if (!opts.force && process.stdin.isTTY) {
+      console.error("This will remove HashPilot and all its components.");
+      console.error(`  Target: ${targetDir}`);
+      console.error(`  Keep config: ${Boolean(opts.keepConfig)}`);
+      console.error("  Pass --force to skip this prompt.");
+    }
+
+    try {
+      const response = await fetch(uninstallUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to download uninstall script: ${response.status} ${response.statusText}`);
+      }
+      const script = await response.text();
+
+      const tmpScript = join(targetDir, `.hashpilot-uninstall-${Date.now()}.sh`);
+      writeFileSync(tmpScript, script, { mode: 0o755 });
+
+      const args: string[] = [];
+      if (opts.target) args.push("--target", opts.target);
+      if (opts.keepConfig) args.push("--keep-config");
+      if (opts.force || !process.stdin.isTTY) args.push("--force");
+
+      const proc = Bun.spawn(["bash", tmpScript, ...args], {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          HASHPILOT_DIR: targetDir,
+          PATH: `${join(targetDir, "bin")}:${process.env.PATH || ""}`,
+        },
+      });
+
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+
+      try { rmSync(tmpScript); } catch {}
+
+      if (stdout) console.error(stdout.trim());
+      if (stderr) console.error(stderr.trim());
+
+      if (exitCode !== 0) {
+        finish({ success: false, error: `Uninstall failed with exit code ${exitCode}` }, ExitCode.INTERNAL);
+        return;
+      }
+
+      finish({ success: true, message: "HashPilot uninstalled successfully" });
+      console.error("Uninstall completed successfully");
+    } catch (e: any) {
+      finish({ success: false, error: e.message }, ExitCode.INTERNAL);
+      console.error(`Uninstall failed: ${e.message}`);
+    }
+  });
+
+program
   .command("route")
   .description("Show which edit route would be chosen (with detailed explanation)")
   .argument("<file>", "File path")
@@ -1109,7 +1205,7 @@ function reportInternalError(err: unknown): void {
         errorCode: ErrorCode.READ_FAILED,
         path: err.file,
         message,
-        recovery: "Check that the telemetry log is readable, or run `structured-edit telemetry clear`.",
+        recovery: "Check that the telemetry log is readable, or run `hashpilot telemetry clear`.",
       },
       ExitCode.IO,
     );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { Command } from "commander";
 // time, so dist/ carries the real version instead of a hardcoded literal.
 import pkg from "../package.json" with { type: "json" };
 import { join } from "path";
-import { writeFileSync, rmSync, existsSync } from "fs";
+import { writeFileSync, rmSync, existsSync, mkdirSync } from "fs";
 import {
   readMany,
   readHash,
@@ -1069,12 +1069,13 @@ program
 
     if (opts.dryRun) {
       const components: string[] = [];
+      const keep = Boolean(opts.keepConfig);
+      const kept = (label: string) => keep ? `${label} [preserved by --keep-config]` : label;
       if (existsSync(join(targetDir, "bin", "hashpilot"))) components.push(`CLI launcher: ${targetDir}/bin/hashpilot`);
       if (existsSync(join(targetDir, "structured-editing"))) components.push(`Core source: ${targetDir}/structured-editing`);
-      if (existsSync(join(targetDir, "logs"))) components.push(`Telemetry logs: ${targetDir}/logs`);
+      components.push(kept(`Telemetry logs: ${targetDir}/logs`));
       if (existsSync(join(targetDir, "manifest.json"))) components.push(`Manifest: ${targetDir}/manifest.json`);
-      if (existsSync(join(process.env.HOME || "/root", ".config", "hashpilot", "config.json")))
-        components.push("Config: ~/.config/hashpilot/config.json");
+      components.push(kept("Config: ~/.config/hashpilot/config.json"));
       if (existsSync(join(process.env.HOME || "/root", ".claude", "CLAUDE.md")))
         components.push("Claude integration: ~/.claude/CLAUDE.md (section removal)");
       if (existsSync(join(process.env.HOME || "/root", ".config", "opencode", "skills", "hashpilot", "SKILL.md")))
@@ -1113,6 +1114,7 @@ program
       const script = await response.text();
 
       const tmpScript = join(targetDir, `.hashpilot-uninstall-${Date.now()}.sh`);
+      try { mkdirSync(join(targetDir), { recursive: true }); } catch {}
       writeFileSync(tmpScript, script, { mode: 0o755 });
 
       const args: string[] = [];

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -6,7 +6,7 @@ const HOME = process.env.HOME || "/root";
 const AGENTIC_TOOLS = join(HOME, ".agentic-tools");
 const CORE_DIR = join(AGENTIC_TOOLS, "structured-editing");
 const BIN_DIR = join(AGENTIC_TOOLS, "bin");
-const CLI_LAUNCHER = join(BIN_DIR, "structured-edit");
+const CLI_LAUNCHER = join(BIN_DIR, "hashpilot");
 const LOG_DIR = join(AGENTIC_TOOLS, "logs");
 const MANIFEST = join(AGENTIC_TOOLS, "manifest.json");
 const CONFIG_DIR = join(HOME, ".config", "hashpilot");
@@ -105,7 +105,7 @@ export function doctor(): DoctorReport {
 
 function checkCLIExecutable(): DoctorCheck {
   try {
-    const proc = Bun.spawnSync(["structured-edit", "--version"], {
+    const proc = Bun.spawnSync(["hashpilot", "--version"], {
       env: { ...process.env, PATH: `${BIN_DIR}:${process.env.PATH || ""}` },
     });
     if (proc.exitCode === 0) {

--- a/src/core/hash-edit.ts
+++ b/src/core/hash-edit.ts
@@ -293,7 +293,7 @@ async function applyReplacement(
           message:
             `Edit was discarded: the result does not parse (syntax error at line ${after.line}:${after.column} — ${after.nodeType}). ` +
             `The file parsed cleanly before, so this replacement would have corrupted it.`,
-          recovery: `structured-edit read-hash ${filePath} ${after.line} — re-read around the break, or pass --allow-parse-errors to write anyway.`,
+          recovery: `hashpilot read-hash ${filePath} ${after.line} — re-read around the break, or pass --allow-parse-errors to write anyway.`,
         };
       }
     }

--- a/templates/claude-section.md
+++ b/templates/claude-section.md
@@ -4,32 +4,32 @@
 curl -fsSL https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/install.sh | bash
 ```
 
-This installs the `structured-edit` CLI and injects the sections below into `~/.claude/CLAUDE.md`.
+This installs the `hashpilot` CLI and injects the sections below into `~/.claude/CLAUDE.md`.
 
 ---
 
 ## HashPilot Claude — Structured Editing Integration
 
 This session has HashPilot Claude active at user scope.
-HashPilot Core (`structured-edit`) is available on PATH.
+HashPilot Core (`hashpilot`) is available on PATH.
 
 **Use HashPilot when:** editing existing files, renaming symbols, replacing function bodies, managing imports, batch reading, or verifying changes.
 
 **Skip HashPilot when:** creating new files, deleting files, moving/renaming files, simple one-off edits, or file system operations — use direct commands instead.
 
 Edit hierarchy (prefer top first):
-1. **`structured-edit ast <subcommand>`** — syntax-aware structured edit (best)
-2. **`structured-edit replace-hash`** — hash-anchored content replacement (safe)
+1. **`hashpilot ast <subcommand>`** — syntax-aware structured edit (best)
+2. **`hashpilot replace-hash`** — hash-anchored content replacement (safe)
 3. **Direct Edit/Write** — fallback only
 
 Batched operations (use these over single-file tools when practical):
-- `/hashpilot-read <paths>` — batched file reads via structured-edit read-many
-- `/hashpilot-search <pattern>` — batched search via structured-edit grep-many
-- `/hashpilot-verify [files]` — bundled verification via structured-edit verify-changes
+- `/hashpilot-read <paths>` — batched file reads via hashpilot read-many
+- `/hashpilot-search <pattern>` — batched search via hashpilot grep-many
+- `/hashpilot-verify [files]` — bundled verification via hashpilot verify-changes
 
 Route introspection and config:
-- `structured-edit route <file> <op> [--policy <json>]` — detailed route explanation with policy testing
-- `structured-edit config` — show current merged configuration
+- `hashpilot route <file> <op> [--policy <json>]` — detailed route explanation with policy testing
+- `hashpilot config` — show current merged configuration
 
 Output shape (all commands, apiVersion 1):
 `{ apiVersion, ok, command, data, error, warnings }` — the per-command payload is under

--- a/templates/opencode-agent.md
+++ b/templates/opencode-agent.md
@@ -21,7 +21,7 @@ permissions:
   bash: allow
 ---
 
-You are the HashPilot editing agent. Make precise, minimal file edits using structured-edit commands. Never guess line numbers.
+You are the HashPilot editing agent. Make precise, minimal file edits using hashpilot commands. Never guess line numbers.
 
 ## When to use this agent (delegate here)
 

--- a/templates/opencode-skill.md
+++ b/templates/opencode-skill.md
@@ -11,7 +11,7 @@ description: HashPilot structured editing core for coding agents. Provides hash-
 curl -fsSL https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/install.sh | bash
 ```
 
-This installs the `structured-edit` CLI and registers the OpenCode skill + subagent.
+This installs the `hashpilot` CLI and registers the OpenCode skill + subagent.
 
 ---
 
@@ -27,7 +27,7 @@ HashPilot is a global, tool-agnostic structured editing system that improves cod
 
 ## When NOT to Use This Skill
 
-- **Creating new files**: Use direct write/edit instead (structured-edit edits existing files)
+- **Creating new files**: Use direct write/edit instead (hashpilot edits existing files)
 - **Deleting files/directories**: Use raw bash (`rm`, `rmdir`)
 - **Renaming/moving files**: Use raw bash (`mv`, `git mv`)
 - **Simple single-line edits in non-critical files**: Direct edit is cheaper and just as safe
@@ -36,11 +36,11 @@ HashPilot is a global, tool-agnostic structured editing system that improves cod
 
 ## Prerequisites
 
-HashPilot must be installed at `~/.agentic-tools/structured-editing/` with the CLI at `~/.agentic-tools/bin/structured-edit`.
+HashPilot must be installed at `~/.agentic-tools/structured-editing/` with the CLI at `~/.agentic-tools/bin/hashpilot`.
 
 Verify installation:
 ```bash
-structured-edit --version
+hashpilot --version
 ```
 
 If not installed, see `~/.agentic-tools/structured-editing/docs/INSTALL.md`.
@@ -53,14 +53,14 @@ Always prefer the highest-confidence route:
 2. **Hash route** — For all other edits where you have a content hash
 3. **Diff route** — Fallback for unsupported operations
 
-Check routing: `structured-edit route <file> <operation>`
+Check routing: `hashpilot route <file> <operation>`
 
 ## Core Commands
 
 ### read-many — Batch read files with hashes
 
 ```bash
-structured-edit read-many <file1> [file2] ...
+hashpilot read-many <file1> [file2] ...
 ```
 
 Returns the standard envelope; `data` is an array of `{ path, content, hash, lines }`.
@@ -70,7 +70,7 @@ Store `hash` for subsequent `replace-hash` calls.
 
 ```bash
 # Read multiple files
-result=$(structured-edit read-many src/api.ts src/utils.ts src/config.ts)
+result=$(hashpilot read-many src/api.ts src/utils.ts src/config.ts)
 # Extract hash for later editing
 hash=$(echo "$result" | jq -r '.data[] | select(.path | contains("api.ts")) | .hash')
 ```
@@ -78,7 +78,7 @@ hash=$(echo "$result" | jq -r '.data[] | select(.path | contains("api.ts")) | .h
 ### read-hash — Read line with context hash
 
 ```bash
-structured-edit read-hash <file> <line-number> [-c <context-lines>]
+hashpilot read-hash <file> <line-number> [-c <context-lines>]
 ```
 
 Returns `lineHash`, `contextHash`, `contextBefore`, `contextAfter`. Use `contextHash` for anchoring edits to specific line ranges.
@@ -86,19 +86,19 @@ Returns `lineHash`, `contextHash`, `contextBefore`, `contextAfter`. Use `context
 ### grep-many — Search across paths
 
 ```bash
-structured-edit grep-many <pattern> <paths...> [-i] [--file-pattern <glob>] [--max-results <n>]
+hashpilot grep-many <pattern> <paths...> [-i] [--file-pattern <glob>] [--max-results <n>]
 ```
 
 ### symbol-lookup-many — Find symbol definitions
 
 ```bash
-structured-edit symbol-lookup-many <paths...> --names name1,name2
+hashpilot symbol-lookup-many <paths...> --names name1,name2
 ```
 
 ### replace-hash — Hash-anchored content replacement
 
 ```bash
-structured-edit replace-hash <file> <old-hash> <new-content> [--range start:end] [--dry-run]
+hashpilot replace-hash <file> <old-hash> <new-content> [--range start:end] [--dry-run]
 ```
 
 **Critical**: If result shows `"stale": true`, the file changed since the hash was computed. Re-read the file and retry with the new hash.
@@ -112,7 +112,7 @@ structured-edit replace-hash <file> <old-hash> <new-content> [--range start:end]
 ### find-symbols — List all symbols
 
 ```bash
-structured-edit ast find-symbols <file>
+hashpilot ast find-symbols <file>
 ```
 
 Returns array of `{name, kind, startRow, endRow, startCol, endCol}`.
@@ -120,13 +120,13 @@ Returns array of `{name, kind, startRow, endRow, startCol, endCol}`.
 ### rename-symbol — Rename all references
 
 ```bash
-structured-edit ast rename-symbol <file> <old-name> <new-name> [--dry-run]
+hashpilot ast rename-symbol <file> <old-name> <new-name> [--dry-run]
 ```
 
 ### replace-body — Replace function/method body
 
 ```bash
-structured-edit ast replace-body <file> <symbol-name> <new-body> [--dry-run]
+hashpilot ast replace-body <file> <symbol-name> <new-body> [--dry-run]
 ```
 
 Body can be `@filepath` to read from a file.
@@ -134,30 +134,30 @@ Body can be `@filepath` to read from a file.
 ### add-import — Add import statement
 
 ```bash
-structured-edit ast add-import <file> '<import-spec>' [--dry-run]
+hashpilot ast add-import <file> '<import-spec>' [--dry-run]
 ```
 
 Examples:
-- `structured-edit ast add-import src/app.ts '{ Router } from express'`
-- `structured-edit ast add-import src/app.ts '* as React from react'`
+- `hashpilot ast add-import src/app.ts '{ Router } from express'`
+- `hashpilot ast add-import src/app.ts '* as React from react'`
 
 ### remove-import — Remove import line
 
 ```bash
-structured-edit ast remove-import <file> '<import-spec>' [--dry-run]
+hashpilot ast remove-import <file> '<import-spec>' [--dry-run]
 ```
 
 ### insert-before / insert-after — Insert content relative to a symbol
 
 ```bash
-structured-edit ast insert-before <file> <symbol-name> <content> [--dry-run]
-structured-edit ast insert-after <file> <symbol-name> <content> [--dry-run]
+hashpilot ast insert-before <file> <symbol-name> <content> [--dry-run]
+hashpilot ast insert-after <file> <symbol-name> <content> [--dry-run]
 ```
 
 ## verify-changes — Bundle formatter + linter + tests
 
 ```bash
-structured-edit verify-changes <files...> [--formatter <cmd>] [--linter <cmd>] [--test-filter <pattern>]
+hashpilot verify-changes <files...> [--formatter <cmd>] [--linter <cmd>] [--test-filter <pattern>]
 ```
 
 Returns `{overall: "pass"|"fail"|"partial", formatter, linter, tests, fileHashes}`.
@@ -165,9 +165,9 @@ Returns `{overall: "pass"|"fail"|"partial", formatter, linter, tests, fileHashes
 ## Telemetry
 
 ```bash
-structured-edit telemetry show [-n <limit>]
-structured-edit telemetry summary
-structured-edit telemetry clear
+hashpilot telemetry show [-n <limit>]
+hashpilot telemetry summary
+hashpilot telemetry clear
 ```
 
 ## Workflow Patterns
@@ -176,21 +176,21 @@ structured-edit telemetry clear
 
 ```bash
 # 1. Find the symbol
-structured-edit ast find-symbols src/api.ts
+hashpilot ast find-symbols src/api.ts
 # 2. Rename
-structured-edit ast rename-symbol src/api.ts oldName newName
+hashpilot ast rename-symbol src/api.ts oldName newName
 # 3. Verify
-structured-edit verify-changes src/api.ts --formatter prettier --linter eslint
+hashpilot verify-changes src/api.ts --formatter prettier --linter eslint
 ```
 
 ### Pattern 2: Hash-anchored edit (any file)
 
 ```bash
 # 1. Read file with hash
-data=$(structured-edit read-many config.yaml)
+data=$(hashpilot read-many config.yaml)
 hash=$(echo "$data" | jq -r '.[0].hash')
 # 2. Edit with hash anchor
-structured-edit replace-hash config.yaml "$hash" "new: content"
+hashpilot replace-hash config.yaml "$hash" "new: content"
 # 3. On stale hash: re-read and retry
 ```
 
@@ -198,10 +198,10 @@ structured-edit replace-hash config.yaml "$hash" "new: content"
 
 ```bash
 # 1. Batch read
-structured-edit read-many src/a.ts src/b.ts src/c.ts
+hashpilot read-many src/a.ts src/b.ts src/c.ts
 # 2. Extract hash for target file
 # 3. Replace targeted range
-structured-edit replace-hash src/b.ts "$hash" "replacement content" --range 10:15
+hashpilot replace-hash src/b.ts "$hash" "replacement content" --range 10:15
 ```
 
 ## Error Recovery

--- a/templates/pi-extension.ts
+++ b/templates/pi-extension.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
 import { Type } from "@sinclair/typebox"
 
-const STRUCTURED_EDIT = "structured-edit"
+const HASHPILOT_BIN = "hashpilot"
 
 const MAX_BYTES = 50 * 1024
 
@@ -11,7 +11,7 @@ function truncate(value: string): string {
 }
 
 async function runSE(args: string[], pi: ExtensionAPI, signal: AbortSignal, cwd?: string): Promise<{ exitCode: number; output: string }> {
-  const result = await pi.exec(STRUCTURED_EDIT, args, { cwd, signal })
+  const result = await pi.exec(HASHPILOT_BIN, args, { cwd, signal })
   const output = result.stdout || result.stderr || ""
   return { exitCode: result.code, output: truncate(output) }
 }
@@ -37,7 +37,7 @@ export default function (pi: ExtensionAPI) {
       return {
         isError: exitCode !== 0,
         content: [{ type: "text", text: output || "(no output)" }],
-        details: { exitCode, command: `${STRUCTURED_EDIT} ${args.join(" ")}` },
+        details: { exitCode, command: `${HASHPILOT_BIN} ${args.join(" ")}` },
       }
     },
   })
@@ -68,7 +68,7 @@ export default function (pi: ExtensionAPI) {
       return {
         isError: exitCode !== 0,
         content: [{ type: "text", text: output || "(no output)" }],
-        details: { exitCode, command: `${STRUCTURED_EDIT} ${args.join(" ")}` },
+        details: { exitCode, command: `${HASHPILOT_BIN} ${args.join(" ")}` },
       }
     },
   })
@@ -267,14 +267,14 @@ export default function (pi: ExtensionAPI) {
     async handler(args, _ctx) {
       const parts = (args || "").trim().split(/\s+/)
       if (parts[0] === "route" && parts[1] && parts[2]) {
-        const proc = await pi.exec(STRUCTURED_EDIT, ["route", parts[1], parts[2]], {})
+        const proc = await pi.exec(HASHPILOT_BIN, ["route", parts[1], parts[2]], {})
         return proc.stdout || proc.stderr || "(no output)"
       }
       if (parts[0] === "telemetry") {
-        const proc = await pi.exec(STRUCTURED_EDIT, ["telemetry", "summary"], {})
+        const proc = await pi.exec(HASHPILOT_BIN, ["telemetry", "summary"], {})
         return proc.stdout || proc.stderr || "(no output)"
       }
-      const proc = await pi.exec(STRUCTURED_EDIT, ["--version"], {})
+      const proc = await pi.exec(HASHPILOT_BIN, ["--version"], {})
       return `HashPilot v${proc.stdout?.trim() || "unknown"}\n\nCommands: route <file> <op> | telemetry`
     },
   })

--- a/templates/pi-skill.md
+++ b/templates/pi-skill.md
@@ -11,7 +11,7 @@ description: HashPilot structured editing — prefers AST edits for TypeScript, 
 curl -fsSL https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/install.sh | bash
 ```
 
-This installs the `structured-edit` CLI and registers the Pi extension with `/hp` slash command.
+This installs the `hashpilot` CLI and registers the Pi extension with `/hp` slash command.
 
 ---
 

--- a/tests/cli-contract.test.ts
+++ b/tests/cli-contract.test.ts
@@ -156,7 +156,7 @@ describe("docs/CLI-QUICKREF.md", () => {
       .filter((c): c is string => Boolean(c) && c !== "help");
     expect(commands.length).toBeGreaterThan(10);
     for (const cmd of commands) {
-      expect(doc).toContain(`structured-edit ${cmd}`);
+      expect(doc).toContain(`hashpilot ${cmd}`);
     }
   });
 

--- a/tests/envelope.test.ts
+++ b/tests/envelope.test.ts
@@ -98,6 +98,7 @@ const INVOCATIONS: Array<[name: string, args: string[]]> = [
   ["doctor", ["doctor"]],
   ["config", ["config"]],
   ["upgrade", ["upgrade", "--dry-run"]],
+  ["uninstall", ["uninstall", "--dry-run"]],
 ];
 
 describe("the envelope is uniform across every command", () => {

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -28,7 +28,7 @@ for pair in \
   "file.rb:null"; do
   file="${pair%%:*}"
   expected="${pair##*:}"
-  result=$(structured-edit route "$file" "rename-symbol" | python3 -c "import json,sys; print(json.load(sys.stdin).get('language') or 'null')")
+  result=$(hashpilot route "$file" "rename-symbol" | python3 -c "import json,sys; print(json.load(sys.stdin).get('language') or 'null')")
   if [ "$result" = "$expected" ]; then ok "$file -> $expected"; else fail "$file -> $result (expected $expected)"; fi
 done
 
@@ -36,7 +36,7 @@ done
 echo ""
 echo "--- Capabilities ---"
 
-LANGS=$(structured-edit ast capabilities | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+LANGS=$(hashpilot ast capabilities | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
 if [ "$LANGS" = "6" ]; then ok "ast capabilities reports 6 languages"; else fail "ast capabilities reports $LANGS languages (expected 6)"; fi
 
 # ── 3. find-symbols per language ───────────────────────────────────────
@@ -45,31 +45,31 @@ echo "--- find-symbols ---"
 
 # TypeScript
 echo 'function greet() {}' > "$TMP/test.ts"
-if structured-edit ast find-symbols "$TMP/test.ts" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d), 'greet not found'"; then
+if hashpilot ast find-symbols "$TMP/test.ts" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d), 'greet not found'"; then
   ok "TypeScript find-symbols"
 else fail "TypeScript find-symbols"; fi
 
 # JavaScript
 echo 'function greet() {}' > "$TMP/test.js"
-if structured-edit ast find-symbols "$TMP/test.js" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
+if hashpilot ast find-symbols "$TMP/test.js" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
   ok "JavaScript find-symbols"
 else fail "JavaScript find-symbols"; fi
 
 # Python
 echo -e 'def greet():\n    pass' > "$TMP/test.py"
-if structured-edit ast find-symbols "$TMP/test.py" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
+if hashpilot ast find-symbols "$TMP/test.py" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
   ok "Python find-symbols"
 else fail "Python find-symbols"; fi
 
 # Go
 echo -e 'package main\nfunc greet() {}' > "$TMP/test.go"
-if structured-edit ast find-symbols "$TMP/test.go" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
+if hashpilot ast find-symbols "$TMP/test.go" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
   ok "Go find-symbols"
 else fail "Go find-symbols"; fi
 
 # Rust
 echo -e 'fn greet() {}' > "$TMP/test.rs"
-if structured-edit ast find-symbols "$TMP/test.rs" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
+if hashpilot ast find-symbols "$TMP/test.rs" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
   ok "Rust find-symbols"
 else fail "Rust find-symbols"; fi
 
@@ -78,22 +78,22 @@ echo ""
 echo "--- rename-symbol ---"
 
 echo 'function greet() { return greet(); }' > "$TMP/test.js"
-if structured-edit ast rename-symbol "$TMP/test.js" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 2"; then
+if hashpilot ast rename-symbol "$TMP/test.js" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 2"; then
   ok "JavaScript rename-symbol"
 else fail "JavaScript rename-symbol"; fi
 
 echo -e 'def greet():\n    return greet()' > "$TMP/test.py"
-if structured-edit ast rename-symbol "$TMP/test.py" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 1"; then
+if hashpilot ast rename-symbol "$TMP/test.py" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 1"; then
   ok "Python rename-symbol"
 else fail "Python rename-symbol"; fi
 
 echo -e 'package main\nfunc greet() string { return "hi" }' > "$TMP/test.go"
-if structured-edit ast rename-symbol "$TMP/test.go" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 1"; then
+if hashpilot ast rename-symbol "$TMP/test.go" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 1"; then
   ok "Go rename-symbol"
 else fail "Go rename-symbol"; fi
 
 echo -e 'fn greet() -> &str { "hi" }' > "$TMP/test.rs"
-if structured-edit ast rename-symbol "$TMP/test.rs" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 1"; then
+if hashpilot ast rename-symbol "$TMP/test.rs" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 1"; then
   ok "Rust rename-symbol"
 else fail "Rust rename-symbol"; fi
 
@@ -102,7 +102,7 @@ echo ""
 echo "--- Go add-import ---"
 
 echo -e 'package main\n\nfunc main() {}' > "$TMP/go_noimport.go"
-RESULT=$(structured-edit ast add-import "$TMP/go_noimport.go" "fmt" --dry-run 2>&1)
+RESULT=$(hashpilot ast add-import "$TMP/go_noimport.go" "fmt" --dry-run 2>&1)
 POS=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('newSource','').find('import'))")
 if [ "$POS" -gt 0 ]; then ok "Go add-import places after package clause (index=$POS)"; else fail "Go add-import at position $POS"; fi
 
@@ -111,10 +111,10 @@ echo ""
 echo "--- Python add-import ---"
 
 echo -e 'import os\n\ndef f(): pass' > "$TMP/test_py.py"
-if structured-edit ast add-import "$TMP/test_py.py" "from sys import argv" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and 'from sys' in d.get('newSource','')"; then
+if hashpilot ast add-import "$TMP/test_py.py" "from sys import argv" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and 'from sys' in d.get('newSource','')"; then
   ok "Python from-import"
 else fail "Python from-import"; fi
-if structured-edit ast add-import "$TMP/test_py.py" "json" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and 'import json' in d.get('newSource','')"; then
+if hashpilot ast add-import "$TMP/test_py.py" "json" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and 'import json' in d.get('newSource','')"; then
   ok "Python simple import"
 else fail "Python simple import"; fi
 
@@ -123,10 +123,10 @@ echo ""
 echo "--- Rust remove-import ---"
 
 echo -e 'use std::collections::HashMap;\n\nfn main() {}' > "$TMP/test_rs.rs"
-if structured-edit ast remove-import "$TMP/test_rs.rs" "HashMap" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success']"; then
+if hashpilot ast remove-import "$TMP/test_rs.rs" "HashMap" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success']"; then
   ok "Rust remove-import (AST-aware)"
 else fail "Rust remove-import"; fi
-if structured-edit ast remove-import "$TMP/test_rs.rs" "NonExistent" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert not d['success']"; then
+if hashpilot ast remove-import "$TMP/test_rs.rs" "NonExistent" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert not d['success']"; then
   ok "Rust remove-import no-op when not found"
 else fail "Rust remove-import no-op"; fi
 
@@ -134,11 +134,11 @@ else fail "Rust remove-import no-op"; fi
 echo ""
 echo "--- Routing ---"
 
-if structured-edit route "file.rb" "rename-symbol" | python3 -c "import json,sys; assert json.load(sys.stdin)['route'] == 'diff'"; then
+if hashpilot route "file.rb" "rename-symbol" | python3 -c "import json,sys; assert json.load(sys.stdin)['route'] == 'diff'"; then
   ok "Unsupported .rb routes to diff"
 else fail "Unsupported .rb routing"; fi
 
-if structured-edit route "test.ts" "rename-symbol" | python3 -c "import json,sys; assert json.load(sys.stdin)['route'] == 'ast'"; then
+if hashpilot route "test.ts" "rename-symbol" | python3 -c "import json,sys; assert json.load(sys.stdin)['route'] == 'ast'"; then
   ok "Supported .ts routes to ast"
 else fail "Supported .ts routing"; fi
 


### PR DESCRIPTION
## Breaking Change

The CLI binary is now `hashpilot` instead of `structured-edit`. All subcommands, flags, output shapes, and exit codes are unchanged.

The on-disk install directory remains `~/.agentic-tools/structured-editing/` for upgrade compatibility.

## New Feature: `hashpilot uninstall`

Users can now uninstall HashPilot directly from the CLI:

```bash
hashpilot uninstall                    # full removal (with prompt)
hashpilot uninstall --keep-config       # remove binaries, keep config + telemetry
hashpilot uninstall --force             # skip confirmation
hashpilot uninstall --dry-run           # preview what would be removed
```

Delegates to `scripts/uninstall.sh`, mirroring the existing `upgrade` command pattern.

## Migration for Users

1. Re-run the installer or `bun run install-cli` to get the new `hashpilot` symlink
2. Remove the old symlink: `rm ~/.agentic-tools/bin/structured-edit`
3. Update any agent prompts or scripts that call `structured-edit` to use `hashpilot`

## Files Changed (30 files, 467 insertions, 344 deletions)

| Category | Files |
|----------|-------|
| Core source | `src/cli.ts`, `src/cli-node.cjs`, `src/core/doctor.ts`, `src/core/hash-edit.ts` |
| Package | `package.json` |
| Shell scripts | `scripts/install.sh`, `scripts/doctor.sh`, `scripts/uninstall.sh` |
| Tests | `tests/smoke.sh`, `tests/cli-contract.test.ts`, `tests/envelope.test.ts` |
| Templates | `templates/claude-section.md`, `templates/opencode-skill.md`, `templates/opencode-agent.md`, `templates/pi-extension.ts`, `templates/pi-skill.md` |
| Docs | `docs/CLI-QUICKREF.md`, `docs/ADAPTER-CONTRACT.md`, `docs/INSTALL.md`, `docs/ARCHITECTURE.md`, `docs/INTEGRATION-CLAUDE.md`, `docs/INTEGRATION-OPENCODE.md`, `docs/INTEGRATION-PI.md` |
| Other | `README.md`, `CLAUDE.md`, `index.html`, `.github/workflows/ci.yml`, `.claude/settings.local.json`, `scripts/gen-cli-quickref.ts`, `schema/hashpilot-envelope.schema.json` |

## Verification

- `bun test`: **598 pass / 0 fail**
- `bun run lint:docs`: **passes** (CLI-QUICKREF regenerated, ROADMAP consistent)
- `bash -n` on all shell scripts: **passes**
- Grep sweep: **zero** `structured-edit` references (excluding historical CHANGELOG entries and generated dist/)