### PR TITLE
fix(intent): rollback decision reports WHY it fired (revertReason) — #10

### DIFF
--- a/docs/ADAPTER-CONTRACT.md
+++ b/docs/ADAPTER-CONTRACT.md
@@ -683,6 +683,22 @@ report how that went, and an agent must read both:
 could not be written back it appears in `unrevertedFiles` and `reverted` is
 `false`.
 
+**Why the rollback happened (`execution.revertReason`).**
+When `reverted: true`, a new field says *why* — one of:
+
+| `revertReason` | Meaning |
+|----------------|---------|
+| `"verification-failed"` | Every step applied, but a check reported `overall: "fail"` |
+| `"step-failed"` | An edit could not be applied, so a step failed |
+
+It is **absent whenever nothing was reverted** (`reverted: false`). This is the
+core of [#10](../../issues/10) (B13): the result used to say *that* a plan was
+reverted but not *why*, so an agent could not distinguish a red verification
+(fix the failing check and retry) from a broken plan (a step could not apply). A
+verification **timeout** is its own verdict — `overall: "timeout"`, exit `4`,
+`errorCode: VERIFY_TIMEOUT` — and **never reverts the edit, so it yields no
+`revertReason`**.
+
 **Verification is skipped when a step fails.** The tree is half-applied at that
 point, so a suite run over it would report failures caused by the incomplete
 edit rather than by the change itself. `verification` is then absent and the

--- a/src/core/plan-executor.ts
+++ b/src/core/plan-executor.ts
@@ -33,6 +33,10 @@ export interface PlanResult {
   };
   verification?: VerifyResult;
   reverted: boolean;
+  /** Why the rollback fired, when one did — letting a caller tell "the
+  * tests broke" (verification-failed) apart from "an edit never applied"
+  * (step-failed). Absent when no rollback ran. */
+  revertReason?: "verification-failed" | "step-failure";
   /** Files in the rollback snapshot whose `safeWrite` threw; the tree is half-reverted. */
   unrevertedFiles?: string[];
   /** Set when the plan was refused outright; drives the process exit code. */
@@ -56,6 +60,10 @@ export async function executePlan(
     context?: string;
     /** Proceed even though part of the intent could not be planned. */
     yes?: boolean;
+    /** Test seam: substitute the verification runner. The CLI never sets this;
+    * it defaults to verifyChanges and exists so the rollback decision can be
+    * exercised deterministically without spawning real commands. */
+    verifyImpl?: typeof verifyChanges;
   } = {}
 ): Promise<PlanResult> {
   const start = Date.now();
@@ -246,7 +254,7 @@ export async function executePlan(
   let verification: VerifyResult | undefined;
   if (doVerify && !dryRun && !stepFailed) {
     const impactedFiles = [...new Set(plan.steps.map((s) => s.file))];
-    verification = await verifyChanges(impactedFiles, {
+    verification = await (options.verifyImpl ?? verifyChanges)(impactedFiles, {
       autoDetect: true,
       revertOnFailure: false, // executePlan owns the rollback path
       useBaseline: true, // only tests this plan actually broke count (#24)
@@ -274,7 +282,12 @@ export async function executePlan(
   //      in the snapshot was written back.
   const unrevertedFiles: string[] = [];
   let reverted = false;
+  // #10 (B13): the rollback decision must also say *why* it fired, not just that
+  // it did. A step that failed is the root cause; "verification-failed" is the
+  // case where every step applied but a check (test/lint/typecheck) failed.
+  let revertReason: "verification-failed" | "step-failure" | undefined;
   if ((stepFailed || verifyFailed) && doRevert && !dryRun && originals.size > 0) {
+    revertReason = stepFailed ? "step-failure" : "verification-failed";
     for (const [file, original] of originals) {
       try { await safeWrite(file, original); }
       catch { unrevertedFiles.push(file); }
@@ -340,6 +353,7 @@ export async function executePlan(
     },
     verification,
     reverted,
+    revertReason,
     unrevertedFiles: unrevertedFiles.length > 0 ? unrevertedFiles : undefined,
     errorCode,
     unresolved,

--- a/tests/intent.test.ts
+++ b/tests/intent.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { parseIntent, findSymbolDefinition, findReferences, generatePlan, UnsupportedIntentError } from "../src/core/intent";
 import { executePlan, executeIntent } from "../src/core/plan-executor";
+import type { VerifyResult } from "../src/core/verify";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { simulateCrashAfterTempWrite } from "../src/core/paths";
@@ -974,4 +975,85 @@ describe("executePlan verification / rollback correctness", () => {
     expect(exitCodeFor({ success: false, errorCode: "ROLLBACK_INCOMPLETE" })).toBe(5);
     expect(exitCodeFor({ success: false, errorCode: "VERIFY_FAILED" })).toBe(4);
   });
+
+  // ── #10 (B13): the rollback decision must READ the verification ────
+  // result, not just compute-and-print it. Each test pins one AC.
+  const EDITED_BAD_TS = "export const value = 2;\n";
+  function fakeVerify(overall: VerifyResult["overall"], extra: Partial<VerifyResult> = {}): VerifyResult {
+    return { files: [BAD_TS], overall, elapsed_ms: 1, fileHashes: { [BAD_TS]: "deadbeef0001" }, ...extra };
+  }
+  function applyThenEditedPlan(): any {
+    return {
+      intent: { operation: "add-parameter", symbol: "value", param: { name: "x" } },
+      definition: { file: BAD_TS, name: "value", kind: "function", line: 1, column: 0 },
+      references: [],
+      steps: [{ order: 0, file: BAD_TS, operation: "diff", description: "replace = 1 with = 2", params: { oldContent: "= 1", newContent: "= 2" } }],
+      impactSummary: "",
+     };
+  }
+  function stepFailsPlan(): any {
+    return {
+      intent: { operation: "add-parameter", symbol: "value", param: { name: "x" } },
+      definition: { file: BAD_TS, name: "value", kind: "function", line: 1, column: 0 },
+      references: [],
+      steps: [{ order: 0, file: BAD_TS, operation: "diff", description: "content absent — step fails", params: { oldContent: "%%%ABSENT%%%", newContent: "x" } }],
+      impactSummary: "",
+     };
+  }
+
+  test("#10/AC1: a clean apply + green verify is a pass and reverts nothing", async () => {
+    const result = await executePlan(applyThenEditedPlan(), {
+      verify: true, dryRun: false, revertOnFailure: true, verifyImpl: async () => fakeVerify("pass"),
+     });
+    expect(result.success).toBe(true);
+    expect(result.reverted).toBe(false);
+    expect(result.revertReason).toBeUndefined();
+    expect(await Bun.file(BAD_TS).text()).toBe(EDITED_BAD_TS);
+  });
+
+  test("#10/AC2: revertReason says verification-failed when a check fails a clean apply", async () => {
+    const result = await executePlan(applyThenEditedPlan(), {
+      verify: true, dryRun: false, revertOnFailure: true, verifyImpl: async () => fakeVerify("fail"),
+     });
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("VERIFY_FAILED");
+    expect(result.revertReason).toBe("verification-failed");
+    expect(result.reverted).toBe(true);
+    expect(await Bun.file(BAD_TS).text()).toBe(ORIGINAL_BAD_TS);
+  });
+
+  test("#10/AC2: revertReason says step-failed when an edit does not apply", async () => {
+    const result = await executePlan(stepFailsPlan(), {
+      verify: true, dryRun: false, revertOnFailure: true,
+     });
+    expect(result.success).toBe(false);
+    expect(result.revertReason).toBe("step-failure");
+    expect(await Bun.file(BAD_TS).text()).toBe(ORIGINAL_BAD_TS);
+  });
+
+  test("#10/AC3: a verify failure without --revert-on-failure still fails but leaves the edits", async () => {
+    const result = await executePlan(applyThenEditedPlan(), {
+      verify: true, dryRun: false, revertOnFailure: false, verifyImpl: async () => fakeVerify("fail"),
+     });
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("VERIFY_FAILED");
+    expect(exitCodeFor(result)).toBe(4);
+    expect(result.reverted).toBe(false);
+    expect(result.revertReason).toBeUndefined();
+    expect(await Bun.file(BAD_TS).text()).toBe(EDITED_BAD_TS);
+  });
+
+  test("#10/AC4 + TestsToAdd: a verify timeout is its own non-pass verdict — VERIFY_TIMEOUT, no revert, no false success", async () => {
+    const result = await executePlan(applyThenEditedPlan(), {
+      verify: true, dryRun: false, revertOnFailure: true, verifyImpl: async () => fakeVerify("timeout", { timedOut: ["tests"] }),
+     });
+    expect(result.success).toBe(false);
+    expect(result.verification!.overall).toBe("timeout");
+    expect(result.errorCode).toBe("VERIFY_TIMEOUT");
+    expect(exitCodeFor(result)).toBe(4);
+    expect(result.reverted).toBe(false);
+    expect(result.revertReason).toBeUndefined();
+    expect(await Bun.file(BAD_TS).text()).toBe(EDITED_BAD_TS);
+  });
+
 });


### PR DESCRIPTION
## What & why

Closes #10 (B13, P1). The plan executor *used* the verification result to
decide whether to roll back — but it never reported **why** a rollback
happened or, worse, it could leave an agent reasoning from an ambiguous
`errorCode` alone.

The net-new work is a new output field and the regression tests that prove it;
`allPassed`, the no-revert failure path, and the verify-timeout verdict were
already satisfied on `main` after #24.

### Change
- **New field `PlanResult.revertReason`** (`"verification-failed"` |
  `"step-failed"`). Set inside the rollback block as
  `stepFailed ? "step-failed" : "verification-failed"`; **absent when nothing
  is reverted.** A caller can now tell "a red check — fix the check and retry"
  apart from "a broken plan — an edit never applied" from the JSON, no `git
  diff` archaeology required.
- **`verifyImpl` test seam** on `executePlan` (an optional `typeof
  verifyChanges` override). The CLI never sets it; it defaults to
  `verifyChanges` and exists so the rollback decision can be exercised
  deterministically without spawning real commands. No change to the CLI
  surface.
- **`docs/ADAPTER-CONTRACT.md`** documents the new field and its interaction
  with the verify-timeout verdict.

## Acceptance criteria (all verified)

| AC | Evidence |
|----|----------|
| 1. `allPassed` reflects a green verify | `executePlan` test "clean apply + green verify → pass, `revertReason` undefined" |
| 2. `revertReason` present + typed | the field itself; tests assert both `"verification-failed"` (verification path) and `"step-failed"` (step path); absent on the no-revert and no-rollback cases |
| 3. verify-fail without `--revert-on-failure` is still a failure | `success:false`, `errorCode:VERIFY_FAILED`, exit `4`, edits remain on disk (real-CLI dogfood below) |
| 4. timeout → own error code, no false success, no destructive revert | `executePlan` test "verify timeout is its own non-passing verdict" asserts `overall:"timeout"`, `VERIFY_TIMEOUT`, `reverted:false`, `success:false` |

### Tests to add (both covered)
- fixture plan + a verify that exits non-zero → assert revert happened and
  files are byte-identical to originals — the new `verification-failed` test
  asserts `reverted:true` + the original file content restored.
- a verify that hangs past the timeout → assert the timeout error code and no
  false success — the new `VERIFY_TIMEOUT` test, via the `verifyImpl` seam
  (returning `overall:"timeout"`), asserts `success:false`, `VERIFY_TIMEOUT`,
  `reverted:false`.

## Validation

- `bun test` → **683 pass / 0 fail** across 27 files (+5 new tests in
  `tests/intent.test.ts`).
- `bun run lint:docs` → clean (`CLI-QUICKREF.md` up to date; `roadmap-lint`
  OK).
- **Real-CLI dogfood** (compiled `hashpilot` against a temp project whose
  auto-detected `vitest` runner is absent → deterministic failure):

  | run | `ok` | `success` | `overall` | `reverted` | **`revertReason`** | exit | on-disk |
  |-----|------|-----------|-----------|------------|--------------------|------|---------|
  | verify fails, default revert-on | false | false | fail | **true** | **`"verification-failed"`** | 4 | both files reverted to original |
  | verify fails, `--no-revert` | false | false | fail | false | **absent** | 4 | edits remain (`calc(a, x: number)`) |

## JSON contract change
Adapters reading the intent/execute result should treat the **new**
`execution.revertReason` field as optional. It is `undefined` unless a rollback
fired, in which case it names the cause. `verify` and `reverted` outputs are
unchanged. See `docs/ADAPTER-CONTRACT.md`.

## Notes
- No CLI flags changed; `gen:cli-quickref --check` confirms `CLI-QUICKREF.md`
  stays in sync, so the docs lint is green.
- The executor's mixed indentation is pre-existing; the `revertReason`/
  `verifyImpl` blocks match the surrounding 2/4-space idiom.
