### PR TITLE
fix: wire verification into success flag and make rollback atomic (#10, #17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@ logs/
 desktop-*.png
 mobile-*.png
 
+# Test scratch directories
+tests/__tmp_*/
+
 # Local task tracking
 tasks/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,6 +154,17 @@ highest-frequency operations.
   5. Verify results
   6. Return `{ success, changeset, steps: [{file, operation, status, error?}] }`
 
+**Rollback & verification invariants (issues #10, #17)**:
+- Verification failure (`VerifyResult.overall === "fail"`), not just step failure, must
+  trigger rollback when `revertOnFailure` is true. `PlanResult.success` reflects both
+  dimensions; it is `false` when either the steps fail *or* the post-edit verification
+  fails. The `errorCode` of `VERIFY_FAILED` maps to exit code 4.
+- A half-reverted tree must never claim `reverted: true`. The revert loop now tracks
+  every snapshot file whose `safeWrite` threw and returns them in `unrevertedFiles`.
+  `reverted` is `true` only when every snapshot file was fully restored to its pre-edit
+  state; otherwise `reverted: false` and `unrevertedFiles` names the files still in
+  their post-edit state.
+
 #### `src/provenance.ts` — Edit History (M6)
 - ChangeSet-based tracking (group of related edits)
 - `provenanceQuery(file, line?)`: Shows edit history per file/line

--- a/src/core/plan-executor.ts
+++ b/src/core/plan-executor.ts
@@ -4,7 +4,7 @@ import { insertParameter, insertCallArg, renameSymbol, detectLanguage } from "./
 import { replaceHash } from "./hash-edit";
 import { computeHash } from "./read";
 import { verifyChanges, VerifyResult } from "./verify";
-import { recordEvent } from "./telemetry";
+import { recordEvent, ErrorCode } from "./telemetry";
 import type { TelemetryEvent } from "./telemetry";
 import { createChangeSet, buildProvenanceFields } from "./provenance";
 
@@ -32,6 +32,8 @@ export interface PlanResult {
   };
   verification?: VerifyResult;
   reverted: boolean;
+  /** Files in the rollback snapshot whose `safeWrite` threw; the tree is half-reverted. */
+  unrevertedFiles?: string[];
   /** Set when the plan was refused outright; drives the process exit code. */
   errorCode?: string;
   /** Work the planner could not compute. Non-empty means the plan was partial. */
@@ -201,29 +203,48 @@ export async function executePlan(
 
   const succeeded = results.filter((r) => r.success).length;
   const failed = results.length - succeeded;
-  const allPassed = failed === 0;
+  const stepFailed = failed > 0;
 
-  // Run verification
+  // Run verification after all steps have applied, so the verify run sees the
+  // full in-memory state.
   let verification: VerifyResult | undefined;
   if (doVerify && !dryRun) {
     const impactedFiles = [...new Set(plan.steps.map((s) => s.file))];
     verification = await verifyChanges(impactedFiles, {
       autoDetect: true,
-      revertOnFailure: false, // We handle rollback ourselves
+      revertOnFailure: false, // executePlan owns the rollback path
       timeout,
     });
   }
 
-  // Rollback on failure
+  const verifyFailed = verification?.overall === "fail";
+  const allPassed = !stepFailed && !verifyFailed;
+
+  // Rollback on step failure OR verification failure.
+  //
+  // #10: verification was computed but its result was never read.  The old loop
+  //      condition `!allPassed` only tracked step failures, so a green step /
+  //      red test suite reported `success: true` and kept the broken changes.
+  //
+  // #17: `catch {}` in the revert loop meant a half-reverted tree still set
+  //       `reverted: true`.  `unrevertedFiles` now names every snapshot file
+  //      that could not be restored; `reverted` is only `true` when every file
+  //      in the snapshot was written back.
+  const unrevertedFiles: string[] = [];
   let reverted = false;
-  if (!allPassed && doRevert && !dryRun && originals.size > 0) {
+  if ((stepFailed || verifyFailed) && doRevert && !dryRun && originals.size > 0) {
     for (const [file, original] of originals) {
-      try { await safeWrite(file, original); } catch {}
+      try { await safeWrite(file, original); }
+      catch { unrevertedFiles.push(file); }
     }
-    reverted = true;
+    reverted = unrevertedFiles.length === 0;
   }
 
   const elapsed = Date.now() - start;
+
+  // VERIFY_FAILED has its own exit-code slot (code 4). A bare step failure has
+  // no errorCode and the exit-code system maps `success: false` to code 2.
+  const errorCode: string | undefined = verifyFailed ? ErrorCode.VERIFY_FAILED : undefined;
 
   recordEvent({
     operation: `intent-${plan.intent.operation}`,
@@ -237,6 +258,7 @@ export async function executePlan(
     reason: planReason,
     context: planContext,
     stepTotal: plan.steps.length,
+    errorCode,
   });
 
   return {
@@ -252,6 +274,8 @@ export async function executePlan(
     },
     verification,
     reverted,
+    unrevertedFiles: unrevertedFiles.length > 0 ? unrevertedFiles : undefined,
+    errorCode,
     unresolved,
   };
 }

--- a/tests/intent.test.ts
+++ b/tests/intent.test.ts
@@ -3,6 +3,7 @@ import { parseIntent, findSymbolDefinition, findReferences, generatePlan, Unsupp
 import { executePlan, executeIntent } from "../src/core/plan-executor";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
+import { simulateCrashAfterTempWrite } from "../src/core/paths";
 
 const TMP_DIR = join(import.meta.dir, "__tmp_intent_tests__");
 
@@ -764,4 +765,139 @@ describe("intent edge cases", () => {
     expect(def).not.toBeNull();
     expect(def!.name).toBe("greet");
   });
+});
+
+// ── #10 / #17: verification feedback loop and rollback correctness ────
+
+describe("executePlan verification / rollback correctness", () => {
+  const VERIFY_FAIL_DIR = join(TMP_DIR, "__verify_fail__");
+  const BAD_TS = join(VERIFY_FAIL_DIR, "bad.ts");
+  const BAD_PKG = join(VERIFY_FAIL_DIR, "package.json");
+  const ORIGINAL_BAD_TS = "export const value = 1;\n";
+
+  beforeEach(() => {
+    simulateCrashAfterTempWrite(false);
+    try { rmSync(VERIFY_FAIL_DIR, { recursive: true, force: true }); } catch {}
+    mkdirSync(VERIFY_FAIL_DIR, { recursive: true });
+    writeFileSync(BAD_TS, ORIGINAL_BAD_TS);
+     // Auto-detection finds this package.json when walking up from BAD_TS;
+     // vitest is not in node_modules, so `npx --no-install vitest run` exits
+     // non-zero — a deterministic verify-overall="fail" without network flakiness.
+    writeFileSync(BAD_PKG, JSON.stringify({
+      name: "verify-fail-fixture",
+      devDependencies: { vitest: "^1.0.0" },
+     }));
+   });
+
+  afterEach(() => {
+    simulateCrashAfterTempWrite(false);
+    try { rmSync(VERIFY_FAIL_DIR, { recursive: true, force: true }); } catch {}
+   });
+
+  test("verification failure makes success:false and reverts changes (#10)", async () => {
+    const plan = {
+      intent: { operation: "add-parameter", symbol: "value", param: { name: "x" } },
+      definition: { file: BAD_TS, name: "value", kind: "function", line: 1, column: 0 },
+      references: [],
+      steps: [
+        {
+          order: 0,
+          file: BAD_TS,
+          operation: "diff",
+          description: "replace content",
+          params: { oldContent: "= 1", newContent: "= 2" },
+        },
+      ],
+      impactSummary: "",
+    };
+
+    const result = await executePlan(plan, { verify: true, dryRun: false, revertOnFailure: true });
+
+     // #10 core invariant: a red verification result is not reported as success.
+    expect(result.success).toBe(false);
+    expect(result.verification).toBeDefined();
+    expect(result.verification!.overall).toBe("fail");
+    expect(result.errorCode).toBe("VERIFY_FAILED");
+
+     // Rollback must fire on verification failure, not just on step failure.
+    expect(result.reverted).toBe(true);
+    expect(await Bun.file(BAD_TS).text()).toBe(ORIGINAL_BAD_TS);
+   });
+
+  test("rollback failure sets reverted:false and lists unrevertedFiles (#17)", async () => {
+     // simulateCrashAfterTempWrite makes every atomicWrite throw after the
+     // temp-file write but before the rename.  The originals snapshot uses
+     // Bun.file().text() (no atomicWrite), so it is captured before the crash
+     // fires.  Every safeWrite in the rollback loop then throws, proving that
+     // `reverted` is never set to true over a half-reverted tree.
+    setup();
+    simulateCrashAfterTempWrite(true);
+
+    const plan = {
+      intent: { operation: "rename-exported-symbol", symbol: "greet", newName: "sayHello" },
+      definition: { file: FILE_A, name: "greet", kind: "function", line: 1, column: 0 },
+      references: [],
+      steps: [
+        {
+          order: 0,
+          file: FILE_A,
+          operation: "diff",
+          description: "apply change to a.ts",
+          params: { oldContent: "greet", newContent: "sayHello" },
+        },
+        {
+          order: 1,
+          file: FILE_B,
+          operation: "diff",
+          description: "apply change to b.ts",
+          params: { oldContent: "greet", newContent: "sayHello" },
+        },
+      ],
+      impactSummary: "",
+    };
+
+    const result = await executePlan(plan, { verify: false, dryRun: false, revertOnFailure: true });
+
+     // #17 core invariant: when the revert loop catches a write error the result
+     // must not claim a clean revert.
+    expect(result.reverted).toBe(false);
+    expect(result.unrevertedFiles).toBeDefined();
+    expect(result.unrevertedFiles!.length).toBeGreaterThan(0);
+    expect(result.unrevertedFiles).toContain(FILE_A);
+    expect(result.unrevertedFiles).toContain(FILE_B);
+   });
+
+  test("reverted:true when every snapshot file is restored cleanly", async () => {
+     // No crash → every revert write succeeds → reverted: true, unrevertedFiles: undefined.
+    setup();
+    const originalA = await Bun.file(FILE_A).text();
+
+    const plan = {
+      intent: { operation: "rename-exported-symbol", symbol: "greet", newName: "sayHello" },
+      definition: { file: FILE_A, name: "greet", kind: "function", line: 1, column: 0 },
+      references: [],
+      steps: [
+        {
+          order: 0,
+          file: FILE_A,
+          operation: "rename-symbol",
+          description: "Rename greet to sayHello",
+          params: { oldName: "greet", newName: "sayHello" },
+        },
+        {
+          order: 1,
+          file: FILE_A,
+          operation: "diff",
+          description: "Step 1 content not found — forces rollback",
+          params: { oldContent: "%%%NOT_FOUND%%%", newContent: "x" },
+        },
+      ],
+      impactSummary: "",
+    };
+
+    const result = await executePlan(plan, { verify: false, dryRun: false, revertOnFailure: true });
+    expect(result.reverted).toBe(true);
+    expect(result.unrevertedFiles).toBeUndefined();
+    expect(await Bun.file(FILE_A).text()).toBe(originalA);
+   });
 });


### PR DESCRIPTION
## What

Two bugs in `src/core/plan-executor.ts:198-224` that shared a fix:

### #10 — Verification is decorative

`verifyChanges` ran and its result was stored in `PlanResult.verification`, but nothing
read it. The `allPassed` flag tracked only whether each step applied. So a plan that
succeeded cleanly at the step level but triggered a failed test run would:
- Report `success: true`
- Keep the changes on disk
- Hand the agent a green light

### #17 — Silent partial rollback

In the revert loop:
```ts
for (const [file, original] of originals) {
  try { await safeWrite(file, original); } catch {}
}
reverted = true;   // set unconditionally after the loop
```

A file-write failure on file 3 of 5 was swallowed, and `reverted: true` was reported
over a half-reverted tree. This is worse than no rollback: the agent stops looking.

## Fix

### `src/core/plan-executor.ts` (~30 lines)

1. `verifyFailed = verification?.overall === "fail"` — computed after verify runs.
2. `allPassed = !stepFailed && !verifyFailed` — both dimensions must pass.
3. Rollback condition: `(stepFailed || verifyFailed) && …` — rollback fires on either.
4. `reverted = unrevertedFiles.length === 0` — only true when every snapshot was written back.
5. `unrevertedFiles?: string[]` — new `PlanResult` field; names files still in post-edit
   state, so the caller knows exactly what is broken.
6. `errorCode: VERIFY_FAILED` — emitted when verify fails so exit code 4 is correct
   (previously no `errorCode` was set, causing the generic code 2).

### `docs/ARCHITECTURE.md`

Added the two invariants to the `plan-executor.ts` section.

### `tests/intent.test.ts`

Three new tests:
- `verification failure makes success:false and reverts changes (#10)`
- `rollback failure sets reverted:false and lists unrevertedFiles (#17)`
- `reverted:true when every snapshot file is restored cleanly` (positive control)

## Validation

- `bun test` — 619 pass / 0 fail
- `bun run lint:docs` — clean
- CI `docs-verify` gate satisfied: `docs/ARCHITECTURE.md` is updated alongside `src/`

## Files changed

| File | Change |
|------|--------|
| `src/core/plan-executor.ts` | Core logic fix (~30 lines) |
| `tests/intent.test.ts` | 3 new tests, `simulateCrashAfterTempWrite` import |
| `docs/ARCHITECTURE.md` | Documents the two invariants |
| `.gitignore` | Excludes test scratch dirs (`tests/__tmp_*/`) |