### PR TITLE
fix(rename): make rename-symbol file-scoped and binding-aware (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You edit source files every time a user asks for a change. With HashPilot:
 
 - **You know the hash is correct.** `replace-hash` targets content by its SHA-256 fingerprint. No ambiguity.
 - **You don't need to re-read the file.** The hash from `read-many` is valid until the file changes. That's one less API round-trip.
-- **AST edits are syntax-safe.** `rename-symbol`, `replace-body`, `add-import` — tree-sitter guarantees the edit is structurally valid.
+- **AST edits are syntax-safe.** `rename-symbol`, `replace-body`, `add-import` — tree-sitter guarantees the edit is structurally valid. `rename-symbol` is **file-scoped and binding-aware**: it renames a symbol and its references within the target file, but refuses with `AMBIGUOUS_SYMBOL` when the same name binds more than one symbol in that file — a shadowed local, a foreign `import`, or a duplicate top-level declaration — so a file-wide rename never clobbers an unintended binding. Disambiguate by scoping the rename or renaming each declaration separately.
 - **Intents handle the blast radius.** One `intent` command handles definition + all call sites + verification.
 - **Telemetry tells you when something's wrong.** Stale-anchor rates, per-language failure rates, verify pass rates — all queryable.
 
@@ -284,7 +284,7 @@ Retention defaults to 200 changeSets / 7 days, configurable under `snapshots` in
 |---------|-------------|
 | `ast capabilities` | Show supported languages, operations, and limitations |
 | `ast find-symbols <file>` | List all symbols (functions, classes, variables) |
-| `ast rename-symbol <file> <old> <new>` | Rename a symbol and all its references |
+| `ast rename-symbol <file> <old> <new>` | Rename a symbol and all its references within **one file**, binding-aware — refuses with `AMBIGUOUS_SYMBOL` (exit `2`) when the name binds more than one symbol (a shadowed local, a foreign import, or a duplicate declaration) |
 | `ast replace-body <file> <symbol> <body>` | Replace a function/method body |
 | `ast add-import <file> <spec>` | Add an import with grouped-import merging |
 | `ast remove-import <file> <spec>` | Remove an import statement |

--- a/docs/ADAPTER-CONTRACT.md
+++ b/docs/ADAPTER-CONTRACT.md
@@ -1057,9 +1057,24 @@ All commands return JSON with:
 - `message` with human-readable description
 
 **Error codes:** `PARSE_ERROR`, `SYMBOL_NOT_FOUND`, `STALE_ANCHOR`,
-`AMBIGUOUS_ANCHOR`, `HASH_MISMATCH`, `INVALID_ARGUMENT`, `PATH_DENIED`,
+`AMBIGUOUS_ANCHOR`, `AMBIGUOUS_SYMBOL`, `HASH_MISMATCH`, `INVALID_ARGUMENT`,
+`PATH_DENIED`,
 `UNSUPPORTED_OPERATION`, `FILE_NOT_FOUND`, `READ_FAILED`, `WRITE_FAILED`,
 `VERIFY_FAILED`, `VERIFY_TIMEOUT`.
+
+`AMBIGUOUS_SYMBOL` is returned by `ast rename-symbol` when the target name
+binds more than one symbol in the file — a shadowed local, a foreign
+`import`, or a duplicate top-level declaration (it maps to exit code `2`,
+the `SYMBOL_NOT_FOUND` edit-failure band). The file is **not** touched. The
+error `message` lists the contending binding sites, each as `line <N> (kind)`
+where `kind` is the declaration type (`variable_declarator`,
+`function_declaration`, `function_definition`, `class_declaration`,
+`type_alias_declaration`, `interface_declaration`, `enum_declaration`,
+`import`, or `parameter`). `rename-symbol` is file-scoped and binding-aware
+by design: it renames a symbol and its references within the target file only,
+and refuses a file-wide rename that would clobber an unintended binding.
+Disambiguate by scoping the rename to the intended binding, or rename each
+declaration separately.
 
 `READ_FAILED` means the file exists but could not be read (permissions, a
 directory in its place, a device error) — distinct from `FILE_NOT_FOUND`.

--- a/docs/CLI-QUICKREF.md
+++ b/docs/CLI-QUICKREF.md
@@ -258,7 +258,7 @@ hashpilot ast find-symbols [options] <file>
 
 #### `ast rename-symbol`
 
-Rename a symbol across a file
+File-scoped, binding-aware rename of a symbol and its references. Refuses with AMBIGUOUS_SYMBOL when the name binds more than one symbol in the file (a shadowed local, a foreign import, or a duplicate declaration).
 
 ```
 hashpilot ast rename-symbol [options] <file> <old-name> <new-name>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -307,7 +307,11 @@ function recordProvenanceEvent(opts: {
 
 astCmd
   .command("rename-symbol")
-  .description("Rename a symbol across a file")
+   .description(
+      "File-scoped, binding-aware rename of a symbol and its references. " +
+      "Refuses with AMBIGUOUS_SYMBOL when the name binds more than one symbol " +
+      "in the file (a shadowed local, a foreign import, or a duplicate declaration).",
+     )
   .argument("<file>", "File path")
   .argument("<old-name>", "Current symbol name")
   .argument("<new-name>", "New symbol name")

--- a/src/core/ast-edit.ts
+++ b/src/core/ast-edit.ts
@@ -298,6 +298,121 @@ export function findSymbols(source: string, filePath: string): SymbolInfo[] {
   return symbols;
 }
 
+/**
+* Node types whose presence in an ancestor chain marks an identifier as an
+* imported name (rather than a local use). Conservative across the six
+* grammars — better to over-flag a binding than to miss one.
+*/
+const IMPORT_CONTEXT = new Set([
+   // TypeScript / JavaScript
+  "import_statement", "import_clause", "named_import", "import",
+   // Python
+  "import_from_statement", "import_prefix", "alias", "dotted_name",
+   // Go
+  "import_declaration", "import_spec", "imported_path",
+   // Rust
+  "use_declaration", "use_as_clause", "nested_use_delimiter",
+  "identifier_path", "scoped_identifier",
+]);
+
+
+/**
+* Node types whose presence in an ancestor chain marks an identifier as a
+* *parameter*. A name bound as a parameter is a fresh scope, so two parameters
+* — or a parameter and a local — of the same name in one file are two bindings
+* (shadowing), and a file-wide rename is unsafe. Parameter node names differ
+* across the six grammars, so the list is approximate and deliberately
+* conservative (better to refuse than to clobber).
+*/
+const PARAM_CONTEXT = new Set([
+    // TypeScript / JavaScript
+    "function_parameter", "variable_pattern", "pattern",
+    // Python
+    "parameters", "typed_parameter", "default_parameter", "optional_parameter",
+    "required_parameter", "simple_parameter",
+    // Go / Rust
+    "parameter_declaration", "parameter_list", "function_parameter", "parameter",
+    "formal_parameters",
+]);
+
+/** A place in a file where a name is *bound* (declared or imported). */
+interface BindingSite {
+  row: number;
+  kind: string;
+}
+
+/**
+* Collect every location that binds `oldName`: each declaration whose symbol
+* name equals it (a shadow is simply a *second* declaration at an inner scope)
+* plus each import that binds the name. `rename-symbol` is file-safe only when
+* there is at most one such site; more than one means the name is genuinely
+* multi-bound and a file-wide textual rename would clobber an unintended one.
+*
+* Property keys, string literals, and comments are never `identifier`/
+* `type_identifier` nodes here, so they are excluded for free — the only gap
+* this fills is the *binding* gap (which of several same-named symbols targeted).
+*/
+function collectBindingSites(
+  tree: Parser.SyntaxTree,
+  oldName: string,
+  cfg: LangConfig
+): BindingSite[] {
+  const sites: BindingSite[] = [];
+  const seen = new Set<number>();
+  const push = (row: number, kind: string, idx: number) => {
+    if (!seen.has(idx)) {
+       seen.add(idx);
+      sites.push({ row, kind });
+     }
+   };
+
+  function isImportBinding(node: Parser.SyntaxNode): boolean {
+    let p = node.parent;
+    while (p && p.type) {
+      if (IMPORT_CONTEXT.has(p.type)) return true;
+      p = p.parent;
+      }
+    return false;
+    }
+
+  function isParamBinding(node: Parser.SyntaxNode): boolean {
+    let p = node.parent;
+    while (p && p.type) {
+      if (PARAM_CONTEXT.has(p.type)) return true;
+      p = p.parent;
+      }
+    return false;
+    }
+
+  function walk(node: Parser.SyntaxNode) {
+     // Declaration site: a symbol-kind node whose declared name matches.
+    if (cfg.symbolKinds.includes(node.type)) {
+      const nameNode =
+        node.childForFieldName("name") ||
+        node.children.find((c) => IDENTIFIER_TYPES.has(c.type));
+      if (nameNode && nameNode.text === oldName) {
+        push(node.startPosition.row + 1, node.type, node.startIndex);
+        }
+      }
+     // An identifier that is not a declaration may still bind the name as an
+     // import or as a parameter. Only one of those applies to a given node.
+    const isIdent = node.type === "identifier" || node.type === "type_identifier";
+    if (isIdent && node.text === oldName) {
+      if (isImportBinding(node)) {
+        push(node.startPosition.row + 1, "import", node.startIndex);
+        return; // an import is a binding on its own; don't re-count as a param
+        }
+      if (isParamBinding(node)) {
+        push(node.startPosition.row + 1, "parameter", node.startIndex);
+        }
+      }
+    for (const child of node.children) walk(child);
+    }
+
+  walk(tree.rootNode);
+  return sites;
+}
+
 function renameSymbolUnchecked(
   source: string,
   filePath: string,
@@ -313,6 +428,31 @@ function renameSymbolUnchecked(
   let changes = 0;
   const edits: { start: number; end: number; text: string }[] = [];
 
+   // #14 (B9): a file-wide rename is only safe when the name binds at most one
+   // symbol in this file. Detect the bindings first; if there is more than one
+   // (a shadow/local, a foreign import, or duplicate top-level declarations)
+   // refuse and name the sites. The node-type filter below already spares
+   // property keys, string literals, and comments.
+  const cfg = configFor(lang);
+  const bindingSites = cfg ? collectBindingSites(tree, oldName, cfg) : [];
+  if (bindingSites.length > 1) {
+    const where = bindingSites
+       .map((s) => `   line ${s.row} (${s.kind})`)
+       .join("\n");
+    return {
+      success: false,
+      path: filePath,
+      operation: "rename-symbol",
+      changes: 0,
+      message:
+         `Symbol '${oldName}' binds ${bindingSites.length} distinct locations in this ` +
+         `file (a shadow, a foreign import, or duplicate declarations); refusing a ` +
+         `file-wide rename that would clobber an unintended binding. Disambiguate by ` +
+         `scoping the rename or renaming each declaration separately:\n${where}`,
+      errorCode: ErrorCode.AMBIGUOUS_SYMBOL,
+      symbolFound: true,
+      };
+   }
   function findRefs(node: Parser.SyntaxNode) {
     if ((node.type === "identifier" || node.type === "type_identifier") && node.text === oldName) {
       edits.push({ start: node.startIndex, end: node.endIndex, text: newName });

--- a/src/core/exit-codes.ts
+++ b/src/core/exit-codes.ts
@@ -35,6 +35,10 @@ const ERROR_CODE_EXITS: Record<string, ExitCode> = {
   [ErrorCode.SYMBOL_NOT_FOUND]: ExitCode.EDIT_FAILED,
   [ErrorCode.PARSE_ERROR]: ExitCode.EDIT_FAILED,
   [ErrorCode.DUPLICATE_MATCH]: ExitCode.EDIT_FAILED,
+    // "Same name binds more than one symbol in this file" is a failed edit
+    // attempt (a precondition the caller didn't meet), not a stale/retryable
+    // anchor — so it shares the EDIT_FAILED band with SYMBOL_NOT_FOUND.
+    [ErrorCode.AMBIGUOUS_SYMBOL]: ExitCode.EDIT_FAILED,
   [ErrorCode.UNSUPPORTED_LANGUAGE]: ExitCode.EDIT_FAILED,
   [ErrorCode.VERIFY_FAILED]: ExitCode.VERIFY_FAILED,
   // A timeout shares the verification band — the edit applied, verification did

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -66,6 +66,14 @@ export enum ErrorCode {
   ROLLBACK_INCOMPLETE = "ROLLBACK_INCOMPLETE",
   /** The anchor could not be relocated unambiguously (multiple candidate matches). */
   AMBIGUOUS_ANCHOR = "AMBIGUOUS_ANCHOR",
+   /**
+    * rename-symbol was asked to rename a name that binds **more than one**
+    * distinct symbol in the file — a shadowed local, a foreign import of the
+    * same name, or two top-level declarations. A file-wide textual rename would
+    * clobber a binding the caller did not mean to touch, so the operation
+    * refuses and names the contending binding sites.
+    */
+  AMBIGUOUS_SYMBOL = "AMBIGUOUS_SYMBOL",
   /** A file exists but could not be read (permissions, device error). Distinct from FILE_NOT_FOUND. */
   READ_FAILED = "READ_FAILED",
   /** Lock acquisition timed out — another process holds the advisory lock. */

--- a/tests/ast-edit.test.ts
+++ b/tests/ast-edit.test.ts
@@ -1003,3 +1003,107 @@ describe("parse-validity gate (#13)", () => {
     expect(firstParseError("export declare const x: number", "types.d.ts")).toBeNull();
   });
 });
+
+// ── renameSymbol — binding-aware ambiguity guard (#14) ──────────────────
+// #14: a file-wide `rename-symbol` used to rename every reference of a name
+// in the file with no notion of *which* symbol was intended, silently
+// clobbering a shadowed local, a foreign import, or a duplicate top-level
+// declaration. `rename-symbol` is now file-scoped AND binding-aware: it
+// refuses with AMBIGUOUS_SYMBOL when the name binds more than one symbol.
+
+const SHADOW_TS = `const config = 1;
+function useConfig(x: number) {
+  const config = 99;
+  return x + config;
+}
+export function handle() { return config; }`;
+
+const FOREIGN_IMPORT_TS = `import { value } from "./other-binder";
+const value = 1;
+console.log(value);`;
+
+const DUPLICATE_TS = `function foo() { return 1; }
+const foo = 2;
+function bar() { return 3; }
+const bar = 4;`;
+
+const PY_PARAM_SHADOW = `def outer(x):
+  def inner(x):
+    return x + 1
+  return inner(x) + x`;
+
+// AC3: a single binding where the same spelling also appears as a property key,
+// a string literal, and a comment — none of which are references and must be
+// left untouched by a successful rename.
+const PROPERTY_KEY_TS = `const data = 1;
+function f() {
+  const label = "data"; // a string literal and a comment mention of data
+  return { data: data, label };
+}`;
+
+const CLEAN_TS = `function hello() {
+    const x = 1;
+    return x;
+   }
+export { hello };`;
+
+describe("renameSymbol — binding-aware ambiguity guard (#14)", () => {
+   // AC1: a name shadowed by a local at an inner scope is multi-bound → refuse.
+  test("AC1 — refuses a rename shadowed by a local (TS)", () => {
+    const r = renameSymbol(SHADOW_TS, "shadow.ts", "config", "renamed");
+    expect(r.success).toBe(false);
+    expect(r.errorCode).toBe("AMBIGUOUS_SYMBOL");
+    expect(r.changes).toBe(0);
+    });
+
+   // AC2: a foreign import of the same name is a second binding → refuse.
+  test("AC2 — refuses a rename shadowed by a foreign import (TS)", () => {
+    const r = renameSymbol(FOREIGN_IMPORT_TS, "foreign.ts", "value", "renamed");
+    expect(r.success).toBe(false);
+    expect(r.errorCode).toBe("AMBIGUOUS_SYMBOL");
+    expect(r.changes).toBe(0);
+    });
+
+   // AC3 part 1: duplicate top-level declarations → refuse.
+  test("AC3 — refuses a rename with duplicate top-level declarations (TS)", () => {
+    const r = renameSymbol(DUPLICATE_TS, "dup.ts", "foo", "renamed");
+    expect(r.success).toBe(false);
+    expect(r.errorCode).toBe("AMBIGUOUS_SYMBOL");
+    expect(r.changes).toBe(0);
+    });
+
+   // AC3 part 2: property keys, string literals, and comments are never
+   // references, so a rename of a single-bound name leaves them untouched and
+   // still succeeds.
+  test("AC3 — property keys / strings / comments are not renamed (TS)", () => {
+    const r = renameSymbol(PROPERTY_KEY_TS, "pk.ts", "data", "renamed");
+    expect(r.success).toBe(true);
+    expect(r.changes).toBeGreaterThan(0);
+    expect(r.newSource).toContain("renamed");
+     // the string literal and comment mention survive untouched:
+    expect(r.newSource).toContain('"data"');
+    expect(r.newSource).toContain("comment mention of data");
+    });
+
+   // Python: a name reused as a parameter across nested defs is a shadow.
+  test("shadow across nested function parameters (Python)", () => {
+    const r = renameSymbol(PY_PARAM_SHADOW, "outer.py", "x", "renamed");
+    expect(r.success).toBe(false);
+    expect(r.errorCode).toBe("AMBIGUOUS_SYMBOL");
+    });
+
+   // No over-refusal: a clean single-binding symbol still renames everywhere.
+  test("does NOT over-refuse a clean single binding (TS)", () => {
+    const r = renameSymbol(CLEAN_TS, "hello.ts", "hello", "greet");
+    expect(r.success).toBe(true);
+    expect(r.changes).toBeGreaterThanOrEqual(2);
+    expect(r.newSource).toContain("greet");
+    });
+
+   // The error message names the symbol so the caller can disambiguate.
+  test("error message names the contending symbol", () => {
+    const r = renameSymbol(SHADOW_TS, "shadow.ts", "config", "renamed");
+    expect(r.message).toContain("config");
+    expect(r.message).toMatch(/binding/i);
+    });
+});


### PR DESCRIPTION
# 14 — `rename-symbol` is now file-scoped and binding-aware

`ast rename-symbol` used to rename **every reference** of a name across a file
with no notion of *which symbol* was intended, silently clobbering a **shadowed
local**, a **foreign import**, or a **duplicate top-level declaration**. This is
a silent data-integrity hazard: rename `config` in a file that also binds
`config` shadowed/imported/duplicated and you rename the wrong one (or every
one) with no warning.

## Fix

Rename is now **file-scoped and binding-aware**. Before it edits anything, it
counts the *binding sites* of the target name in the file. If the name binds
**more than one symbol** — a shadowed local, a foreign `import`, or a duplicate
top-level declaration — it **refuses** with a new `AMBIGUOUS_SYMBOL` error code
(mapping to exit code `2`, the `SYMBOL_NOT_FOUND` edit-failure band), leaves the
file **untouched**, and reports each contending site (`line \u003cN\u003e (kind)`),
so the caller can disambiguate by scoping the rename or renaming each
declaration separately.

Binding sites are detected by walking the parsed tree and recognizing each
declaration of the target name (via the operation's `symbolKinds`), plus
identifier occurrences that sit inside an import statement (`IMPORT_CONTEXT`) or
inside a function/method parameter list (`PARAM_CONTEXT`).

## Design decisions

- **File-scoped on purpose.** HashPilot edits one file per invocation; a
  file-scoped rename is the honest contract. "Which of several same-named
  symbols to target" *across files / across scopes* is the LSP tier (tracked as
  a successor) — see the closed sub-scope in the issue.
- **The only gap was the binding gap.** The existing node-type filter
  (`identifier` / `type_identifier`) already excluded property keys, string
  literals, and comments — those three ACs were already met. This change fills
  just the binding-discrimination gap (shadow / foreign-import / duplicate).
- **Conservative.** Over-refusing on a legitimately overloaded name is the safe
  direction: the cost is a one-line disambiguation, the alternative is silently
  clobbering an unintended binding.
- **Removed `"pair"` from `IMPORT_CONTEXT`.** It is the JS object-property node
  type (`{ key: value }` parses as a `pair`), not an import node, and was
   falsely flagging object-literal property keys as import bindings. Real
  import detection (`named_import`, `import_clause`, `import_statement`, …) is
  untouched.

## Validation

Dogfood via the real CLI:
- Clean single-binding rename (TS/Python/Go/Rust) → applies, **exit 0**.
- Shadowed local (`const config` shadowed by inner `const config`) → **refuses
  `AMBIGUOUS_SYMBOL`, file untouched**.
- Foreign import (`import { value }` + `const value`) → **refuses**.
- Nested Python parameter shadow (`def outer(x): def inner(x)`) → **refuses**.
- Property key / string literal / comment of the same spelling → **not renamed**.

| Command | Result |
|---|---|
| `bun test` | **690 pass / 0 fail** (was 683; +7 acceptance tests) |
| `bun test tests/ast-edit.test.ts` | 108 pass / 0 fail |
| `bun run lint:docs` | ✓ clean (CLI-QUICKREF regenerated) |
| CLI dogfood | clean applies; shadow/foreign/duplicate refuse + file untouched |

## Contract changes (per AGENTS.md)

- **New error code `AMBIGUOUS_SYMBOL`** — added to `ErrorCode`
   (`src/core/telemetry.ts`) and mapped to `ExitCode.EDIT_FAILED`
  (`src/core/exit-codes.ts`); documented in `docs/ADAPTER-CONTRACT.md`
   (error-code list + a focused paragraph).
- **`ast rename-symbol` `--help` / `README.md`** updated to state the
  file-scoped, binding-aware contract (`AMBIGUOUS_SYMBOL`, exit 2).

## Files

- `src/core/ast-edit.ts` — `collectBindingSites` + the guard (before edits);
  `PARAM_CONTEXT`; `"pair"` removed from `IMPORT_CONTEXT`.
- `src/core/telemetry.ts` — `AMBIGUOUS_SYMBOL` code.
- `src/core/exit-codes.ts` — mapping to `EDIT_FAILED`.
- `src/cli.ts` — `--help` description.
- `docs/ADAPTER-CONTRACT.md`, `docs/CLI-QUICKREF.md`, `README.md` — contract.
- `tests/ast-edit.test.ts` — +7 acceptance tests.

Closes #14.
