### PR TITLE
fix: close rollback-completeness gaps left by #75 (#10, #17)

### DIFF
--- a/docs/ADAPTER-CONTRACT.md
+++ b/docs/ADAPTER-CONTRACT.md
@@ -627,6 +627,26 @@ signature plus `diff apply` at each call site.
 }
 ```
 
+**Rollback outcome (`execution.reverted`, `execution.unrevertedFiles`)**
+
+A plan is rolled back when any step fails **or** verification fails. Two fields
+report how that went, and an agent must read both:
+
+| Fields | Meaning | What to do |
+|--------|---------|------------|
+| `reverted: false`, no `unrevertedFiles` | No rollback was needed or requested | Nothing |
+| `reverted: true` | Every impacted file was restored to its pre-plan content | Safe to retry the plan |
+| `reverted: false` + `unrevertedFiles: [...]` | **The rollback itself failed.** The listed files still hold edits that were supposed to be undone | **Stop.** Restore those files before any retry. Exit code is `5` with `errorCode: ROLLBACK_INCOMPLETE` |
+
+`reverted: true` is never reported over a partial restore — if even one file
+could not be written back it appears in `unrevertedFiles` and `reverted` is
+`false`.
+
+**Verification is skipped when a step fails.** The tree is half-applied at that
+point, so a suite run over it would report failures caused by the incomplete
+edit rather than by the change itself. `verification` is then absent and the
+exit code is `2` (edit failed), not `4`.
+
 **Partial plans (`plan.unresolved`)**
 
 The planner never invents source text. When part of an intent cannot be
@@ -999,7 +1019,7 @@ Branch on the exit code, not on stderr text.
 | `2` | Edit failed — the operation ran but could not be applied | Try another route or report |
 | `3` | Stale anchor / precondition failed | **Retryable:** re-read the file and reissue with the fresh hash |
 | `4` | Verification failed — the edit applied but format/lint/test did not pass | Inspect the verify output; the edit may have been reverted |
-| `5` | I/O error — file not found, unreadable, or write failed | Check the path and permissions |
+| `5` | I/O error — file not found, unreadable, or write failed. Also an **incomplete rollback** (`errorCode: ROLLBACK_INCOMPLETE`) | Check the path and permissions. On `ROLLBACK_INCOMPLETE`, **stop and inspect** — read `unrevertedFiles` and restore them before retrying anything |
 | `70` | Internal error | Report a bug |
 
 Batch commands return the worst code across all items; an all-success batch

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -164,6 +164,25 @@ highest-frequency operations.
   `reverted` is `true` only when every snapshot file was fully restored to its pre-edit
   state; otherwise `reverted: false` and `unrevertedFiles` names the files still in
   their post-edit state.
+- **Verification is skipped entirely when a step has already failed.** The tree is
+  half-applied at that point, so the suite would report failures that are a
+  consequence of the incomplete edit, not findings about the change — at the cost of
+  a full test run on work that is about to be reverted. It also used to corrupt the
+  diagnosis: `errorCode` became `VERIFY_FAILED` (exit 4, "the edit applied but tests
+  failed") when the edit had never applied at all (exit 2).
+- **An incomplete rollback outranks every other error code.** `unrevertedFiles`
+  being non-empty yields `ROLLBACK_INCOMPLETE`, which maps to exit **5** (I/O) rather
+  than 4. Exit 4 sits in the band an agent reads as "your edit landed, the tests are
+  red" — safe to retry. A half-reverted tree is not safe to retry, so it must not
+  share that code.
+- **The rollback snapshot's own read failures count as unreverted.** A file that
+  could not be read when the pre-edit snapshot was taken has nothing to write back,
+  so the revert loop — which iterates the snapshot — would neither restore it nor
+  report it, reproducing the exact defect #17 closed on the write side. Such a file
+  is folded into `unrevertedFiles` when a step actually modified it. Both the
+  snapshot and the step read through `Bun.file().text()`, so today this requires the
+  file to become readable between the two — a race window, not a reproducible path.
+  It is guarded by construction so the invariant survives future step types.
 
 #### `src/provenance.ts` — Edit History (M6)
 - ChangeSet-based tracking (group of related edits)

--- a/src/core/exit-codes.ts
+++ b/src/core/exit-codes.ts
@@ -37,6 +37,9 @@ const ERROR_CODE_EXITS: Record<string, ExitCode> = {
   [ErrorCode.DUPLICATE_MATCH]: ExitCode.EDIT_FAILED,
   [ErrorCode.UNSUPPORTED_LANGUAGE]: ExitCode.EDIT_FAILED,
   [ErrorCode.VERIFY_FAILED]: ExitCode.VERIFY_FAILED,
+  // Deliberately IO, not VERIFY_FAILED: a half-reverted tree is a filesystem
+  // problem the agent must stop and inspect, not a retryable test failure.
+  [ErrorCode.ROLLBACK_INCOMPLETE]: ExitCode.IO,
   [ErrorCode.INTERNAL_ERROR]: ExitCode.INTERNAL,
 };
 

--- a/src/core/plan-executor.ts
+++ b/src/core/plan-executor.ts
@@ -87,11 +87,23 @@ export async function executePlan(
   const changeSetId = createChangeSet();
   const stepTotal = plan.steps.length;
 
-  // Snapshot all impacted files for rollback
+  // Snapshot all impacted files for rollback.
+  //
+  // A file we cannot read here has no snapshot, so it can never be rolled back.
+  // Swallowing that read failure re-creates the exact defect #17 closed on the
+  // write side: the revert loop iterates `originals`, so an unsnapshotted file
+  // is neither restored nor reported, and `reverted: true` goes out over a tree
+  // that still holds the edit. Record the miss now and fold it into
+  // `unrevertedFiles` if a rollback actually fires.
   const originals = new Map<string, string>();
+  const unsnapshotted: string[] = [];
   if (doRevert) {
     for (const file of [...new Set(plan.steps.map((s) => s.file))]) {
-      try { originals.set(file, await Bun.file(file).text()); } catch {}
+      try {
+        originals.set(file, await Bun.file(file).text());
+      } catch {
+        unsnapshotted.push(file);
+      }
     }
   }
 
@@ -207,8 +219,16 @@ export async function executePlan(
 
   // Run verification after all steps have applied, so the verify run sees the
   // full in-memory state.
+  //
+  // Skipped when a step already failed. The tree is then half-applied, so the
+  // suite is being run over a state no one asked for and is about to be
+  // reverted — it costs a full test run to produce a failure that is a
+  // consequence of the step failure, not an independent finding. Worse, it used
+  // to overwrite the diagnosis: `errorCode` became VERIFY_FAILED (exit 4,
+  // "the edit applied but tests failed") when the edit had in fact never
+  // applied (exit 2).
   let verification: VerifyResult | undefined;
-  if (doVerify && !dryRun) {
+  if (doVerify && !dryRun && !stepFailed) {
     const impactedFiles = [...new Set(plan.steps.map((s) => s.file))];
     verification = await verifyChanges(impactedFiles, {
       autoDetect: true,
@@ -237,14 +257,36 @@ export async function executePlan(
       try { await safeWrite(file, original); }
       catch { unrevertedFiles.push(file); }
     }
+    // A file that was edited but never snapshotted is just as unreverted as one
+    // whose restore write threw — there was nothing to write back. Only count
+    // it if a step actually changed it; an unreadable file that also failed its
+    // step left the tree untouched and needs no rollback.
+    const editedFiles = new Set(results.filter((r) => r.success).map((r) => r.file));
+    for (const file of unsnapshotted) {
+      if (editedFiles.has(file)) unrevertedFiles.push(file);
+    }
     reverted = unrevertedFiles.length === 0;
   }
 
   const elapsed = Date.now() - start;
 
-  // VERIFY_FAILED has its own exit-code slot (code 4). A bare step failure has
-  // no errorCode and the exit-code system maps `success: false` to code 2.
-  const errorCode: string | undefined = verifyFailed ? ErrorCode.VERIFY_FAILED : undefined;
+  // Error-code precedence, most alarming first.
+  //
+  // An incomplete rollback outranks everything else: the tree is now in a state
+  // neither the caller nor the plan asked for. Reporting that as VERIFY_FAILED
+  // (exit 4) tells an agent "your edit applied, the tests didn't pass" — which
+  // reads as safe to retry, when in fact some files still hold edits that were
+  // supposed to be undone. ROLLBACK_INCOMPLETE maps to exit 5 (I/O), so it does
+  // not sit in the retryable band at all.
+  //
+  // VERIFY_FAILED has its own slot (code 4). A bare step failure carries no
+  // errorCode and the exit-code system maps `success: false` to code 2.
+  const errorCode: string | undefined =
+    unrevertedFiles.length > 0
+      ? ErrorCode.ROLLBACK_INCOMPLETE
+      : verifyFailed
+        ? ErrorCode.VERIFY_FAILED
+        : undefined;
 
   recordEvent({
     operation: `intent-${plan.intent.operation}`,

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -51,6 +51,13 @@ export enum ErrorCode {
   UNSUPPORTED_OPERATION = "UNSUPPORTED_OPERATION",
   /** The edit applied but format/lint/test verification failed. */
   VERIFY_FAILED = "VERIFY_FAILED",
+  /**
+   * A rollback ran but could not restore every file, so the tree is left in a
+   * state that is neither the original nor the intended result. Strictly more
+   * serious than the failure that triggered the rollback — see
+   * `PlanResult.unrevertedFiles` for the files still holding edits.
+   */
+  ROLLBACK_INCOMPLETE = "ROLLBACK_INCOMPLETE",
   /** The anchor could not be relocated unambiguously (multiple candidate matches). */
   AMBIGUOUS_ANCHOR = "AMBIGUOUS_ANCHOR",
   /** A file exists but could not be read (permissions, device error). Distinct from FILE_NOT_FOUND. */

--- a/tests/intent.test.ts
+++ b/tests/intent.test.ts
@@ -4,6 +4,7 @@ import { executePlan, executeIntent } from "../src/core/plan-executor";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { simulateCrashAfterTempWrite } from "../src/core/paths";
+import { exitCodeFor } from "../src/core/exit-codes";
 
 const TMP_DIR = join(import.meta.dir, "__tmp_intent_tests__");
 
@@ -900,4 +901,77 @@ describe("executePlan verification / rollback correctness", () => {
     expect(result.unrevertedFiles).toBeUndefined();
     expect(await Bun.file(FILE_A).text()).toBe(originalA);
    });
+
+  test("a failed step skips verification instead of misreporting VERIFY_FAILED", async () => {
+    // The step cannot apply, so the tree never reaches the state the plan
+    // describes. Running the suite over that half-applied tree produced a
+    // failure that was then reported as errorCode VERIFY_FAILED (exit 4,
+    // "the edit applied but tests failed") — the opposite of what happened.
+    // Verification must not run at all here.
+    const plan = {
+      intent: { operation: "add-parameter", symbol: "value", param: { name: "x" } },
+      definition: { file: BAD_TS, name: "value", kind: "function", line: 1, column: 0 },
+      references: [],
+      steps: [
+        {
+          order: 0,
+          file: BAD_TS,
+          operation: "diff",
+          description: "content that is not present",
+          params: { oldContent: "%%%NOT_FOUND%%%", newContent: "x" },
+        },
+      ],
+      impactSummary: "",
+    };
+
+    const result = await executePlan(plan, { verify: true, dryRun: false, revertOnFailure: true });
+
+    expect(result.success).toBe(false);
+    expect(result.verification).toBeUndefined();
+    expect(result.errorCode).toBeUndefined();
+    // A step failure is an edit failure (exit 2), not a verification failure (4).
+    expect(exitCodeFor(result)).toBe(2);
+    // The failed step changed nothing, so the file is untouched either way.
+    expect(await Bun.file(BAD_TS).text()).toBe(ORIGINAL_BAD_TS);
+  });
+
+  test("an incomplete rollback reports ROLLBACK_INCOMPLETE and exits 5", async () => {
+    // #17 gave the half-reverted tree a field (`unrevertedFiles`) but no error
+    // code, so it still exited 4 — which an agent reads as "edit applied, tests
+    // red", i.e. safe to retry. It is not safe to retry: files are left in a
+    // state neither the caller nor the plan asked for.
+    setup();
+    simulateCrashAfterTempWrite(true);
+
+    const plan = {
+      intent: { operation: "rename-exported-symbol", symbol: "greet", newName: "sayHello" },
+      definition: { file: FILE_A, name: "greet", kind: "function", line: 1, column: 0 },
+      references: [],
+      steps: [
+        {
+          order: 0,
+          file: FILE_A,
+          operation: "diff",
+          description: "apply change to a.ts",
+          params: { oldContent: "greet", newContent: "sayHello" },
+        },
+      ],
+      impactSummary: "",
+    };
+
+    const result = await executePlan(plan, { verify: false, dryRun: false, revertOnFailure: true });
+
+    expect(result.reverted).toBe(false);
+    expect(result.unrevertedFiles).toContain(FILE_A);
+    expect(result.errorCode).toBe("ROLLBACK_INCOMPLETE");
+    expect(exitCodeFor(result)).toBe(5);
+  });
+
+  test("ROLLBACK_INCOMPLETE maps to exit 5 so it leaves the retryable band", () => {
+    // #17 gave the half-reverted tree a field but no code: it still exited 4,
+    // which an agent reads as "edit applied, tests red" — safe to retry. It is
+    // not safe to retry; some files still hold edits that should be gone.
+    expect(exitCodeFor({ success: false, errorCode: "ROLLBACK_INCOMPLETE" })).toBe(5);
+    expect(exitCodeFor({ success: false, errorCode: "VERIFY_FAILED" })).toBe(4);
+  });
 });


### PR DESCRIPTION
Review follow-up on #75. That PR's core fix was correct — verification now feeds `success`, and the revert loop no longer swallows write errors. Three gaps remained.

## 1. Snapshot read failures reproduced #17 on the read side

`#75` fixed the write half of the revert loop. The read half kept the original defect:

```ts
try { originals.set(file, await Bun.file(file).text()); } catch {}
```

The revert loop iterates `originals`. A file missing from it is **neither restored nor reported** — so `reverted: true` goes out over a tree that still holds the edit. That is precisely the failure mode #17 set out to eliminate, one screen further up the same function.

Such files are now recorded and folded into `unrevertedFiles` when a step actually modified them (an unreadable file whose step also failed left the tree untouched and needs no rollback).

Honest scope note: both the snapshot and the step read through `Bun.file().text()`, so triggering this today requires the file to become readable *between* the two — a race window, not a reproducible path. It is guarded by construction so the invariant does not depend on every future step type re-deriving it. No test claims to reproduce it.

## 2. Verification ran over a half-applied tree and inverted the diagnosis

Verification ran unconditionally, including when a step had already failed. Two costs:

- A full test-suite run on a state nobody asked for, which is about to be reverted anyway.
- **Wrong error attribution.** The suite fails (of course — the edit is half-applied), so `errorCode` became `VERIFY_FAILED` → exit **4**, documented as *"the edit applied but format/lint/test did not pass"*. The edit had never applied. The correct code is **2**.

Verification is now skipped when `stepFailed`.

## 3. An incomplete rollback had a field but no error code

`#75` added `unrevertedFiles` but left the error code as `VERIFY_FAILED`, so a half-reverted tree still exited **4** — the band an agent reads as "your edit landed, tests are red", i.e. safe to retry. It is not safe to retry: files still hold edits that were supposed to be undone.

New `ErrorCode.ROLLBACK_INCOMPLETE` → exit **5** (I/O), taking precedence over `VERIFY_FAILED`.

## 4. Adapter contract was not updated

`CLAUDE.md` requires `docs/ADAPTER-CONTRACT.md` to change with any output shape. #75 updated `ARCHITECTURE.md` only, while adding a new `unrevertedFiles` field. Added: the rollback-outcome table, the skip-verify-on-step-failure rule, and the exit-5 row.

## Validation

- `bun test` — 622 pass / 0 fail (3 new tests)
- `bun run lint:docs` — clean
- Confirmed the skip works: the intent suite now invokes `vitest` once instead of twice

## Files

| File | Change |
|------|--------|
| `src/core/plan-executor.ts` | Snapshot-miss tracking, skip-verify-on-step-failure, error-code precedence |
| `src/core/telemetry.ts` | New `ROLLBACK_INCOMPLETE` error code |
| `src/core/exit-codes.ts` | Maps it to exit 5 |
| `tests/intent.test.ts` | 3 tests: verify-skipped, `ROLLBACK_INCOMPLETE`+exit 5, exit-code band |
| `docs/ADAPTER-CONTRACT.md` | Rollback outcome table, exit 5 row |
| `docs/ARCHITECTURE.md` | Three invariants documented |

🤖 Generated with [Claude Code](https://claude.com/claude-code)