### PR TITLE
fix(encoding): preserve CRLF, BOM, and trailing newlines across every edit tier (#30)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -206,6 +206,38 @@ highest-frequency operations.
   preserved. A crash mid-write leaves the original byte-identical, and orphaned
   `.hashpilot-tmp-*` files older than an hour are swept after each write.
 
+#### `src/core/encoding.ts` — Byte Fidelity (#30)
+- A structured editor's one non-negotiable property is that it must not change
+  bytes it was not asked to change. Reading with `.split("\n")` and writing back
+  with `.join("\n")` breaks that three ways: it deletes `\r` from every line of a
+  CRLF file, folds a BOM into line 1 where it corrupts that line's hash, and drops
+  or invents a trailing newline. A one-line edit then produces a whole-file diff.
+- **Normalize at the boundary.** `decodeText(raw)` strips the BOM and converts
+  CRLF/CR/LF to plain `\n`, returning that text plus a `FileEncoding` record
+  (`bom`, dominant `eol`, per-line `endings` when the file was inconsistent,
+  `trailingNewline`). Every tier — hashing, line splitting, AST offsets — operates
+  on plain-LF text and never sees a `\r`. `encodeText(text, encoding)` puts the
+  original layout back at write time. `readDecoded(path)` is the read-side entry
+  point, used by `read.ts`, `hash-edit.ts`, `diff-engine.ts`, `plan-executor.ts`,
+  and `router.ts`.
+- **Write side.** `paths.ts` re-applies the *target file's* layout inside both
+  `safeWrite` and `atomicWrite`. It re-decodes the incoming content first, so the
+  transform is correct whether the caller handed back normalized text or text still
+  carrying the file's endings, and applying it twice changes nothing. Encoding runs
+  **before** `recordSnapshot`, or the snapshot would hash bytes that never reached
+  disk and `undo` would fail its own verification.
+- Trailing-newline presence follows the original file, not the edit: an agent
+  handing back content without a final newline is describing lines, not asking to
+  change how the file terminates. The one exception is emptying a file, which
+  yields an empty file rather than a lone blank line.
+- **Known limitation.** A mixed-ending file restores endings *by line position*, so
+  lines after an inserted line take the ending that used to belong to the line at
+  that index. Lines the edit created take the dominant style. Consistent files —
+  effectively all real ones — are unaffected.
+- Astral-plane content is safe without special handling: tree-sitter node
+  `startIndex`/`endIndex` are UTF-16 code units, matching JS string offsets, so
+  emoji and CJK Extension B characters do not shift AST edits.
+
 #### `src/core/path-normalize.ts` — Path Canonicalization for Comparison (#41)
 - `normalizePath(file)` resolves `./`, `../`, and trailing slashes, then expresses
   the result **relative to `process.cwd()`** when it lives underneath it, and

--- a/src/core/diff-engine.ts
+++ b/src/core/diff-engine.ts
@@ -1,4 +1,5 @@
 import { safeWrite } from "./paths";
+import { readDecoded } from "./encoding";
 export interface Hunk {
   oldStart: number;
   oldLines: number;
@@ -256,7 +257,7 @@ export async function applyPatch(
 
   let source: string;
   try {
-    source = await Bun.file(filePath).text();
+    source = (await readDecoded(filePath)).text;
   } catch {
     return { success: false, hunksApplied: 0, hunksFailed: parsePatch(patchText).hunks.length, message: `Cannot read file: ${filePath}` };
   }

--- a/src/core/encoding.ts
+++ b/src/core/encoding.ts
@@ -1,0 +1,116 @@
+/**
+ * Byte-fidelity for file content (issue #30).
+ *
+ * A structured-editing tool has exactly one non-negotiable property: it must
+ * not change bytes it was not asked to change. Reading a file with
+ * `.split("\n")` and writing it back with `.join("\n")` breaks that three ways
+ * — it deletes `\r` from every line of a CRLF file, folds a BOM into line 1
+ * where it corrupts that line's hash, and drops or invents a trailing newline.
+ * The result is a one-line edit that produces a diff touching every line.
+ *
+ * The fix is to normalize at the boundary: `decodeText` strips the BOM and
+ * converts every line ending to `\n`, all the editing tiers operate on that
+ * plain-LF text, and `encodeText` puts the original bytes back. Everything in
+ * between stays simple, and only this module knows about `\r`.
+ */
+
+/** How a file's bytes were laid out, so a write can reproduce them. */
+export interface FileEncoding {
+  /** File began with U+FEFF. */
+  bom: boolean;
+  /** Dominant line ending, used for any line the edit created. */
+  eol: "\n" | "\r\n" | "\r";
+  /**
+   * The original ending of each line, when the file mixed styles. Lines the
+   * edit did not add keep their own ending; anything past the end of this
+   * array falls back to `eol`. Absent when the file was consistent.
+   */
+  endings?: string[];
+  /** File ended with a line ending. */
+  trailingNewline: boolean;
+}
+
+const BOM = "﻿";
+
+/** Matches every line terminator we preserve: CRLF, lone LF, lone CR. */
+const EOL_RE = /\r\n|\n|\r/g;
+
+/**
+ * Split raw file text into plain-LF content plus the information needed to
+ * write the original bytes back. `encodeText(decodeText(raw))` is the
+ * identity for any input.
+ */
+export function decodeText(raw: string): { text: string; encoding: FileEncoding } {
+  const bom = raw.startsWith(BOM);
+  const body = bom ? raw.slice(BOM.length) : raw;
+
+  const endings: string[] = [];
+  let counts = { "\n": 0, "\r\n": 0, "\r": 0 };
+  let text = "";
+  let last = 0;
+  EOL_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = EOL_RE.exec(body)) !== null) {
+    text += body.slice(last, m.index) + "\n";
+    endings.push(m[0]);
+    counts[m[0] as keyof typeof counts]++;
+    last = m.index + m[0].length;
+  }
+  text += body.slice(last);
+
+  const trailingNewline = endings.length > 0 && last === body.length;
+
+  // Dominant style, with LF as the tiebreak: a file with no line endings at
+  // all has no evidence either way, and LF is what a new line should use.
+  let eol: FileEncoding["eol"] = "\n";
+  let best = 0;
+  for (const style of ["\n", "\r\n", "\r"] as const) {
+    if (counts[style] > best) {
+      best = counts[style];
+      eol = style;
+    }
+  }
+
+  const consistent = endings.every((e) => e === eol);
+  return {
+    text,
+    encoding: { bom, eol, trailingNewline, ...(consistent ? {} : { endings }) },
+  };
+}
+
+/**
+ * Reassemble plain-LF text into the file's original byte layout.
+ *
+ * Line endings are restored by position, so an edit that rewrites line 3 of a
+ * mixed-ending file leaves lines 1, 2, and 4 exactly as they were. Lines the
+ * edit added take the dominant style — there is no original ending to copy.
+ *
+ * Trailing-newline presence follows the original file, not the edit: an agent
+ * that hands back content with or without a final newline is describing the
+ * lines it wants, not asking to change how the file terminates.
+ */
+export function encodeText(text: string, encoding: FileEncoding): string {
+  // Emptying a file means an empty file. Restoring the trailing newline here
+  // would turn a deletion into a file containing one blank line.
+  if (text === "") return encoding.bom ? BOM : "";
+
+  const hadTrailing = text.endsWith("\n");
+  const body = hadTrailing ? text.slice(0, -1) : text;
+  const lines = body.split("\n");
+
+  let out = encoding.bom ? BOM : "";
+  for (let i = 0; i < lines.length; i++) {
+    out += lines[i];
+    const isLast = i === lines.length - 1;
+    if (isLast && !encoding.trailingNewline) break;
+    out += encoding.endings?.[i] ?? encoding.eol;
+  }
+  return out;
+}
+
+/** Read a file and decode it in one step. */
+export async function readDecoded(
+  filePath: string
+): Promise<{ text: string; encoding: FileEncoding }> {
+  return decodeText(await Bun.file(filePath).text());
+}

--- a/src/core/hash-edit.ts
+++ b/src/core/hash-edit.ts
@@ -4,6 +4,7 @@ import { addWarning } from "./envelope";
 import { assertWritable, atomicWrite, PathDeniedError, type AssertWritableOptions } from "./paths";
 import { recordSnapshot } from "./snapshot";
 import { firstParseError } from "./ast-edit";
+import { readDecoded } from "./encoding";
 
 /**
  * What to do when the anchor hash no longer matches the content at the given range.
@@ -100,7 +101,7 @@ export async function replaceHash(
 
   let content: string;
   try {
-    content = await Bun.file(filePath).text();
+    content = (await readDecoded(filePath)).text;
   } catch (e: any) {
     return fail(
       `Failed to read file: ${e.message}`,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -124,3 +124,5 @@ export type { RecoveryMode } from "./hash-edit";
 export { UnsupportedIntentError } from "./intent";
 export { redactSecrets, redactEvent, isSensitiveFile } from "./redact";
 export { normalizePath, pathsEqual } from "./path-normalize";
+export { decodeText, encodeText, readDecoded } from "./encoding";
+export type { FileEncoding } from "./encoding";

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,7 +1,8 @@
 import {
-  existsSync, realpathSync, writeFileSync, renameSync, unlinkSync,
+  existsSync, readFileSync, realpathSync, writeFileSync, renameSync, unlinkSync,
   statSync, openSync, fsyncSync, closeSync,
 } from "node:fs";
+import { decodeText, encodeText } from "./encoding";
 import { homedir, platform } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { ErrorCode } from "./telemetry";
@@ -223,9 +224,41 @@ export async function safeWrite(
   options: AssertWritableOptions = {},
 ): Promise<string> {
   const resolved = assertWritable(target, options);
-  recordSnapshot(resolved, content);
-  atomicWrite(resolved, content);
+  // Encode before snapshotting: the snapshot records the bytes that actually
+  // land on disk, and undo verifies against them (#30).
+  const encoded = restoreEncoding(resolved, content);
+  recordSnapshot(resolved, encoded);
+  atomicWrite(resolved, encoded);
   return resolved;
+}
+
+/**
+ * Put the target file's byte layout back on the content about to replace it
+ * (#30).
+ *
+ * The editing tiers work on plain-LF text with no BOM, which is what makes
+ * line splitting, hashing, and AST offsets tractable. That normalization is
+ * only safe if the bytes are restored on the way out — otherwise a one-line
+ * edit in a CRLF repo rewrites every line ending in the file, and a BOM or a
+ * trailing newline disappears.
+ *
+ * The incoming content is decoded first, so this is correct whether the caller
+ * handed us normalized text or text that still carries the file's own endings,
+ * and applying it twice changes nothing.
+ */
+function restoreEncoding(resolved: string, content: string): string {
+  const { text } = decodeText(content);
+  let encoding;
+  try {
+    // A file that does not exist yet has no layout to preserve; the content's
+    // own is the only evidence available.
+    encoding = existsSync(resolved)
+      ? decodeText(readFileSync(resolved, "utf8")).encoding
+      : decodeText(content).encoding;
+  } catch {
+    return content;
+  }
+  return encodeText(text, encoding);
 }
 
 /** Injectable failure point, so a test can simulate a crash mid-write. */
@@ -250,6 +283,7 @@ export function simulateCrashAfterTempWrite(value: boolean): void {
  * exactly the non-atomic write this replaces.
  */
 export function atomicWrite(resolved: string, content: string): void {
+  content = restoreEncoding(resolved, content);
   const dir = dirname(resolved);
   const tmp = join(dir, `.hashpilot-tmp-${process.pid}-${Math.random().toString(36).slice(2)}`);
 

--- a/src/core/plan-executor.ts
+++ b/src/core/plan-executor.ts
@@ -7,6 +7,7 @@ import { verifyChanges, recordVerifyBaseline, VerifyResult } from "./verify";
 import { recordEvent, ErrorCode } from "./telemetry";
 import type { TelemetryEvent } from "./telemetry";
 import { createChangeSet, buildProvenanceFields } from "./provenance";
+import { readDecoded } from "./encoding";
 
 // ── Result types ──────────────────────────────────────────────────────
 
@@ -100,7 +101,7 @@ export async function executePlan(
   if (doRevert) {
     for (const file of [...new Set(plan.steps.map((s) => s.file))]) {
       try {
-        originals.set(file, await Bun.file(file).text());
+        originals.set(file, (await readDecoded(file)).text);
       } catch {
         unsnapshotted.push(file);
       }
@@ -133,7 +134,7 @@ export async function executePlan(
     let stepSource: string | undefined;
 
     try {
-      stepSource = await Bun.file(step.file).text();
+      stepSource = (await readDecoded(step.file)).text;
       const source = stepSource;
       let result: { success: boolean; message: string; newSource?: string };
 

--- a/src/core/read.ts
+++ b/src/core/read.ts
@@ -1,4 +1,5 @@
 import { createHash } from "crypto";
+import { readDecoded } from "./encoding";
 
 export interface ReadResult {
   path: string;
@@ -32,7 +33,7 @@ export async function readMany(files: string[]): Promise<ReadResult[]> {
   const results = await Promise.all(
     files.map(async (p) => {
       try {
-        const content = await Bun.file(p).text();
+        const { text: content } = await readDecoded(p);
         return {
           path: p,
           content,
@@ -64,7 +65,7 @@ export async function readHash(
   contextLines: number = 3
 ): Promise<ReadHashResult> {
   try {
-    const content = await Bun.file(filePath).text();
+    const { text: content } = await readDecoded(filePath);
     const lines = content.split("\n");
     const targetLine = lines[line - 1];
     // A blank line is an empty string, which is falsy — checking truthiness here

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -18,6 +18,7 @@ import { buildProvenanceFields } from "./provenance";
 import { loadConfig, policyForce, RoutePolicy } from "./config";
 import { addWarning } from "./envelope";
 import { acquireLock, LOCK_TIMEOUT_MS, LockAcquireError } from "./locking";
+import { readDecoded } from "./encoding";
 
 export type EditRoute = "ast" | "hash" | "diff";
 
@@ -224,7 +225,7 @@ export async function routeEdit(params: {
         let source: string;
         let casHash: string | undefined;
         try {
-          source = await Bun.file(filePath).text();
+          source = (await readDecoded(filePath)).text;
           editSource = source;
           casHash = computeHash(source);
         } catch (e: any) {
@@ -279,7 +280,7 @@ export async function routeEdit(params: {
       // Write result to file if successful — CAS guard prevents silent data
       // loss when concurrent edits both read the same snapshot.
       if (result.success && (result as any).newSource && !dryRun) {
-        const currentOnDisk = await Bun.file(filePath).text();
+        const currentOnDisk = (await readDecoded(filePath)).text;
         const nowHash = computeHash(currentOnDisk);
         if (nowHash !== casHash) {
           result = {
@@ -298,9 +299,9 @@ export async function routeEdit(params: {
       break;
     }
     case "hash":
-      editSource = await Bun.file(filePath).text();
+      editSource = (await readDecoded(filePath)).text;
       result = await replaceHash(filePath, oldHash!, newContent!, { range, dryRun });
-      editResult = (await Bun.file(filePath).text());
+      editResult = ((await readDecoded(filePath)).text);
       break;
     case "diff": {
       // An empty newContent is a deletion. Only oldContent must be non-empty —
@@ -312,7 +313,7 @@ export async function routeEdit(params: {
       let source: string;
       let casHash: string | undefined;
       try {
-        source = await Bun.file(filePath).text();
+        source = (await readDecoded(filePath)).text;
         editSource = source;
         casHash = computeHash(source);
       } catch (e: any) {
@@ -336,7 +337,7 @@ export async function routeEdit(params: {
         }
       }
       if (result.success && (result as any).newSource && !dryRun) {
-        const currentOnDisk = await Bun.file(filePath).text();
+        const currentOnDisk = (await readDecoded(filePath)).text;
         const nowHash = computeHash(currentOnDisk);
         if (nowHash !== casHash) {
           result = {

--- a/tests/encoding.test.ts
+++ b/tests/encoding.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Issue #30 — byte fidelity across the read/edit/write boundary.
+ *
+ * Fixtures are generated rather than committed: a file whose whole point is
+ * its CRLF endings or its BOM is exactly the file git's autocrlf and
+ * text-normalization settings are most likely to rewrite on checkout, which
+ * would silently turn these into no-op tests on someone else's machine.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { decodeText, encodeText, readDecoded } from "../src/core/encoding";
+import { readMany, computeHash } from "../src/core/read";
+import { replaceHash } from "../src/core/hash-edit";
+import { routeEdit } from "../src/core/router";
+
+const BOM = "﻿";
+
+/** name -> raw bytes, covering every layout the tiers have to survive. */
+const FIXTURES: Record<string, string> = {
+  lf: "alpha\nbeta\ngamma\n",
+  crlf: "alpha\r\nbeta\r\ngamma\r\n",
+  cr: "alpha\rbeta\rgamma\r",
+  mixed: "alpha\r\nbeta\ngamma\r\n",
+  "no-trailing-newline": "alpha\nbeta\ngamma",
+  "bom-lf": `${BOM}alpha\nbeta\ngamma\n`,
+  "bom-crlf": `${BOM}alpha\r\nbeta\r\ngamma\r\n`,
+  emoji: "const label = \"\u{1F680}\u{1F680} astral\";\nconst other = 1;\n",
+  cjk: "const 名前 = \"漢字テスト\";\nconst other = 1;\n",
+  "cjk-ext-b": "const x = \"\u{20BB7}\u{2A6B2}\";\nconst other = 1;\n",
+};
+
+const DIR = join(import.meta.dir, "__tmp_encoding__");
+const write = (name: string, raw: string): string => {
+  const p = join(DIR, `${name}.ts`);
+  writeFileSync(p, raw, "utf8");
+  return p;
+};
+const bytes = (p: string): string => readFileSync(p, "utf8");
+
+beforeEach(() => {
+  rmSync(DIR, { recursive: true, force: true });
+  mkdirSync(DIR, { recursive: true });
+});
+afterEach(() => rmSync(DIR, { recursive: true, force: true }));
+
+describe("decodeText / encodeText (issue #30)", () => {
+  for (const [name, raw] of Object.entries(FIXTURES)) {
+    test(`${name} round-trips byte-for-byte`, () => {
+      const { text, encoding } = decodeText(raw);
+      expect(text).not.toContain("\r");
+      expect(encodeText(text, encoding)).toBe(raw);
+    });
+  }
+
+  test("the BOM is stripped from the text, not folded into line 1", () => {
+    const { text } = decodeText(FIXTURES["bom-lf"]);
+    expect(text.startsWith("alpha")).toBe(true);
+    // Line 1's hash must not depend on a byte-order mark the agent never sees.
+    expect(text).toBe(decodeText(FIXTURES.lf).text);
+  });
+
+  test("a mixed-ending file records per-line endings; a consistent one does not", () => {
+    expect(decodeText(FIXTURES.mixed).encoding.endings).toEqual(["\r\n", "\n", "\r\n"]);
+    expect(decodeText(FIXTURES.crlf).encoding.endings).toBeUndefined();
+  });
+
+  test("a file with no line endings at all defaults to LF for new lines", () => {
+    const { encoding } = decodeText("solo");
+    expect(encoding.eol).toBe("\n");
+    expect(encoding.trailingNewline).toBe(false);
+  });
+
+  test("emptying a file yields an empty file, not a blank line", () => {
+    const { encoding } = decodeText(FIXTURES.crlf);
+    expect(encodeText("", encoding)).toBe("");
+  });
+
+  test("readDecoded normalizes what the tiers see", async () => {
+    const p = write("crlf", FIXTURES.crlf);
+    expect((await readDecoded(p)).text).toBe(FIXTURES.lf);
+  });
+});
+
+describe("read tier sees normalized text (issue #30)", () => {
+  test("the same logical content hashes the same regardless of layout", async () => {
+    const paths = [write("lf", FIXTURES.lf), write("crlf", FIXTURES.crlf), write("bom-lf", FIXTURES["bom-lf"])];
+    const results = await readMany(paths);
+    const hashes = new Set(results.map((r) => r.hash));
+    expect(hashes.size).toBe(1);
+    expect([...hashes][0]).toBe(computeHash(FIXTURES.lf));
+  });
+});
+
+describe("edit tiers preserve byte layout (issue #30)", () => {
+  const layouts = ["lf", "crlf", "cr", "mixed", "no-trailing-newline", "bom-lf", "bom-crlf"];
+
+  for (const name of layouts) {
+    test(`hash tier: replacing content with itself leaves ${name} byte-identical`, async () => {
+      const p = write(name, FIXTURES[name]);
+      const { text } = await readDecoded(p);
+      const result = await replaceHash(p, computeHash(text), text);
+      expect(result.success).toBe(true);
+      expect(bytes(p)).toBe(FIXTURES[name]);
+    });
+
+    test(`diff tier: replacing content with itself leaves ${name} byte-identical`, async () => {
+      const p = write(name, FIXTURES[name]);
+      const { text } = await readDecoded(p);
+      const result = await routeEdit({
+        filePath: p, operation: "search-replace", method: "diff",
+        oldContent: text, newContent: text,
+      });
+      expect(result.result.success).toBe(true);
+      expect(bytes(p)).toBe(FIXTURES[name]);
+    });
+  }
+
+  test("a one-line edit in a CRLF file changes exactly one line", async () => {
+    const p = write("crlf", FIXTURES.crlf);
+    const result = await routeEdit({
+      filePath: p, operation: "search-replace", method: "diff",
+      oldContent: "beta", newContent: "BETA",
+    });
+    expect(result.result.success).toBe(true);
+    expect(bytes(p)).toBe("alpha\r\nBETA\r\ngamma\r\n");
+  });
+
+  test("an edit does not invent a trailing newline the file never had", async () => {
+    const p = write("no-trailing-newline", FIXTURES["no-trailing-newline"]);
+    await routeEdit({
+      filePath: p, operation: "search-replace", method: "diff",
+      oldContent: "gamma", newContent: "GAMMA",
+    });
+    expect(bytes(p)).toBe("alpha\nbeta\nGAMMA");
+  });
+
+  test("the BOM survives an edit and stays out of line 1", async () => {
+    const p = write("bom-crlf", FIXTURES["bom-crlf"]);
+    await routeEdit({
+      filePath: p, operation: "search-replace", method: "diff",
+      oldContent: "alpha", newContent: "ALPHA",
+    });
+    expect(bytes(p)).toBe(`${BOM}ALPHA\r\nbeta\r\ngamma\r\n`);
+  });
+
+  test("AST offsets line up with JS string offsets past the BMP", async () => {
+    for (const name of ["emoji", "cjk", "cjk-ext-b"]) {
+      const p = write(name, FIXTURES[name]);
+      const result = await routeEdit({
+        filePath: p, operation: "rename-symbol", oldName: "other", newName: "renamed",
+      });
+      expect(result.result.success).toBe(true);
+      expect(bytes(p)).toBe(FIXTURES[name].replace("other", "renamed"));
+    }
+  });
+});

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -286,7 +286,10 @@ describe("routeEdit", () => {
     expect(result.route).toBe("hash");
     expect(result.result.success).toBe(true);
     const updated = readFileSync(file, "utf-8");
-    expect(updated).toBe("alpha\nbeta\ngamma");
+    // The original ended with a newline, so the result does too (#30): an agent
+    // handing back content without one is describing lines, not asking to
+    // change how the file terminates.
+    expect(updated).toBe("alpha\nbeta\ngamma\n");
     teardown(file);
   });
 

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -107,7 +107,8 @@ describe("undo", () => {
 
     setCurrentChangeSet("cs-1");
     await safeWrite(file, "clobbered");
-    expect(readFileSync(file, "utf8")).toBe("clobbered");
+    // The write inherits the file's CRLF and trailing newline (#30).
+    expect(readFileSync(file, "utf8")).toBe("clobbered\r\n");
 
     setCurrentChangeSet(null);
     const result = undoChangeSet("cs-1");


### PR DESCRIPTION
Closes #30 (audit ref B27).

## Problem

Every read site did `.split("\n")` and every write did `.join("\n")`. That broke byte fidelity three ways:

- `\r` deleted from every line of a CRLF file — a one-line edit produced a whole-file diff
- a BOM folded into line 1, corrupting that line's hash
- the trailing newline dropped, or invented where the file never had one

## Approach

Normalize at the boundary rather than threading encoding metadata through every tier:

- `src/core/encoding.ts` — `decodeText` strips the BOM and converts CRLF/CR/LF to plain `\n`, returning the text plus a `FileEncoding` (`bom`, dominant `eol`, per-line `endings` when the file was inconsistent, `trailingNewline`). `encodeText` restores the original layout. `readDecoded` is the read-side entry point.
- Read sites now use `readDecoded`: `read.ts`, `hash-edit.ts`, `diff-engine.ts`, `plan-executor.ts`, `router.ts`. Hashing, line splitting, and AST offsets never see a `\r`.
- Write side re-applies the target file's layout in both `safeWrite` and `atomicWrite`. The incoming content is re-decoded first, so the transform is idempotent and correct whether or not the caller normalized. Encoding runs **before** `recordSnapshot` — otherwise the snapshot hashes bytes that never reach disk and `undo` fails its own verification.
- Trailing-newline presence follows the file, not the edit. Emptying a file yields an empty file, not a lone blank line.

Astral-plane content needed no change: tree-sitter `startIndex`/`endIndex` are UTF-16 code units matching JS string offsets, verified by test for emoji, CJK, and CJK Extension B.

## Tests

`tests/encoding.test.ts` — 34 tests. Fixtures (LF, CRLF, lone CR, mixed, no-trailing-newline, BOM+LF, BOM+CRLF, emoji, CJK, CJK-ext-B) are generated rather than committed: a file whose whole point is its CRLF endings is exactly the file git's text normalization would rewrite on someone else's checkout. Covers unit round-trips, layout-independent hashing, and per-tier replace-content-with-itself byte-identity across hash and diff tiers.

Two existing tests updated to the corrected behavior (`router.test.ts` trailing newline, `snapshot.test.ts` CRLF).

Full suite: **676 pass / 0 fail**.

## Known limitation

Mixed-ending files restore endings *by line position*, so lines after an insertion take the ending that used to belong to that index; new lines take the dominant style. Documented in `docs/ARCHITECTURE.md`.

## Note on the base branch

Stacked on `feat/verify-scope-baseline` (PR #84, green, unmerged). Retarget to `main` once #84 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)