### PR TITLE
fix(verify,format): stop swallowing jest/vitest failures; fix text-mode newline

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -404,7 +404,9 @@ sequenceDiagram
     `cargo test` when every change is an integration test). Every result reports
     `testScope.scoped` and a `reason`, so an unscoped fallback is visible rather
     than silent. `parseFailures()` extracts individual test names and returns
-    `null` — never an empty list — when the output shape is unrecognised.
+    `null` — never an empty list — when the output shape is unrecognised. Its
+    jest/vitest file marker is `FAIL` only: `✗` also prefixes a failing test
+    name, and matching it as a filename swallowed every failure on that line.
   - `src/verify-baseline.ts` — a pre-edit run of the same scope, cached under
     `~/.agentic-tools/verify-baselines/` keyed by root + commit SHA + runner +
     scope signature. `recordVerifyBaseline()` is called by `plan-executor` on the

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -266,7 +266,7 @@ registerRenderer("telemetry-prune", (p) => process.stdout.write("✓ pruned " + 
 
 // route-query
 registerRenderer("route", (p) => {
-  process.stdout.write(p.success ? "✓ " + (p.route || "ok") : "✗ " + (p.errorCode || "routing failed") + "\n");
+  process.stdout.write((p.success ? "✓ " + (p.route || "ok") : "✗ " + (p.errorCode || "routing failed")) + "\n");
 });
 
 // ast-capabilities
@@ -280,8 +280,7 @@ registerRenderer("health", (p) => {
   process.stdout.write((p.success ? "✓ " : "✗ ") + (p.message || "") + "\n");
 });
 registerRenderer("telemetry-summary", (p) => {
-   const keys = p.success ? [...(Object.keys(p))] : [...(Object.keys(p))];
-   process.stdout.write((p.success ? "✓ " : "✗ ") + (p.message || JSON.stringify(Object.keys(p)).slice(0, 120)) + "\n");
+  process.stdout.write((p.success ? "✓ " : "✗ ") + (p.message || JSON.stringify(Object.keys(p)).slice(0, 120)) + "\n");
 });
 
 // ── helpers ────────────────────────────────────────────────────────────

--- a/src/core/verify-scope.ts
+++ b/src/core/verify-scope.ts
@@ -239,7 +239,10 @@ export function parseFailures(runner: string, output: string): string[] | null {
     case "jest": {
       let file = "";
       for (const line of lines) {
-        const f = line.match(/^\s*(?:FAIL|✗)\s+(\S+)/);
+        // Only FAIL marks a file. `✗` is left out deliberately: it also marks a
+        // failing test name below, and this branch runs first — matching it here
+        // would swallow every `✗ test name` line as a filename.
+        const f = line.match(/^\s*FAIL\s+(\S+)/);
         if (f) { file = f[1]; continue; }
         const t = line.match(/^\s*(?:✕|×|✗)\s+(.+?)(?:\s+\(\d+\s*m?s\))?\s*$/);
         if (t) out.push(`${file}::${t[1].trim()}`);


### PR DESCRIPTION
Findings from a `/review` pass over the merged diff of #84/#86/#87/#88/#91/#92.

1. **`verify-scope.ts` `parseFailures()`** — real bug. `✗` appeared in both the jest/vitest file-marker regex and the test-name regex; the file branch runs first and `continue`s, so every `✗ test name` line was swallowed as a filename. The failure list came back empty and `compareToBaseline` reported a regressing run as clean. File marker narrowed to `FAIL`.
2. **`format.ts` `route` renderer** — `+ "\n"` bound only to the failure branch; successful `--format text` output had no trailing newline.
3. **`format.ts` `telemetry-summary`** — dead `const keys`, both ternary branches identical.

699 pass / 0 fail, `lint:docs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)