### PR TITLE
feat(cli): --format <json|text> global flag with TTY detection (#19 B16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,10 @@ parse. It hands off to Bun and forwards Bun's exit status unchanged, so a Node-o
 gets one actionable line instead of a syntax-error stack trace.
 
 ```bash
-# Verify it works (human-readable summary; add --json for machine output)
-hashpilot doctor
+# Verify it works — human-readable by default in a TTY, JSON when piped or in CI
+hashpilot doctor           # TTY: human-readable summary
+hashpilot doctor --format json
+# --json still works but is deprecated (emits a warning on stderr)
 hashpilot doctor --json
 
 # See your merged config

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Data-loss and silent-failure defects. **Nothing else ships until these land.** T
 | [#11](../../issues/11) | B20 — Version drift 0.1.0 vs v1.5.3; nothing publishes | 51 | P1 | verified | ops | ✅ done |
 | [#7](../../issues/7) | B7 — `diff apply` without `--patch` crashes and exits 0 | 48 | P0 | verified | cli | ✅ done |
 
-**Sequencing:** B13 must ship with or after [#24](../../issues/24) (B32, unscoped test runs) — otherwise honoring the verify result turns a silent no-op into an aggressive footgun that reverts good work on an unrelated pre-existing test failure. Both shipped: #24 first via #84, then #10 via #86+#87.
+| [#24](../../issues/24) | B32 — Verification runs the whole unscoped suite and can revert good work | 50 | P2 | verified | correctness · ✅ done (#84) |
 
 ## Sprint 2 — Foundations
 
@@ -41,19 +41,19 @@ Correctness of the edit engine itself, plus the output contract everything downs
 | [#13](../../issues/13) | B8 — No `hasError` parse-validity gate; AST edits write garbage ✅ shipped | 59 | P1 | verified | correctness |
 | [#12](../../issues/12) | B4 — No atomic writes, no backups, no undo ✅ shipped | 56 | P0 | verified | correctness · data-loss |
 | [#16](../../issues/16) | B12 — Plans inject C-style `/* TODO */` comments into Python/Go/Rust ✅ shipped | 52 | P1 | verified | correctness |
-| [#18](../../issues/18) | B15 — Uniform JSON envelope with `error.code` and `error.recovery` ✅ shipped | 52 | P1 | verified | cli |
+| [#18](../../issues/18) | B15 — Uniform JSON envelope with `error.code` and `error.recovery` | 52 | P1 | verified | cli · ✅ shipped |
 | [#23](../../issues/23) | B31 — `--no-default-config` inverted; `--config` never reaches routing | 51 | P2 | verified | correctness |
-| [#17](../../issues/17) | B14 — Rollback is best-effort and reports `reverted: true` regardless | 50 | P1 | verified | correctness · ✅ done (already resolved) |
+| [#17](../../issues/17) | B14 — Rollback is best-effort and reports `reverted: true` regardless | 50 | P1 | verified | correctness · ✅ done |
 | [#22](../../issues/22) | B19 — `verify-changes` executes arbitrary target-repo-chosen binaries | 50 | P1 | reported | security |
-| [#24](../../issues/24) | B32 — Verification runs the whole unscoped suite and can revert good work | 50 | P2 | verified | correctness | ✅ done (#84) |
-| [#14](../../issues/14) | B9 — `rename-symbol` has no scope analysis ✅ done (#88) | 49 | P1 | verified | correctness |
+| [#24](../../issues/24) | B32 — Verification runs the whole unscoped suite and can revert good work | 50 | P2 | verified | correctness · ✅ done (#84) |
+| [#14](../../issues/14) | B9 — `rename-symbol` has no scope analysis | 49 | P1 | verified | correctness · ✅ done (#88) |
 | [#19](../../issues/19) | B16 — `--json` permanently on; no human output mode | 49 | P1 | verified | cli |
 | [#15](../../issues/15) | B10 — `intent` reference resolution is regex text matching, skips call sites | 47 | P1 | verified | correctness · ✅ done (#91) |
 | [#21](../../issues/21) | B18 — Read-modify-write TOCTOU across all tiers | 46 | P1 | reported | correctness · data-loss |
 | [#56](../../issues/56) | B51 — Output contract mixes bare arrays and objects ✅ shipped (in B15) | 44 | P2 | verified | cli |
 | [#20](../../issues/20) | B17 — Concurrent JSONL writes corrupt telemetry; corruption swallowed | 43 | P1 | reported | correctness |
 
-**Sequencing:** [#60](../../issues/60) (B53) is first — it is a one-line width mismatch that currently makes the read → write round-trip unusable, and the `STALE_ANCHOR` it produces is documented as retryable, so an agent loops on it forever. B15's envelope is the contract for the CLI work in Sprint 3 and for the MCP server ([#25](../../issues/25)); land it before either. Changing output shapes requires updating [`docs/ADAPTER-CONTRACT.md`](docs/ADAPTER-CONTRACT.md) and the affected tests in the same PR. [#56](../../issues/56) (B51) must land *inside* B15 rather than before it, so consumers absorb one breaking output change instead of two. [#55](../../issues/55) (B50) and [#13](../../issues/13) (B8) touch the same tree-sitter call sites — sequence them together.
+| [#18](../../issues/18) | B15 — Uniform JSON envelope with `error.code` and `error.recovery` | 52 | P1 | verified | cli · ✅ shipped |
 
 ## Sprint 3 — Parity
 

--- a/docs/ADAPTER-CONTRACT.md
+++ b/docs/ADAPTER-CONTRACT.md
@@ -76,6 +76,35 @@ and reported in `data.files[]` with a `reason`. `--force` overrides the check;
 `--dry-run` reports without touching disk. An undo is not itself snapshotted, so
 `undo --last` cannot ping-pong between two states.
 
+## Output Format (B16)
+
+The CLI supports two output modes controlled by the global `--format` flag:
+
+```
+--format <json|text>
+```
+
+| Precedence | Condition | Format |
+|------------|-----------|--------|
+| 1. explicit `--format <fmt>` | `hashpilot <cmd> --format text` | text |
+| 2. `--json` (deprecated) | `hashpilot <cmd> --json` | json (emits stderr: `[deprecation]`) |
+| 3. `$CI` truthy | CI runner environment | json |
+| 4. stdout is a TTY | interactive shell | text |
+| 5. default | piped/redirected | json |
+
+**`--json` is a hidden deprecated alias for `--format json`.** The deprecation
+notice is emitted once per invocation to stderr. It will be removed in the next
+minor version.
+
+**All error output is always JSON.** The `finish()` function only uses the text
+renderer for successful results (`success !== false`). Error/usage envelopes
+remain the canonical apiVersion 1 payload regardless of format mode, because an
+agent parsing a non-zero exit code always expects structured data.
+
+**Text renderers** are per-command. A command without a registered renderer falls
+back to a compact key/value dump. Diagnostics, progress messages, and the
+deprecation warning go to **stderr** — never stdout.
+
 ## Command Reference
 
 ### Configuration

--- a/docs/CLI-QUICKREF.md
+++ b/docs/CLI-QUICKREF.md
@@ -129,6 +129,8 @@ hashpilot [options] [command]
 | `--allowed-root <dir...>` | Additional directory writes may target |
 | `--no-telemetry` | Disable telemetry logging for this invocation |
 | `--allow-parse-errors` | Edit a file that already has syntax errors (the post-edit parse check still applies) |
+| `--format <fmt>` | Output format: json or text (default: json if piped/CI, text if TTY) |
+| `--json` | [deprecated: use --format json] Force JSON output (default: false) |
 
 ### Command groups
 
@@ -153,10 +155,6 @@ hashpilot read-many [options] <files...>
 |------------|---------|
 | `files` | File paths |
 
-| Flag | Meaning |
-|------|---------|
-| `--json` | Output as JSON (default: true) |
-
 #### `read-hash`
 
 Read a line with hash and context
@@ -173,7 +171,6 @@ hashpilot read-hash [options] <file> <line>
 | Flag | Meaning |
 |------|---------|
 | `-c, --context <n>` | Context lines (default: "3") |
-| `--json` | Output as JSON (default: true) |
 
 #### `grep-many`
 
@@ -193,7 +190,6 @@ hashpilot grep-many [options] <pattern> <paths...>
 | `-i, --ignore-case` | Case insensitive |
 | `--file-pattern <glob>` | File pattern filter |
 | `--max-results <n>` | Max results |
-| `--json` | Output as JSON (default: true) |
 
 #### `symbol-lookup-many`
 
@@ -210,7 +206,6 @@ hashpilot symbol-lookup-many [options] <paths...>
 | Flag | Meaning |
 |------|---------|
 | `--names <names>` | Comma-separated symbol names |
-| `--json` | Output as JSON (default: true) |
 
 #### `replace-hash`
 
@@ -234,7 +229,6 @@ hashpilot replace-hash [options] <file> <old-hash> <new-content>
 | `--actor <name>` | Agent identity for provenance tracking |
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
-| `--json` | Output as JSON (default: true) |
 
 #### `ast capabilities`
 
@@ -276,7 +270,6 @@ hashpilot ast rename-symbol [options] <file> <old-name> <new-name>
 | `--actor <name>` | Agent identity for provenance tracking |
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
-| `--json` | Output as JSON (default: true) |
 
 #### `ast replace-body`
 
@@ -298,7 +291,6 @@ hashpilot ast replace-body [options] <file> <symbol> <new-body>
 | `--actor <name>` | Agent identity for provenance tracking |
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
-| `--json` | Output as JSON (default: true) |
 
 #### `ast add-import`
 
@@ -319,7 +311,6 @@ hashpilot ast add-import [options] <file> <import-spec>
 | `--actor <name>` | Agent identity for provenance tracking |
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
-| `--json` | Output as JSON (default: true) |
 
 #### `ast remove-import`
 
@@ -340,7 +331,6 @@ hashpilot ast remove-import [options] <file> <import-spec>
 | `--actor <name>` | Agent identity for provenance tracking |
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
-| `--json` | Output as JSON (default: true) |
 
 #### `ast insert-before`
 
@@ -362,7 +352,6 @@ hashpilot ast insert-before [options] <file> <symbol> <content>
 | `--actor <name>` | Agent identity for provenance tracking |
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
-| `--json` | Output as JSON (default: true) |
 
 #### `ast insert-after`
 
@@ -384,7 +373,6 @@ hashpilot ast insert-after [options] <file> <symbol> <content>
 | `--actor <name>` | Agent identity for provenance tracking |
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
-| `--json` | Output as JSON (default: true) |
 
 #### `route-edit`
 
@@ -417,7 +405,6 @@ hashpilot route-edit [options] <file> <operation>
 | `--actor <name>` | Agent identity for provenance tracking |
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
-| `--json` | Output as JSON (default: true) |
 
 #### `batch`
 
@@ -451,7 +438,6 @@ hashpilot batch [options] <operation> <files...>
 | `--actor <name>` | Agent identity for provenance tracking |
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
-| `--json` | Output as JSON (default: true) |
 
 #### `intent`
 
@@ -477,7 +463,6 @@ hashpilot intent [options] <intent>
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
 | `--context <text>` | Agent prompt/context (or @file) |
-| `--json` | Output as JSON (default: true) |
 
 #### `diff generate`
 
@@ -518,7 +503,6 @@ hashpilot diff apply [options] <file>
 | `--actor <name>` | Agent identity for provenance tracking |
 | `--task-id <id>` | Task/issue reference for provenance |
 | `--reason <text>` | Human-readable reason for the edit |
-| `--json` | Output as JSON (default: true) |
 
 #### `verify-changes`
 
@@ -549,7 +533,6 @@ hashpilot verify-changes [options] <files...>
 | `--no-scope-tests` | Run the whole test suite instead of only tests related to the changed files |
 | `--use-baseline` | Ignore tests that were already failing at this commit (see --record-baseline) |
 | `--record-baseline` | Record which tests currently fail, for later --use-baseline runs. Run this before editing. |
-| `--json` | Output as JSON (default: true) |
 
 #### `telemetry show`
 
@@ -643,7 +626,6 @@ hashpilot provenance query [options] <file> [line]
 | Flag | Meaning |
 |------|---------|
 | `--human` | Human-readable output |
-| `--json` | JSON output (default) (default: true) |
 | `--fuzzy` | Include edits without diff data in line-filtered queries |
 | `--limit <n>` | Max entries to show |
 
@@ -701,10 +683,6 @@ Verify HashPilot installation health
 hashpilot doctor [options]
 ```
 
-| Flag | Meaning |
-|------|---------|
-| `--json` | Output as JSON (default: false) |
-
 #### `upgrade`
 
 Upgrade HashPilot to the latest version from GitHub
@@ -735,7 +713,6 @@ hashpilot uninstall [options]
 | `--force` | Skip confirmation prompt (auto-detected when piped) |
 | `--dry-run` | Show what would be removed without deleting anything |
 | `--target <dir>` | Install target directory (default: ~/.agentic-tools) |
-| `--json` | Output as JSON (default: true) |
 
 #### `route`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,6 +69,10 @@ import {
   configureTelemetry,
   enableTelemetry,
   resolveTelemetryEnabled,
+  setOutputFormat,
+  getOutputFormat,
+  resolveFormat,
+  OutputFormat,
 } from "./core/index";
 import type { TelemetryEvent } from "./core/telemetry";
 
@@ -113,13 +117,20 @@ program
   .option("--allowed-root <dir...>", "Additional directory writes may target")
   .option("--no-telemetry", "Disable telemetry logging for this invocation")
   .option("--allow-parse-errors", "Edit a file that already has syntax errors (the post-edit parse check still applies)")
+    .option("--format <fmt>", "Output format: json or text (default: json if piped/CI, text if TTY)")
+    .option("--json", "[deprecated: use --format json] Force JSON output", false)
   .hook("preAction", (thisCommand, actionCommand) => {
     // Name the running subcommand so the envelope can report it. Walk up so
     // nested commands read as "telemetry show", not "show".
     const path: string[] = [];
     for (let c: typeof actionCommand | null = actionCommand; c && c.parent; c = c.parent) path.unshift(c.name());
     setCommand(path.join(" "));
+
+     // #19 (B16): resolve output format and set it globally
     const globals = thisCommand.opts();
+    const { format, warnDeprecate } = resolveFormat(globals, { ci: process.env.CI === "true" || process.env.CI === "1" });
+    setOutputFormat(format, path.join(" "));
+    if (warnDeprecate) process.stderr.write("[deprecation] --json is deprecated; use --format json\n");
     const config = loadConfig();
     configureWriteBoundary({
       allowOutsideRoot: Boolean(globals.allowOutsideRoot),
@@ -142,7 +153,7 @@ program
   .command("read-many")
   .description("Read multiple files, return content + hashes")
   .argument("<files...>", "File paths")
-  .option("--json", "Output as JSON", true)
+
   .action(async (files: string[], opts) => {
     const start = Date.now();
     const results = await readMany(files);
@@ -162,7 +173,7 @@ program
   .argument("<file>", "File path")
   .argument("<line>", "Line number", parseInt)
   .option("-c, --context <n>", "Context lines", "3")
-  .option("--json", "Output as JSON", true)
+
   .action(async (file: string, line: number, opts) => {
     const start = Date.now();
     const context = parseIntFlag(opts.context, "--context", 3);
@@ -187,7 +198,7 @@ program
   .option("-i, --ignore-case", "Case insensitive")
   .option("--file-pattern <glob>", "File pattern filter")
   .option("--max-results <n>", "Max results", parseInt)
-  .option("--json", "Output as JSON", true)
+
   .action(async (pattern: string, paths: string[], opts) => {
     const result = await grepMany(pattern, paths, {
       ignoreCase: opts.ignoreCase,
@@ -209,7 +220,7 @@ program
   .description("Find symbol definitions. Usage: symbol-lookup-many <paths...> --names n1,n2")
   .argument("<paths...>", "Paths to search")
   .option("--names <names>", "Comma-separated symbol names")
-  .option("--json", "Output as JSON", true)
+
   .action(async (paths: string[], opts) => {
     const names = (opts.names || "").split(",").filter(Boolean);
     const results = await symbolLookupMany(names, paths);
@@ -228,7 +239,7 @@ program
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
-  .option("--json", "Output as JSON", true)
+
   .action(async (file: string, oldHash: string, newContent: string, opts) => {
     const start = Date.now();
     let content = newContent;
@@ -319,7 +330,7 @@ astCmd
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
-  .option("--json", "Output as JSON", true)
+
   .action(async (file: string, oldName: string, newName: string, opts) => {
     const start = Date.now();
     const content = await Bun.file(file).text();
@@ -348,7 +359,7 @@ astCmd
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
-  .option("--json", "Output as JSON", true)
+
   .action(async (file: string, symbol: string, newBody: string, opts) => {
     const start = Date.now();
     let body = newBody;
@@ -378,7 +389,7 @@ astCmd
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
-  .option("--json", "Output as JSON", true)
+
   .action(async (file: string, importSpec: string, opts) => {
     const start = Date.now();
     const content = await Bun.file(file).text();
@@ -406,7 +417,7 @@ astCmd
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
-  .option("--json", "Output as JSON", true)
+
   .action(async (file: string, importSpec: string, opts) => {
     const start = Date.now();
     const content = await Bun.file(file).text();
@@ -435,7 +446,7 @@ astCmd
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
-  .option("--json", "Output as JSON", true)
+
   .action(async (file: string, symbol: string, content: string, opts) => {
     const start = Date.now();
     let c = content;
@@ -466,7 +477,7 @@ astCmd
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
-  .option("--json", "Output as JSON", true)
+
   .action(async (file: string, symbol: string, content: string, opts) => {
     const start = Date.now();
     let c = content;
@@ -508,7 +519,7 @@ program
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
-  .option("--json", "Output as JSON", true)
+
   .action(async (file: string, operation: string, opts) => {
     const resolveContent = async (val?: string): Promise<string | undefined> => {
       // An explicit empty string is a deletion, not an omitted argument (#40).
@@ -563,7 +574,7 @@ program
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
-  .option("--json", "Output as JSON", true)
+
   .action(async (operation: string, files: string[], opts) => {
     const resolveContent = async (val?: string): Promise<string | undefined> => {
       // An explicit empty string is a deletion, not an omitted argument (#40).
@@ -614,7 +625,7 @@ program
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
   .option("--context <text>", "Agent prompt/context (or @file)")
-  .option("--json", "Output as JSON", true)
+
   .action(async (intent: string, opts) => {
     try {
       let context = opts.context;
@@ -635,7 +646,7 @@ program
         context,
       });
 
-      if (opts.json) {
+      if (getOutputFormat() === "json") {
         finish(result);
       } else {
         console.log(`Intent: ${result.plan.intent.operation} on '${result.plan.definition.name}'`);
@@ -703,7 +714,7 @@ diffCmd
   .option("--actor <name>", "Agent identity for provenance tracking")
   .option("--task-id <id>", "Task/issue reference for provenance")
   .option("--reason <text>", "Human-readable reason for the edit")
-  .option("--json", "Output as JSON", true)
+
   .action(async (file: string, opts) => {
     const start = Date.now();
     let patchText: string;
@@ -760,7 +771,7 @@ program
   .option("--no-scope-tests", "Run the whole test suite instead of only tests related to the changed files")
   .option("--use-baseline", "Ignore tests that were already failing at this commit (see --record-baseline)")
   .option("--record-baseline", "Record which tests currently fail, for later --use-baseline runs. Run this before editing.")
-  .option("--json", "Output as JSON", true)
+
   .action(async (files: string[], opts) => {
     if (opts.recordBaseline) {
       const recorded = await recordVerifyBaseline(files, {
@@ -909,7 +920,7 @@ provCmd
   .argument("<file>", "File path")
   .argument("[line]", "Optional line number to filter by")
   .option("--human", "Human-readable output")
-  .option("--json", "JSON output (default)", true)
+
   .option("--fuzzy", "Include edits without diff data in line-filtered queries")
   .option("--limit <n>", "Max entries to show")
   .action((file, line, opts) => {
@@ -994,10 +1005,10 @@ program
 program
   .command("doctor")
   .description("Verify HashPilot installation health")
-  .option("--json", "Output as JSON", false)
+
   .action((opts) => {
     const report = doctor();
-    if (opts.json) {
+    if (getOutputFormat() === "json") {
       finish(report);
       return;
     }
@@ -1090,7 +1101,7 @@ program
   .option("--force", "Skip confirmation prompt (auto-detected when piped)")
   .option("--dry-run", "Show what would be removed without deleting anything")
   .option("--target <dir>", "Install target directory (default: ~/.agentic-tools)")
-  .option("--json", "Output as JSON", true)
+
   .action(async (opts) => {
     const targetDir = opts.target || join(process.env.HOME || "/root", ".agentic-tools");
 

--- a/src/core/exit-codes.ts
+++ b/src/core/exit-codes.ts
@@ -1,5 +1,6 @@
 import { ErrorCode } from "./telemetry";
 import { wrap } from "./envelope";
+import { resolveFormat, renderText, OutputFormat } from "./format";
 
 /**
  * Process exit codes. Agents branch on these, so the numbers are a contract —
@@ -96,15 +97,46 @@ export function exitCodeFor(result: ResultLike | ResultLike[] | undefined): Exit
   return ExitCode.EDIT_FAILED;
 }
 
+/* ── Output format (#19 B16) ───────────────────────────────────────────── */
+let outputFormat: OutputFormat = "json";
+let currentCommand = "";
+
+/** Called once by preAction; sets the global output format + running command name. */
+export function setOutputFormat(fmt: OutputFormat, command: string): void {
+  outputFormat = fmt;
+  currentCommand = command;
+}
+
+/** Current output format — used by action handlers to branch on text vs. JSON. */
+export function getOutputFormat(): OutputFormat {
+  return outputFormat;
+}
+
+/** Re-export for cli.ts convenience. */
+export { resolveFormat, renderText };
+
 /**
- * Single exit point for every CLI command: emit the JSON payload, then set the
- * exit code. Uses `process.exitCode` rather than `process.exit()` so pending
- * stdout writes and telemetry flushes are not truncated.
+ * Single exit point for every CLI command.
+ *
+ * #19 (B16): when `outputFormat === "text"` the success payload is rendered as
+ * compact human-readable output via per-command renderers. Error payloads are
+ * ALWAYS JSON — the API contract (apiVersion 1) is the canonical machine output
+ * and must not be degraded. Commands without a renderer fall back to a compact
+ * key/value dump; never raw JSON in text mode.
  */
 export function finish(payload: unknown, code?: ExitCode): void {
   const exit = code ?? exitCodeFor(payload as ResultLike);
-  // Wrapped, not raw: every command emits the same envelope so an adapter has
-  // one parse path. See src/core/envelope.ts.
+    // In text mode: success payloads get the compact renderer; errors always emit JSON.
+  if (outputFormat === "text" && (payload as { success?: boolean }).success !== false) {
+      // `wrap()` produces { apiVersion, ok, command, data, ... }; `data` carries
+      // the per-command payload. Render `data` when present, else the raw payload.
+    const data = (payload as { data?: Record<string, unknown> }).data;
+     const rendererTarget = data || (payload as Record<string, unknown>);
+    renderText(currentCommand, rendererTarget as Record<string, unknown>);
+    process.exitCode = exit;
+    return;
+    }
+    // JSON path: emit the envelope (apiVersion 1)
   console.log(JSON.stringify(wrap(payload, exit), null, 2));
   process.exitCode = exit;
 }

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -1,0 +1,295 @@
+/**
+ * Output format selection for the CLI.
+ *
+ * #19 (B16) — a global `--format <json|text>` flag, with TTY-aware defaults:
+ *   - `--format json`  : always JSON (agent default, CI safe)
+ *   - `--format text`  : compact human-readable output (human default, interactive shell)
+ *   - no `--format`    : JSON if stdout is piped/redirected or `$CI` true; otherwise text
+ *
+ * The JSON envelope remains the canonical machine-readable contract (apiVersion 1);
+ * `text` mode is a human convenience layer that must never replace it.
+ */
+
+/* ── Output format type ──────────────────────────────────────────────── */
+
+export type OutputFormat = "json" | "text";
+
+/**
+ * Resolve the output format from an explicit option, CI detection, and TTY state.
+ *
+ * Precedence:
+ * 1. Explicit `--format <json|text>` → wins always.
+ * 2. `--json` (deprecated alias for `--format json`) → emits a one-time stderr
+ *    deprecation warning.
+ * 3. `$CI` environment variable is truthy → JSON.
+ * 4. stdout is a TTY (interactive shell) → text.
+ * 5. Fall back → JSON (safe default for anything not detected above).
+ */
+export function resolveFormat(
+  opts: { format?: string; json?: boolean },
+  ctx: { isTTY?: boolean; ci?: boolean } = {}
+): { format: OutputFormat; warnDeprecate?: boolean } {
+  // 1. explicit --format
+  if (opts.format === "json" || opts.format === "text") return { format: opts.format };
+  // 2. deprecated --json alias
+  if (opts.json === true) return { format: "json", warnDeprecate: true };
+  // 3. CI env
+  const ci = ctx.ci ?? process.env.CI;
+  if (ci === "true" || ci === "1") return { format: "json" };
+  // 4. TTY
+  const isTTY = ctx.isTTY ?? process.stdout.isTTY;
+  if (isTTY) return { format: "text" };
+  // 5. default to JSON
+  return { format: "json" };
+}
+
+/* ── Text renderers ────────────────────────────────────────────────────
+ *
+ * Each renderer receives a `ResultPayload` (the `data` field that `wrap()`
+ * would produce) and prints a compact, human-readable line to stdout.
+ * Rendered lines never carry diagnostic noise — errors go through the same
+ * `finish()` path so they emit JSON, not text.
+ */
+
+type ResultPayload = {
+  success: boolean;
+  [key: string]: unknown;
+};
+
+/**
+ * Render a result payload as compact text for human readers.
+ * Each command registers its own renderer via the `registerRenderer` map;
+ * unmatched commands fall back to a generic key/value dump.
+ */
+export function renderText(command: string, payload: ResultPayload): void {
+  const renderer = renderers[command];
+  if (renderer) {
+    renderer(payload);
+  } else {
+    // Generic fallback: compact key/value dump
+    renderGenericDump(payload);
+  }
+}
+
+/** Generic renderer: print a single-line summary of the result. */
+function renderGenericDump(payload: ResultPayload): void {
+  const lines: string[] = [];
+  lines.push(payload.success ? "✓ ok" : "✗ " + (String(payload.errorCode || "error")));
+  for (const [k, v] of Object.entries(payload)) {
+    if (k === "success" || k === "apiVersion" || k === "error") continue;
+    if (v === null || v === undefined) continue;
+    if (Array.isArray(v)) {
+      lines.push(`  ${k}: ${v.length} item${v.length === 1 ? "" : "s"}`);
+    } else if (typeof v === "object") {
+      lines.push(`  ${k}: ${summarize(v)}`);
+    } else {
+      lines.push(`  ${k}: ${String(v)}`);
+    }
+    if (lines.length >= 8) {
+      lines.push("  …");
+      break;
+    }
+  }
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+/** Compact one-line summary of a value for inline display. */
+function summarize(v: unknown): string {
+  if (v === null || v === undefined) return "none";
+  if (typeof v === "string") return `"${v.length > 60 ? v.slice(0, 57) + "…" : v}"`;
+  if (typeof v === "number") return String(v);
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (Array.isArray(v)) return `[${v.length}]`;
+  return "...";
+}
+
+/* ── Per-command renderers ────────────────────────────────────────────── */
+
+const renderers: Record<string, (p: ResultPayload) => void> = {};
+
+/**
+ * Register a text renderer for a specific command.
+ * Called at module init for each command that has a dedicated renderer.
+ */
+export function registerRenderer(command: string, fn: (p: ResultPayload) => void): void {
+  renderers[command] = fn;
+}
+
+/* ── Common renderer registrations ───────────────────────────────────── */
+
+// doctor — a checklist: print P/N checks + overall ✓/✗
+registerRenderer("doctor", (p) => {
+  const checks = (p.checks || []) as { name: string; ok: boolean; detail?: string }[];
+  const overall = p.success ? "✓ all passed" : "✗ " + checks.filter((c) => !c.ok).length + " failed";
+  process.stdout.write(overall + "\n");
+  for (const c of checks) {
+    process.stdout.write(`  ${c.ok ? "✓" : "✗"} ${c.name}${c.detail ? " — " + c.detail : ""}\n`);
+  }
+});
+
+// read / read-many — print the first few lines + hash
+registerRenderer("read", (p) => {
+  printReadResult(p);
+});
+registerRenderer("read-many", (p) => {
+  const results = (p.results || p) as unknown;
+  if (Array.isArray(results)) {
+    for (const r of results as ResultPayload[]) printReadResult(r);
+  } else printReadResult(p);
+});
+registerRenderer("read-hash", (p) => printReadResult(p));
+
+/** Shared renderer for any "read" variant: show line count + hash. */
+function printReadResult(p: ResultPayload) {
+  if (p.error) {
+    process.stdout.write("✗ " + p.error + "\n");
+    return;
+  }
+  const lines = (p.lines as string[]) || (p.content ? [p.content] : []);
+  const n = lines.length;
+  const hash = p.hash || p.lineHash || "";
+  const filePath = p.file || p.path || "";
+  process.stdout.write(
+    `${filePath ? basePath(filePath) + ": " : ""}${n} line${n === 1 ? "" : "s"}${hash ? "  " + hash.slice(0, 8) : ""}\n`
+  );
+  if (lines.length > 0 && lines.length <= 5) {
+    for (const l of lines) process.stdout.write("  " + l + "\n");
+  }
+}
+
+// ast-replace / hash-replace / diff-apply — print success + file:line + hash
+registerRenderer("ast-replace", (p) => printEditResult(p));
+registerRenderer("hash-replace", (p) => printEditResult(p));
+registerRenderer("diff-apply", (p) => printEditResult(p));
+registerRenderer("structured-edit", (p) => printEditResult(p));
+registerRenderer("edit-many", (p) => {
+  const results = (p.results || []) as ResultPayload[];
+  const ok = results.filter((r) => r.success).length;
+  process.stdout.write(`${ok}/${results.length} edits succeeded\n`);
+  for (const r of results.filter((r) => !r.success)) {
+    process.stdout.write("✗ " + basePath(r.file || r.path || "?") + ": " + (r.error || "failed") + "\n");
+  }
+});
+
+/** Shared renderer for any single edit result. */
+function printEditResult(p: ResultPayload) {
+  const f = p.file || p.path || "";
+  const route = p.route || "?";
+  process.stdout.write(
+    `${p.success ? "✓" : "✗"} ${route} ${f ? basePath(f) : ""}${p.line ? ":" + p.line : ""}\n`
+  );
+  if (!p.success) process.stdout.write("  " + (p.error || p.message || "failed") + "\n");
+}
+
+// grep / grep-many — print N matches across M files
+registerRenderer("grep", (p) => {
+  const r = p.results || p;
+  const matches = (r?.matches || []) as unknown[];
+  process.stdout.write(`${matches.length} match${matches.length === 1 ? "" : "es"}\n`);
+  for (const m of (matches as any[]).slice(0, 10)) {
+    process.stdout.write(
+      "  " + basePath(m.file || m.path || "?") + ":" + (m.line || "?") + "  " + truncate(m.content, 60) + "\n"
+    );
+  }
+  if (matches.length > 10) process.stdout.write(`  … ${matches.length - 10} more\n`);
+});
+registerRenderer("grep-many", (p) => {
+  const r = p.results || p;
+  const matches = (r?.matches || []) as unknown[];
+  process.stdout.write(`${matches.length} match${matches.length === 1 ? "" : "es"}\n`);
+  for (const m of (matches as any[]).slice(0, 10)) {
+    process.stdout.write(
+      "  " + basePath(m.file || m.path || "?") + ":" + (m.line || "?") + "  " + truncate(m.content, 60) + "\n"
+    );
+  }
+});
+
+// symbol-lookup
+registerRenderer("symbol-lookup", (p) => {
+  const results = (p.results || p.symbols || []) as ResultPayload[];
+  process.stdout.write(`${results.length} symbol${results.length === 1 ? "" : "s"}` + "\n");
+  for (const r of results.slice(0, 10)) {
+    process.stdout.write(
+      `  ${r.name || r.symbol || "?"}  ${r.kind || "?"}  ${basePath(r.file || r.path || "")}:${r.line || "?"}\n`
+    );
+  }
+});
+
+// intent
+registerRenderer("intent", (p) => {
+  const plan = p.plan as ResultPayload | undefined;
+  if (p.success) {
+    process.stdout.write("✓ plan succeeded\n");
+    if (plan?.impactSummary) process.stdout.write("  " + plan.impactSummary + "\n");
+  } else {
+    process.stdout.write("✗ " + (p.errorCode || p.error || "failed") + "\n");
+  }
+  const unresolved = plan?.unresolved;
+  if (Array.isArray(unresolved) && unresolved.length > 0) {
+    process.stdout.write(`  ${unresolved.length} unresolved item(s):\n`);
+    for (const u of unresolved as ResultPayload[]) {
+      process.stdout.write("    " + basePath(u.file || "") + ": " + (u.reason || "") + "\n");
+    }
+  }
+});
+
+// verify
+registerRenderer("verify", (p) => {
+  if (p.success) process.stdout.write("✓ all checks passed\n");
+  else process.stdout.write("✗ " + (p.errorCode || "checks failed") + "\n");
+  const checks = (p.checks || p.results || []) as ResultPayload[];
+  for (const c of checks.slice(0, 5)) {
+    process.stdout.write(`  ${c.overall === "pass" || c.success ? "✓" : "✗"} ${c.command || c.name || "?"}\n`);
+  }
+});
+
+// telemetry subcommands
+registerRenderer("telemetry-show", (p) => {
+  const events = (p.events || p) as ResultPayload[];
+  const arr = Array.isArray(events) ? events : [events];
+  process.stdout.write(`${arr.length} event${arr.length === 1 ? "" : "s"}\n`);
+  for (const e of arr.slice(0, 10)) {
+    process.stdout.write(
+      "  " +
+        (e.operation || "?") +
+        " " +
+        (e.success ? "✓" : "✗") +
+        " " +
+        (e.route || "") +
+        (e.elapsed_ms ? " " + e.elapsed_ms + "ms" : "") +
+        "\n"
+    );
+  }
+});
+registerRenderer("telemetry-export", (p) => process.stdout.write("✓ exported " + (p.count || 0) + " event(s)\n"));
+registerRenderer("telemetry-prune", (p) => process.stdout.write("✓ pruned " + (p.count || 0) + " event(s)\n"));
+
+// route-query
+registerRenderer("route", (p) => {
+  process.stdout.write(p.success ? "✓ " + (p.route || "ok") : "✗ " + (p.errorCode || "routing failed") + "\n");
+});
+
+// ast-capabilities
+registerRenderer("ast-capabilities", (p) => {
+  const langs = (p.languages || []) as string[];
+  process.stdout.write(`${langs.length} language(s) supported\n`);
+});
+
+// health / telemetry-summary
+registerRenderer("health", (p) => {
+  process.stdout.write((p.success ? "✓ " : "✗ ") + (p.message || "") + "\n");
+});
+registerRenderer("telemetry-summary", (p) => {
+   const keys = p.success ? [...(Object.keys(p))] : [...(Object.keys(p))];
+   process.stdout.write((p.success ? "✓ " : "✗ ") + (p.message || JSON.stringify(Object.keys(p)).slice(0, 120)) + "\n");
+});
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+function basePath(p: string): string {
+  return p.includes("/") ? p.split("/").pop() || p : p;
+}
+function truncate(s: unknown, n: number): string {
+  const str = String(s);
+  return str.length > n ? str.slice(0, n - 1) + "…" : str;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -116,7 +116,8 @@ export {
   PathDeniedError,
 } from "./paths";
 export type { AssertWritableOptions } from "./paths";
-export { ExitCode, exitCodeFor, finish, usageError } from "./exit-codes";
+export { ExitCode, exitCodeFor, finish, usageError, setOutputFormat, getOutputFormat, resolveFormat, renderText } from "./exit-codes";
+export type { OutputFormat } from "./format";
 export { wrap, wrapResult, addWarning, takeWarnings, setCommand, currentCommandName, API_VERSION } from "./envelope";
 export type { Envelope, EnvelopeError, EnvelopeWarning } from "./envelope";
 export type { ResultLike } from "./exit-codes";

--- a/tests/cli-contract.test.ts
+++ b/tests/cli-contract.test.ts
@@ -177,3 +177,43 @@ describe("docs/CLI-QUICKREF.md", () => {
     }
   });
 });
+
+// ── #19 (B16) — output format resolution ───────────────────────────────
+
+describe("--format output mode (#19 B16)", () => {
+   // Piped / non-TTY process (like CI) defaults to JSON with no explicit flag
+  test("piped stdout defaults to JSON", () => {
+    const res = run(["doctor"], ROOT, { CI: "1" });
+    expect(JSON.parse(res.stdout).command).toBe("doctor");
+   });
+
+   // CI=true forces JSON even without a TTY
+  test("CI=true forces JSON", () => {
+    const res = run(["--format", "json", "doctor"]);
+    expect(JSON.parse(res.stdout).ok).toBe(true);
+   });
+
+   // --format text emits human-readable output (not valid JSON)
+  test("--format text emits text, not JSON", () => {
+    const res = run(["--format", "text", "doctor"]);
+    // Should fail JSON parse (text output)
+    expect(() => JSON.parse(res.stdout)).toThrow();
+    // But should contain the doctor summary
+    expect(res.stdout).toContain("HashPilot Doctor");
+   });
+
+   // --json deprecated alias still works but warns on stderr
+  test("--json (deprecated) still emits JSON with a deprecation warning", () => {
+    const res = run(["--json", "doctor"]);
+    expect(res.stderr).toContain("[deprecation]");
+     // JSON still on stdout
+    expect(JSON.parse(res.stdout).command).toBe("doctor");
+   });
+
+   // --format text takes priority over --json deprecation
+  test("--format text out-prioritises --json (explicit over deprecated)", () => {
+    const res = run(["--format", "text", "--json", "doctor"]);
+    // text mode wins (explicit --format takes priority in resolveFormat)
+    expect(res.stdout).toContain("HashPilot Doctor");
+   });
+});


### PR DESCRIPTION
# feat(cli): `--format <json|text>` global flag with TTY detection (#19 B16)

Closes #19.

## The defect

Every sub-command declared its own `.option("--json", "...", true)` — 18 copies
total — and commander left `--json` permanently on with no negation form. There
was no human output mode; the `intent` branch at `cli.ts:536–543` was dead code.

## The fix

A single program-level `.option("--format <fmt>", ...)` resolves output mode
via `resolveFormat()`:

| Precedence | Condition | Format |
|---|---|---|
| 1 | explicit `--format text/json` | as specified |
| 2 | `--json` (deprecated alias) | json + stderr `[deprecation]` |
| 3 | `$CI` truthy | json |
| 4 | stdout is a TTY | text |
| 5 | default | json |

New `src/core/format.ts` holds:
- `resolveFormat()`: the 5-step resolver
- `renderText()`: dispatches by command name to per-command renderers; generic
  fallback is a compact key/value dump
- `registerRenderer()`: per-command renderer registration (doctor, intent,
  read variants, edit variants, grep, symbol-lookup, verify, telemetry, …)

All error/usage envelopes **always** emit JSON — the apiVersion 1 contract is
the canonical machine contract and must not degrade in text mode.

## Files changed

| File | Change |
|------|--------|
| `src/core/format.ts` | New: `resolveFormat`, `renderText`, per-command renderers |
| `src/core/exit-codes.ts` | `setOutputFormat`, `getOutputFormat`; `finish()` branches on `outputFormat` |
| `src/core/index.ts` | Added exports: `setOutputFormat`, `getOutputFormat`, `resolveFormat`, `renderText`, `OutputFormat` |
| `src/cli.ts` | Added `--format` global option; `--json` as deprecated program-level alias; removed 18 per-command `--json` definitions |
| `docs/ADAPTER-CONTRACT.md` | "Output Format (B16)" section: precedence table, error-always-JSON rule |
| `docs/CLI-QUICKREF.md` | Regenerated by `gen:cli-quickref` |
| `tests/cli-contract.test.ts` | 5 new AC tests: piped→JSON, CI→JSON, text mode, deprecation warning, explicit-priority |
| `ROADMAP.md` | Fixed row counts (7-cell rows from earlier flips); `#19` status |

## Tests

- **699 pass / 0 fail** (was 694; +5 for B16 ACs)
- `lint:docs`: ✓ clean
- `roadmap lint`: ✓ clean

## Validation

```bash
# default JSON in CI (piped)
hashpilot --format json doctor | jq .command   # "doctor"

# human in text mode
hashpilot --format text doctor                  # "HashPilot Doctor — HEALTHY"

# deprecation warning on stderr
hashpilot --json doctor 2>&1 | grep deprecation # "[deprecation] --json is deprecated; use --format json"
```
