### PR TITLE
feat(mcp): expose HashPilot as an MCP server over stdio (#25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tests/__tmp_*/
 
 # Local task tracking
 tasks/
+.hashpilot-test-tmp/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > AST-aware + provenance-tracked. See [`docs/COMPETITIVE-ANALYSIS.md`](docs/COMPETITIVE-ANALYSIS.md).
 
 Landing page: **[https://bigknoxy.github.io/HashPilot/](https://bigknoxy.github.io/HashPilot/)**
-Architecture: **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** · CLI reference: **[docs/CLI-QUICKREF.md](docs/CLI-QUICKREF.md)** · Roadmap & backlog: **[ROADMAP.md](ROADMAP.md)**
+Architecture: **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** · MCP setup: **[docs/INTEGRATION-MCP.md](docs/INTEGRATION-MCP.md)** · CLI reference: **[docs/CLI-QUICKREF.md](docs/CLI-QUICKREF.md)** · Roadmap & backlog: **[ROADMAP.md](ROADMAP.md)**
 
 Every edit is anchored by a SHA-256 hash — not a fragile line number or a fuzzy text match. If the hash matches, you're editing the right content. No guessing, no retries, no silent corruption.
 
@@ -469,6 +469,21 @@ HashPilot installs adapters for the three major coding agent platforms:
 | **Claude Code** | HashPilot section injected into `~/.claude/CLAUDE.md` teaching Claude to use `hashpilot` commands |
 | **OpenCode** | Skill at `~/.config/opencode/skills/hashpilot/` + subagent at `~/.config/opencode/agent/hashpilot.md` |
 | **Pi** | Native extension at `~/.pi/agent/extensions/hashpilot.ts` with 7 custom tools and `/hp` slash command |
+
+### MCP (recommended)
+
+HashPilot is also an MCP server, which is the recommended way to wire it into any
+MCP-capable host — Claude Code, Claude Desktop, Cursor, Zed, and others:
+
+```bash
+claude mcp add hashpilot -- hashpilot mcp --stdio
+```
+
+Every tier shows up as a typed tool with the same locking, provenance, and
+undo guarantees the CLI has, and multi-line content with quotes or backticks
+rides inside JSON instead of fighting the shell. Copy-paste configs per host:
+**[docs/INTEGRATION-MCP.md](docs/INTEGRATION-MCP.md)**. The CLI remains fully
+supported and is the fallback for hosts without MCP, and for shell and CI use.
 
 All adapters follow the [Adapter Contract](docs/ADAPTER-CONTRACT.md) — a machine-readable JSON protocol any agent can consume.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -438,6 +438,20 @@ sequenceDiagram
 - `editManySerial(operation, files)`: Serial execution for dependent operations
 - Parallel mode uses `Promise.all` for concurrent file processing
 
+#### `src/core/operations.ts` — Operation Registry (#25)
+- One declarative list of every operation both front doors expose: name, CLI command, params, and handler
+- MCP tool schemas are generated from it, so the MCP surface cannot silently drift from the documented CLI
+- Every handler delegates to `routeEdit`, so an MCP caller gets the same locking, compare-and-swap, snapshot, and provenance guarantees a CLI caller does
+- `tests/operations-parity.test.ts` drives the real Commander `--help` tree and asserts every registry param exists as a real CLI flag or argument
+
+#### `src/mcp/server.ts` — MCP Server (#25)
+- Newline-delimited JSON-RPC 2.0 over stdio, protocol revision `2024-11-05`; no SDK dependency
+- Methods: `initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`
+- Protocol errors (`-32700`/`-32600`/`-32601`/`-32603`) are the host's to handle; a failed edit comes back as `isError: true` on a successful result, for the model to read and recover from
+- Requests are handled strictly in order: the advisory lock is not re-entrant, so concurrent handling would deadlock
+- `hashpilot mcp --stdio` owns stdout for the whole process — it is the one command that emits no JSON envelope
+- Host setup: [INTEGRATION-MCP.md](INTEGRATION-MCP.md)
+
 #### `src/index.ts` — Barrel File
 - Re-exports all public API surface from core modules
 

--- a/docs/CLI-QUICKREF.md
+++ b/docs/CLI-QUICKREF.md
@@ -112,7 +112,7 @@ looks unrelated to AST. Green baseline is `bun test` fully passing (515 pass / 0
 
 <!-- BEGIN GENERATED: command reference -->
 
-_35 commands, generated from `--help`. Do not edit by hand — run `bun run gen:cli-quickref`._
+_36 commands, generated from `--help`. Do not edit by hand — run `bun run gen:cli-quickref`._
 
 ### Global options
 
@@ -674,6 +674,18 @@ hashpilot undo [options] [changeSetId]
 | `--last` | Undo the most recent changeSet |
 | `--force` | Restore even files modified since the edit was applied |
 | `--dry-run` | Report what would be restored without touching the disk |
+
+#### `mcp`
+
+Run HashPilot as an MCP server over stdio
+
+```
+hashpilot mcp [options]
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--stdio` | Speak MCP over stdin/stdout (the only transport, and the default) |
 
 #### `doctor`
 

--- a/docs/INTEGRATION-MCP.md
+++ b/docs/INTEGRATION-MCP.md
@@ -1,0 +1,186 @@
+# HashPilot as an MCP server
+
+HashPilot speaks the [Model Context Protocol](https://modelcontextprotocol.io) over
+stdio. Point any MCP host at `hashpilot mcp --stdio` and every editing tier —
+AST, hash-anchored, and diff — shows up as a typed tool, with the same advisory
+locking, provenance, and snapshot/undo guarantees the CLI gets.
+
+MCP is now the recommended integration path. The CLI remains fully supported and
+is the fallback for hosts without MCP support, and for shell and CI use.
+
+## Why MCP over the CLI
+
+| | MCP | CLI |
+|---|---|---|
+| Multi-line content with quotes and backticks | Rides inside JSON; no escaping | Needs `@file` indirection to dodge the shell |
+| Tool discovery | The host lists tools and schemas to the model | The model must be told the commands |
+| Errors | Structured, with `code` and `recovery` the model can act on | Same envelope, but parsed out of stdout |
+| Availability | Requires an MCP-capable host | Anywhere with a shell |
+
+## Install
+
+```bash
+npm install -g hashpilot     # or: bun add -g hashpilot
+hashpilot doctor             # confirm the install is healthy
+```
+
+## Configure your host
+
+### Claude Code
+
+```bash
+claude mcp add hashpilot -- hashpilot mcp --stdio
+```
+
+Or add it to `~/.claude.json` by hand:
+
+```json
+{
+  "mcpServers": {
+    "hashpilot": {
+      "command": "hashpilot",
+      "args": ["mcp", "--stdio"]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS
+(`%APPDATA%\Claude\claude_desktop_config.json` on Windows):
+
+```json
+{
+  "mcpServers": {
+    "hashpilot": {
+      "command": "hashpilot",
+      "args": ["mcp", "--stdio"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop afterwards; it reads the config only at launch.
+
+### Cursor
+
+`.cursor/mcp.json` in the project, or `~/.cursor/mcp.json` globally:
+
+```json
+{
+  "mcpServers": {
+    "hashpilot": {
+      "command": "hashpilot",
+      "args": ["mcp", "--stdio"]
+    }
+  }
+}
+```
+
+### Zed, Continue, and other hosts
+
+Any host that launches a stdio MCP server takes the same three fields — command
+`hashpilot`, args `["mcp", "--stdio"]`, and no environment beyond your shell's.
+If your host wants an absolute path, use `which hashpilot`.
+
+### Running from a checkout
+
+Without a global install, point the host at the repo:
+
+```json
+{
+  "mcpServers": {
+    "hashpilot": {
+      "command": "bun",
+      "args": ["run", "/absolute/path/to/HashPilot/src/cli.ts", "mcp", "--stdio"]
+    }
+  }
+}
+```
+
+## Tools
+
+Every tool is generated from the operation registry in
+[`src/core/operations.ts`](../src/core/operations.ts), which is the same list the
+CLI surface is verified against — the two cannot drift.
+
+### Reading
+
+| Tool | Use it for |
+|---|---|
+| `read_many` | Whole files plus a content hash per file. The hash is the anchor a later `replace_hash` verifies against. |
+| `read_hash` | One line with context and its hash, when you already know the line. |
+| `grep_many` | Regex search across paths. The cheapest way to locate code. |
+| `symbol_lookup_many` | Where symbols are *defined* (not referenced). |
+| `find_symbols` | Every symbol declared in one file. |
+| `ast_capabilities` | Which languages and AST operations are supported. |
+
+### Editing
+
+| Tool | Tier | Use it for |
+|---|---|---|
+| `rename_symbol` | AST | Binding-aware, file-scoped rename. |
+| `replace_body` | AST | Swap a function body, keep the signature. |
+| `add_import` / `remove_import` | AST | Imports, in the language's own style. |
+| `insert_before` / `insert_after` | AST | Code anchored to a symbol, not a line number. |
+| `replace_hash` | Hash | Verified replacement — refuses if the file changed since you read it. |
+| `replace_content` | Diff | Exact-match fallback; refuses on an ambiguous match. |
+| `route_edit` | auto | Any operation, letting HashPilot pick the strongest tier available. |
+
+### Verification
+
+`verify_changes` runs the project's own formatter, linter, type checker, and
+tests, scoped to the files you edited. Pass `useBaseline: true` so tests that
+were already failing do not get blamed on your edit.
+
+Every mutating tool accepts `dryRun`, plus `actor`, `taskId`, and `reason` for
+provenance — the same fields the CLI records, queryable afterwards with
+`hashpilot provenance query <file>`.
+
+## Error handling
+
+A failed edit comes back as a normal MCP result with `isError: true`, not as a
+JSON-RPC error. Protocol errors are the host's problem; tool errors are yours to
+read and recover from. The payload is the standard envelope:
+
+```json
+{
+  "apiVersion": "1",
+  "ok": false,
+  "error": {
+    "code": "STALE_ANCHOR",
+    "message": "the file changed since the hash was taken",
+    "recovery": "Re-read the file and retry with the new hash."
+  }
+}
+```
+
+Act on `error.code`; `error.recovery` says what to do next. The codes are the
+same ones the CLI reports — see [ADAPTER-CONTRACT.md](ADAPTER-CONTRACT.md).
+
+## Write boundary
+
+The MCP server enforces exactly the same boundary as the CLI: writes are
+confined to the project root, and credentials, shell config, and system paths
+are refused unconditionally. A tool call cannot widen it. Widen the project's
+own `allowedRoots` in `.hashpilot.json` if you legitimately need more.
+
+## Troubleshooting
+
+**The host shows no tools.** Check the binary runs: `hashpilot mcp --stdio`
+should sit waiting on stdin rather than exiting. `hashpilot doctor` diagnoses a
+broken install.
+
+**Edits fail with `PATH_DENIED`.** The target is outside the project root. Start
+the host from the project directory, or add the location to `allowedRoots`.
+
+**AST tools fall back to hash or diff.** tree-sitter is a native module; if the
+bindings did not build, parsers load as `null` and routing degrades silently.
+Reinstall, then check `ast_capabilities`.
+
+**Verify a host's view by hand:**
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | hashpilot mcp --stdio
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ import {
   resolveFormat,
   OutputFormat,
 } from "./core/index";
+import { runStdioServer } from "./mcp/server";
 import type { TelemetryEvent } from "./core/telemetry";
 
 const VERSION: string = pkg.version;
@@ -1000,6 +1001,26 @@ program
     setCurrentChangeSet(null);
     const result = undoChangeSet(id, { force: Boolean(opts.force), dryRun: Boolean(opts.dryRun) });
     finish(result, result.success ? ExitCode.OK : ExitCode.PRECONDITION);
+  });
+
+program
+  .command("mcp")
+  .description("Run HashPilot as an MCP server over stdio")
+  .option("--stdio", "Speak MCP over stdin/stdout (the only transport, and the default)")
+  .action(async () => {
+    // stdout is the protocol stream from here on, so nothing may print to it —
+    // including the JSON envelope every other command emits. The server runs
+    // until the host closes stdin; the telemetry event is recorded on the way
+    // out, when the session length is actually known.
+    const start = Date.now();
+    await runStdioServer();
+    recordEvent({
+      operation: "mcp",
+      route: "none",
+      success: true,
+      elapsed_ms: Date.now() - start,
+    });
+    process.exit(0);
   });
 
 program

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1,0 +1,522 @@
+/**
+ * The shared operation registry (#25 / B21).
+ *
+ * HashPilot has two front doors: the Commander CLI and the MCP server. Written
+ * separately they would drift, and a drifted MCP surface is worse than no MCP
+ * surface — it disagrees silently with the documented CLI. So each operation is
+ * declared once here (name, model-facing description, typed parameters,
+ * handler) and both front doors read from this list.
+ *
+ * The CLI's Commander definitions still own their own flag parsing, `@file`
+ * expansion, and telemetry; what this registry guarantees is that every entry
+ * corresponds to a real CLI command and that the parameter names agree.
+ * `tests/operations-parity.test.ts` enforces both directions.
+ *
+ * Handlers deliberately route edits through `routeEdit` rather than calling the
+ * tier functions directly: that is the path that takes the advisory lock, does
+ * the compare-and-swap, records the snapshot, and writes provenance. An MCP
+ * caller must not get a weaker guarantee than a CLI caller.
+ */
+
+import { readMany, readHash } from "./read";
+import { grepMany, symbolLookupMany } from "./grep";
+import { findSymbols, astCapabilities } from "./ast-edit";
+import { routeEdit } from "./router";
+import { verifyChanges } from "./verify";
+
+/* ── Types ───────────────────────────────────────────────────────────── */
+
+export type ParamType = "string" | "number" | "boolean" | "string[]";
+
+export interface OperationParam {
+  /** Parameter name, in camelCase. Must match the CLI's argument or option name. */
+  name: string;
+  type: ParamType;
+  required: boolean;
+  /** Written for a model: what to put here, not what the field is called. */
+  description: string;
+}
+
+export interface Operation {
+  /** MCP tool name. snake_case, because that is what MCP hosts display. */
+  name: string;
+  /** The CLI command path this mirrors, e.g. `["ast", "rename-symbol"]`. */
+  cliCommand: string[];
+  /** One line, shown in tool lists. */
+  summary: string;
+  /**
+   * The model-facing description. Every entry states when NOT to use the tool —
+   * an agent picking the wrong tier is the common failure, not a wrong argument.
+   */
+  description: string;
+  params: OperationParam[];
+  /** True for anything that can write. Hosts surface this as a consent prompt. */
+  mutates: boolean;
+  handler: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+/* ── Argument coercion ───────────────────────────────────────────────── */
+
+function str(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  // An explicit empty string is meaningful (a deletion, #40), so only
+  // undefined/null count as absent.
+  return v === undefined || v === null ? undefined : String(v);
+}
+
+function num(args: Record<string, unknown>, key: string): number | undefined {
+  const v = args[key];
+  if (v === undefined || v === null || v === "") return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function bool(args: Record<string, unknown>, key: string): boolean {
+  return args[key] === true || args[key] === "true";
+}
+
+function strArray(args: Record<string, unknown>, key: string): string[] {
+  const v = args[key];
+  if (Array.isArray(v)) return v.map(String);
+  if (typeof v === "string" && v !== "") return [v];
+  return [];
+}
+
+/** `"3:9"` → `{start: 3, end: 9}`; `"3"` → `{start: 3, end: 3}`. */
+function parseRangeArg(raw: string | undefined): { start: number; end: number } | undefined {
+  if (!raw) return undefined;
+  const [s, e] = raw.split(":").map(Number);
+  if (!Number.isFinite(s)) return undefined;
+  return { start: s, end: Number.isFinite(e) ? e : s };
+}
+
+/** Provenance parameters every mutating operation accepts. */
+const PROVENANCE_PARAMS: OperationParam[] = [
+  { name: "actor", type: "string", required: false, description: "Your agent identity, recorded in the edit history." },
+  { name: "taskId", type: "string", required: false, description: "Task or issue reference this edit belongs to." },
+  { name: "reason", type: "string", required: false, description: "Why this edit is being made, in one line." },
+  { name: "dryRun", type: "boolean", required: false, description: "Compute the edit and report it without writing to disk." },
+];
+
+/** Shared handler for every edit: one path, so locking and provenance are uniform. */
+function editHandler(
+  operation: string,
+  method: "ast" | "hash" | "diff" | undefined,
+  map: (args: Record<string, unknown>) => Record<string, unknown>
+) {
+  return async (args: Record<string, unknown>) =>
+    routeEdit({
+      filePath: str(args, "file")!,
+      operation,
+      method,
+      dryRun: bool(args, "dryRun"),
+      actor: str(args, "actor"),
+      taskId: str(args, "taskId"),
+      reason: str(args, "reason"),
+      ...map(args),
+    } as Parameters<typeof routeEdit>[0]);
+}
+
+const FILE_PARAM: OperationParam = {
+  name: "file",
+  type: "string",
+  required: true,
+  description: "Path to the file to edit, relative to the project root.",
+};
+
+/* ── The registry ────────────────────────────────────────────────────── */
+
+export const OPERATIONS: Operation[] = [
+  /* — Reading — */
+  {
+    name: "read_many",
+    cliCommand: ["read-many"],
+    summary: "Read whole files and get a SHA-256 hash for each.",
+    description:
+      "Read one or more files, returning content plus a content hash per file. " +
+      "Read this way before any hash-anchored edit: the hash you get back is the " +
+      "anchor `replace_hash` verifies against, which is what makes the edit refuse " +
+      "rather than clobber when the file changed underneath you. " +
+      "Do NOT use it to scan a large tree looking for something — use `grep_many`, " +
+      "which returns matches instead of whole files.",
+    params: [{ name: "files", type: "string[]", required: true, description: "Paths of the files to read, relative to the project root." }],
+    mutates: false,
+    handler: async (a) => readMany(strArray(a, "files")),
+  },
+  {
+    name: "read_hash",
+    cliCommand: ["read-hash"],
+    summary: "Read a single line with its hash and surrounding context.",
+    description:
+      "Read one line of a file plus N lines of context, with a hash for the line. " +
+      "Use it when you already know the line you intend to change and do not want " +
+      "the whole file in context. Do NOT use it to read a region — pass a `range` " +
+      "to `replace_hash` instead of stitching single lines together.",
+    params: [
+      { name: "file", type: "string", required: true, description: "Path to the file to read." },
+      { name: "line", type: "number", required: true, description: "1-indexed line number." },
+      { name: "context", type: "number", required: false, description: "Lines of context either side. Default 3." },
+    ],
+    mutates: false,
+    handler: async (a) => readHash(str(a, "file")!, num(a, "line")!, num(a, "context") ?? 3),
+  },
+  {
+    name: "grep_many",
+    cliCommand: ["grep-many"],
+    summary: "Regex search across paths.",
+    description:
+      "Search a regex across files or directories and get back file, line number, " +
+      "and matching text. This is the cheapest way to locate code. " +
+      "Do NOT use it to find where a symbol is defined — `symbol_lookup_many` " +
+      "understands definitions and will not drown you in call sites.",
+    params: [
+      { name: "pattern", type: "string", required: true, description: "Regular expression to search for." },
+      { name: "paths", type: "string[]", required: true, description: "Files or directories to search." },
+      { name: "ignoreCase", type: "boolean", required: false, description: "Case-insensitive match." },
+      { name: "filePattern", type: "string", required: false, description: "Glob limiting which files are searched, e.g. '*.ts'." },
+      { name: "maxResults", type: "number", required: false, description: "Cap on returned matches." },
+    ],
+    mutates: false,
+    handler: async (a) =>
+      grepMany(str(a, "pattern")!, strArray(a, "paths"), {
+        ignoreCase: bool(a, "ignoreCase"),
+        filePattern: str(a, "filePattern"),
+        maxResults: num(a, "maxResults"),
+      }),
+  },
+  {
+    name: "symbol_lookup_many",
+    cliCommand: ["symbol-lookup-many"],
+    summary: "Find where symbols are defined.",
+    description:
+      "Locate the definitions of named symbols across paths. Use it to answer " +
+      "'where does this function live' before editing it. " +
+      "Do NOT use it to find call sites — it reports definitions only; use `grep_many` for references.",
+    params: [
+      { name: "names", type: "string[]", required: true, description: "Symbol names whose definitions you want located." },
+      { name: "paths", type: "string[]", required: true, description: "Files or directories to search." },
+    ],
+    mutates: false,
+    handler: async (a) => symbolLookupMany(strArray(a, "names"), strArray(a, "paths")),
+  },
+  {
+    name: "find_symbols",
+    cliCommand: ["ast", "find-symbols"],
+    summary: "List every symbol declared in one file.",
+    description:
+      "Parse a file and list the symbols it declares, with their kinds and lines. " +
+      "Use it to orient yourself in an unfamiliar file before an AST edit. " +
+      "Do NOT use it on an unsupported language — check `ast_capabilities` first, " +
+      "or the call returns a parse error.",
+    params: [FILE_PARAM],
+    mutates: false,
+    handler: async (a) => {
+      const file = str(a, "file")!;
+      // A path that does not exist is the caller's mistake, not ours. Without
+      // this it surfaces as INTERNAL_ERROR, which reads to a model as "the tool
+      // is broken" rather than "fix the path".
+      const handle = Bun.file(file);
+      if (!(await handle.exists())) {
+        return { success: false, errorCode: "FILE_NOT_FOUND", error: `No such file: ${file}` };
+      }
+      return findSymbols(await handle.text(), file);
+    },
+  },
+  {
+    name: "ast_capabilities",
+    cliCommand: ["ast", "capabilities"],
+    summary: "List languages and operations the AST tier supports.",
+    description:
+      "Report which languages have tree-sitter support and which AST operations " +
+      "exist. Call it once when you are unsure whether a file can be edited " +
+      "structurally. Do NOT call it before every edit — the answer does not change " +
+      "within a session, and `route_edit` falls back on its own.",
+    params: [],
+    mutates: false,
+    handler: async () => astCapabilities(),
+  },
+
+  /* — Hash tier — */
+  {
+    name: "replace_hash",
+    cliCommand: ["replace-hash"],
+    summary: "Replace content anchored to a SHA-256 hash you read earlier.",
+    description:
+      "Replace a region of a file identified by the hash returned from `read_many` " +
+      "or `read_hash`. If the file changed since you read it, the edit refuses or " +
+      "relocates the anchor rather than overwriting someone else's work — this is " +
+      "the safest edit HashPilot offers and the right default for any language " +
+      "without AST support. " +
+      "Do NOT use it for a rename that spans call sites: `rename_symbol` understands " +
+      "bindings and this does not.",
+    params: [
+      FILE_PARAM,
+      { name: "oldHash", type: "string", required: true, description: "The hash of the content you are replacing, from a prior read." },
+      { name: "newContent", type: "string", required: true, description: "Replacement text. An empty string deletes the region." },
+      { name: "range", type: "string", required: false, description: "Line range as 'start:end' or a single 'N', 1-indexed." },
+      ...PROVENANCE_PARAMS,
+    ],
+    mutates: true,
+    handler: editHandler("replace-hash", "hash", (a) => ({
+      oldHash: str(a, "oldHash"),
+      newContent: str(a, "newContent"),
+      range: parseRangeArg(str(a, "range")),
+    })),
+  },
+  {
+    name: "replace_content",
+    cliCommand: ["route-edit"],
+    summary: "Search-and-replace fallback for content you cannot hash or parse.",
+    description:
+      "Replace an exact block of text with another. Refuses when the old text " +
+      "appears more than once, so an ambiguous match fails loudly instead of " +
+      "editing the wrong copy. " +
+      "Do NOT reach for this first — prefer `replace_hash` (verified) or an AST " +
+      "tool (structural). This tier exists for languages and shapes the other two cannot handle.",
+    params: [
+      FILE_PARAM,
+      { name: "oldContent", type: "string", required: true, description: "Exact existing text to replace. Must occur exactly once." },
+      { name: "newContent", type: "string", required: true, description: "Replacement text. An empty string deletes the block." },
+      ...PROVENANCE_PARAMS,
+    ],
+    mutates: true,
+    handler: editHandler("replace-content", "diff", (a) => ({
+      oldContent: str(a, "oldContent"),
+      newContent: str(a, "newContent"),
+    })),
+  },
+
+  /* — AST tier — */
+  {
+    name: "rename_symbol",
+    cliCommand: ["ast", "rename-symbol"],
+    summary: "Rename a symbol and its references within one file.",
+    description:
+      "Rename a declaration and every reference bound to it in the same file, using " +
+      "the syntax tree rather than text matching — so a string containing the name, " +
+      "or a different symbol that happens to share it, is left alone. Refuses with " +
+      "AMBIGUOUS_SYMBOL when the name binds more than once in the file. " +
+      "Do NOT expect it to cross file boundaries: it is file-scoped by design. " +
+      "Rename each file, or use `intent` for a cross-file plan.",
+    params: [
+      FILE_PARAM,
+      { name: "oldName", type: "string", required: true, description: "Current symbol name." },
+      { name: "newName", type: "string", required: true, description: "New symbol name." },
+      ...PROVENANCE_PARAMS,
+    ],
+    mutates: true,
+    handler: editHandler("rename-symbol", "ast", (a) => ({
+      oldName: str(a, "oldName"),
+      newName: str(a, "newName"),
+    })),
+  },
+  {
+    name: "replace_body",
+    cliCommand: ["ast", "replace-body"],
+    summary: "Replace a function or method body, keeping its signature.",
+    description:
+      "Swap the body of a named function or method without touching its signature, " +
+      "decorators, or surrounding code. The result is reparsed and the edit is " +
+      "discarded if it would not parse. " +
+      "Do NOT use it to change the signature — that is `intent` with add-parameter, " +
+      "which also updates call sites.",
+    params: [
+      FILE_PARAM,
+      { name: "symbol", type: "string", required: true, description: "Name of the function or method." },
+      { name: "newBody", type: "string", required: true, description: "Replacement body, including its braces or indentation block." },
+      ...PROVENANCE_PARAMS,
+    ],
+    mutates: true,
+    handler: editHandler("replace-body", "ast", (a) => ({
+      symbolName: str(a, "symbol"),
+      newBody: str(a, "newBody"),
+    })),
+  },
+  {
+    name: "add_import",
+    cliCommand: ["ast", "add-import"],
+    summary: "Add an import statement in the language's own style.",
+    description:
+      "Insert an import, placing it with the file's existing imports and merging " +
+      "into a grouped import from the same module where the language allows it. " +
+      "Do NOT hand-write the import with an insert tool — this one knows the " +
+      "per-language formatting and will not produce a duplicate.",
+    params: [
+      FILE_PARAM,
+      { name: "importSpec", type: "string", required: true, description: "Import to add, e.g. '{ Foo } from ./bar'." },
+      ...PROVENANCE_PARAMS,
+    ],
+    mutates: true,
+    handler: editHandler("add-import", "ast", (a) => ({ importSpec: str(a, "importSpec") })),
+  },
+  {
+    name: "remove_import",
+    cliCommand: ["ast", "remove-import"],
+    summary: "Remove an import statement.",
+    description:
+      "Delete an import, and drop just one name out of a grouped import when the " +
+      "rest are still used. " +
+      "Do NOT use it to clean up every unused import — it removes what you name, " +
+      "and does not analyse usage.",
+    params: [
+      FILE_PARAM,
+      { name: "importSpec", type: "string", required: true, description: "Import to remove, in the same form as it appears." },
+      ...PROVENANCE_PARAMS,
+    ],
+    mutates: true,
+    handler: editHandler("remove-import", "ast", (a) => ({ importSpec: str(a, "importSpec") })),
+  },
+  {
+    name: "insert_before",
+    cliCommand: ["ast", "insert-before"],
+    summary: "Insert code immediately before a symbol's declaration.",
+    description:
+      "Place new code directly above a named declaration — a decorator, a helper, " +
+      "a comment block. Anchored to the symbol, so it stays correct even if line " +
+      "numbers moved since you read the file. " +
+      "Do NOT use it to add an import; `add_import` handles placement and grouping.",
+    params: [
+      FILE_PARAM,
+      { name: "symbol", type: "string", required: true, description: "Symbol to insert before." },
+      { name: "content", type: "string", required: true, description: "Code to insert." },
+      ...PROVENANCE_PARAMS,
+    ],
+    mutates: true,
+    handler: editHandler("insert-before", "ast", (a) => ({
+      symbolName: str(a, "symbol"),
+      content: str(a, "content"),
+    })),
+  },
+  {
+    name: "insert_after",
+    cliCommand: ["ast", "insert-after"],
+    summary: "Insert code immediately after a symbol's declaration.",
+    description:
+      "Place new code directly below a named declaration — a sibling function, a " +
+      "test, an export. Anchored to the symbol rather than to a line number. " +
+      "Do NOT use it to append to the end of a file; anchor to the last symbol you " +
+      "actually mean to follow.",
+    params: [
+      FILE_PARAM,
+      { name: "symbol", type: "string", required: true, description: "Symbol to insert after." },
+      { name: "content", type: "string", required: true, description: "Code to insert." },
+      ...PROVENANCE_PARAMS,
+    ],
+    mutates: true,
+    handler: editHandler("insert-after", "ast", (a) => ({
+      symbolName: str(a, "symbol"),
+      content: str(a, "content"),
+    })),
+  },
+
+  /* — Routing and verification — */
+  {
+    name: "route_edit",
+    cliCommand: ["route-edit"],
+    summary: "Apply an edit and let HashPilot pick the safest tier automatically.",
+    description:
+      "Run any edit operation through the AST → hash → diff pipeline, choosing the " +
+      "strongest tier the language and operation support and falling back when it " +
+      "cannot. Use it when you do not want to reason about tiers. " +
+      "Do NOT use it when you already know the tier — the specific tool gives a " +
+      "clearer failure when its precondition is not met, instead of silently falling back.",
+    params: [
+      FILE_PARAM,
+      { name: "operation", type: "string", required: true, description: "One of: rename-symbol, replace-body, add-import, remove-import, insert-before, insert-after, replace-hash, replace-content." },
+      { name: "method", type: "string", required: false, description: "Force a tier: 'ast', 'hash', or 'diff'. Omit to auto-route." },
+      { name: "oldHash", type: "string", required: false, description: "Anchor hash, for the hash tier." },
+      { name: "newContent", type: "string", required: false, description: "Replacement content." },
+      { name: "oldContent", type: "string", required: false, description: "Existing content to match, for the diff tier." },
+      { name: "range", type: "string", required: false, description: "Line range as 'start:end', for the hash tier." },
+      { name: "oldName", type: "string", required: false, description: "Current name, for rename-symbol." },
+      { name: "newName", type: "string", required: false, description: "New name, for rename-symbol." },
+      { name: "symbol", type: "string", required: false, description: "Symbol name, for body replacement and inserts." },
+      { name: "newBody", type: "string", required: false, description: "New body, for replace-body." },
+      { name: "importSpec", type: "string", required: false, description: "Import spec, for add-import and remove-import." },
+      { name: "content", type: "string", required: false, description: "Content, for insert-before and insert-after." },
+      ...PROVENANCE_PARAMS,
+    ],
+    mutates: true,
+    handler: async (a) =>
+      routeEdit({
+        filePath: str(a, "file")!,
+        operation: str(a, "operation")!,
+        method: str(a, "method"),
+        oldHash: str(a, "oldHash"),
+        newContent: str(a, "newContent"),
+        oldContent: str(a, "oldContent"),
+        range: parseRangeArg(str(a, "range")),
+        oldName: str(a, "oldName"),
+        newName: str(a, "newName"),
+        symbolName: str(a, "symbol"),
+        newBody: str(a, "newBody"),
+        importSpec: str(a, "importSpec"),
+        content: str(a, "content"),
+        dryRun: bool(a, "dryRun"),
+        actor: str(a, "actor"),
+        taskId: str(a, "taskId"),
+        reason: str(a, "reason"),
+      } as Parameters<typeof routeEdit>[0]),
+  },
+  {
+    name: "verify_changes",
+    cliCommand: ["verify-changes"],
+    summary: "Run the project's formatter, linter, and tests over changed files.",
+    description:
+      "Run the checks the project already defines, scoped to the files you edited. " +
+      "Every check is opt-in, so ask for what you need. Call it after a batch of " +
+      "edits, not after each one. " +
+      "Do NOT treat a failure as proof your edit broke something unless a baseline " +
+      "was recorded — pass `useBaseline` so pre-existing failures are subtracted.",
+    params: [
+      { name: "files", type: "string[]", required: true, description: "Files the checks should cover." },
+      { name: "autoDetect", type: "boolean", required: false, description: "Detect the project's formatter, linter, and test runner from its manifest. Usually what you want." },
+      { name: "formatter", type: "string", required: false, description: "Formatter command to run, e.g. 'prettier'. Overrides detection." },
+      { name: "linter", type: "string", required: false, description: "Linter command to run, e.g. 'eslint'. Overrides detection." },
+      { name: "typecheck", type: "string", required: false, description: "Type checker command, e.g. 'tsc --noEmit'." },
+      { name: "testRunner", type: "string", required: false, description: "Test runner, e.g. 'bun test', 'vitest', 'pytest', 'go test'." },
+      { name: "testFilter", type: "string", required: false, description: "Only run tests matching this pattern." },
+      { name: "scopeTests", type: "boolean", required: false, description: "Run only tests related to the changed files. Default true." },
+      { name: "useBaseline", type: "boolean", required: false, description: "Subtract tests that were already failing at this commit, so only new breakage fails the run." },
+      { name: "revertOnFailure", type: "boolean", required: false, description: "Restore the files to their pre-edit contents if any check fails." },
+      { name: "timeout", type: "number", required: false, description: "Per-check timeout in milliseconds. Default 30000." },
+    ],
+    mutates: true,
+    handler: async (a) =>
+      verifyChanges(strArray(a, "files"), {
+        autoDetect: bool(a, "autoDetect"),
+        formatter: str(a, "formatter"),
+        linter: str(a, "linter"),
+        typecheck: str(a, "typecheck"),
+        testRunner: str(a, "testRunner"),
+        testFilter: str(a, "testFilter"),
+        // `scopeTests` defaults to true in the core; only an explicit false turns it off.
+        scopeTests: a.scopeTests === undefined ? undefined : bool(a, "scopeTests"),
+        useBaseline: bool(a, "useBaseline"),
+        revertOnFailure: bool(a, "revertOnFailure"),
+        timeout: num(a, "timeout"),
+      }),
+  },
+];
+
+/** Look an operation up by MCP tool name. */
+export function getOperation(name: string): Operation | undefined {
+  return OPERATIONS.find((o) => o.name === name);
+}
+
+/** JSON Schema for an operation's parameters, as MCP's `inputSchema`. */
+export function inputSchemaFor(op: Operation): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  for (const p of op.params) {
+    properties[p.name] =
+      p.type === "string[]"
+        ? { type: "array", items: { type: "string" }, description: p.description }
+        : { type: p.type, description: p.description };
+  }
+  return {
+    type: "object",
+    properties,
+    required: op.params.filter((p) => p.required).map((p) => p.name),
+    additionalProperties: false,
+  };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,296 @@
+/**
+ * MCP server over stdio (#25).
+ *
+ * The protocol surface is hand-written rather than taken from an SDK: MCP's
+ * stdio transport is newline-delimited JSON-RPC 2.0 and the four methods we
+ * need are small, while a dependency here would land in every install of a tool
+ * whose whole pitch is that it drops into any agent without ceremony.
+ *
+ * Tools are not declared here. They come from `OPERATIONS` in
+ * `src/core/operations.ts`, the same list the CLI is checked against, so the
+ * MCP surface cannot quietly drift from the documented commands.
+ */
+
+import { OPERATIONS, getOperation, inputSchemaFor } from "../core/operations";
+import { API_VERSION } from "../core/envelope";
+
+/** The MCP revision we implement. Echoed back in `initialize`. */
+export const PROTOCOL_VERSION = "2024-11-05";
+
+/* ── JSON-RPC types ──────────────────────────────────────────────────── */
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  /** Absent for notifications, which take no response. */
+  id?: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+/** JSON-RPC reserved codes. Tool failures do NOT use these — see `callTool`. */
+const PARSE_ERROR = -32700;
+const INVALID_REQUEST = -32600;
+const METHOD_NOT_FOUND = -32601;
+const INTERNAL_ERROR = -32603;
+
+/* ── Method handlers ─────────────────────────────────────────────────── */
+
+function listTools() {
+  return {
+    tools: OPERATIONS.map((op) => ({
+      name: op.name,
+      description: `${op.summary}\n\n${op.description}`,
+      inputSchema: inputSchemaFor(op),
+      annotations: {
+        readOnlyHint: !op.mutates,
+        destructiveHint: op.mutates,
+        title: op.summary,
+      },
+    })),
+  };
+}
+
+/**
+ * Reject a call whose arguments cannot satisfy the operation before running it.
+ * Only presence and coarse shape are checked; the handlers coerce the rest.
+ * Returns a message, or null when the arguments are acceptable.
+ */
+function validateArgs(op: ReturnType<typeof getOperation>, args: Record<string, unknown>): string | null {
+  if (!op) return null;
+  const missing = op.params
+    .filter((p) => p.required)
+    .filter((p) => {
+      const v = args[p.name];
+      // An empty string is a legitimate value (a deletion, #40); only
+      // absence is missing.
+      return v === undefined || v === null;
+    })
+    .map((p) => p.name);
+  if (missing.length) return `missing required parameter(s): ${missing.join(", ")}`;
+
+  for (const p of op.params) {
+    const v = args[p.name];
+    if (v === undefined || v === null) continue;
+    if (p.type === "string[]" && !Array.isArray(v) && typeof v !== "string") {
+      return `parameter "${p.name}" must be an array of strings`;
+    }
+    // `Number("")` and `Number([])` are both 0, so a NaN test alone lets an
+    // empty string or an array through as a number. The handler then coerces it
+    // back to undefined and the call returns a green result for a nonsense
+    // argument — the same silent-success failure `findFailure` exists to stop.
+    if (p.type === "number" && !isNumeric(v)) {
+      return `parameter "${p.name}" must be a number`;
+    }
+  }
+  return null;
+}
+
+/** True only for a real number, or a string that is entirely one. */
+function isNumeric(v: unknown): boolean {
+  if (typeof v === "number") return Number.isFinite(v);
+  if (typeof v !== "string" || v.trim() === "") return false;
+  return Number.isFinite(Number(v));
+}
+
+/**
+ * Run one tool call.
+ *
+ * A failed *edit* is reported as `isError: true` on a successful JSON-RPC
+ * result, not as a JSON-RPC error: the distinction MCP draws is that protocol
+ * errors are the host's problem while tool errors are the model's to read and
+ * act on. The payload carries the envelope's `code` and `recovery` verbatim,
+ * which is the whole point — a stale anchor should reach the model as
+ * "re-read the file and retry", not as a stack trace.
+ */
+export async function callTool(name: string, rawArgs: unknown): Promise<Record<string, unknown>> {
+  const op = getOperation(name);
+  if (!op) {
+    return errorResult("UNKNOWN_TOOL", `No such tool: ${name}`, "Call tools/list to see the available tools.");
+  }
+
+  const args = (rawArgs && typeof rawArgs === "object" ? rawArgs : {}) as Record<string, unknown>;
+  const invalid = validateArgs(op, args);
+  if (invalid) {
+    return errorResult("INVALID_ARGUMENTS", invalid, "Check the tool's inputSchema and call it again.");
+  }
+
+  try {
+    const data = await op.handler(args);
+    const failure = findFailure(data);
+    if (failure) {
+      return errorResult(
+        String(failure.errorCode || failure.code || "EDIT_FAILED"),
+        String(failure.error || failure.message || "the edit did not apply"),
+        typeof failure.recovery === "string" ? failure.recovery : undefined,
+        data as Record<string, unknown>
+      );
+    }
+    return okResult(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const code = (err as { errorCode?: string })?.errorCode || "INTERNAL_ERROR";
+    return errorResult(code, message);
+  }
+}
+
+/**
+ * Find the payload that reports failure, or null when the call succeeded.
+ *
+ * `routeEdit` reports routing at the top level and the edit's own outcome one
+ * level down under `result`, so a check of only the outer `success` reads a
+ * failed edit as a success — which would hand the model a green result for an
+ * edit that never applied. Both levels are inspected, innermost first, because
+ * the inner object carries the specific `errorCode` worth surfacing.
+ */
+function findFailure(data: unknown): Record<string, unknown> | null {
+  if (!data || typeof data !== "object") return null;
+  const d = data as Record<string, unknown>;
+  const inner = findFailure(d.result);
+  if (inner) return inner;
+  return d.success === false ? d : null;
+}
+
+/**
+ * MCP results carry text content. The text is the JSON envelope: models read it
+ * directly, and a host that wants structure gets the same object back under
+ * `structuredContent`.
+ */
+function okResult(data: unknown): Record<string, unknown> {
+  const payload = { apiVersion: API_VERSION, ok: true, data };
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    structuredContent: payload,
+    isError: false,
+  };
+}
+
+function errorResult(code: string, message: string, recovery?: string, details?: unknown): Record<string, unknown> {
+  const payload = {
+    apiVersion: API_VERSION,
+    ok: false,
+    error: { code, message, ...(recovery ? { recovery } : {}), ...(details ? { details } : {}) },
+  };
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    structuredContent: payload,
+    isError: true,
+  };
+}
+
+/**
+ * Dispatch one request. Returns null for notifications, which JSON-RPC forbids
+ * answering — `notifications/initialized` is the one every host sends.
+ */
+export async function handleRequest(req: JsonRpcRequest): Promise<JsonRpcResponse | null> {
+  const isNotification = req.id === undefined || req.id === null;
+  const id = req.id as string | number;
+
+  try {
+    switch (req.method) {
+      case "initialize":
+        return isNotification ? null : {
+          jsonrpc: "2.0",
+          id,
+          result: {
+            protocolVersion: PROTOCOL_VERSION,
+            capabilities: { tools: { listChanged: false } },
+            serverInfo: { name: "hashpilot", version: process.env.HASHPILOT_VERSION || "dev" },
+          },
+        };
+
+      case "notifications/initialized":
+      case "notifications/cancelled":
+        return null;
+
+      case "ping":
+        return isNotification ? null : { jsonrpc: "2.0", id, result: {} };
+
+      case "tools/list":
+        return isNotification ? null : { jsonrpc: "2.0", id, result: listTools() };
+
+      case "tools/call": {
+        const name = String(req.params?.name || "");
+        const result = await callTool(name, req.params?.arguments);
+        return isNotification ? null : { jsonrpc: "2.0", id, result };
+      }
+
+      default:
+        if (isNotification) return null;
+        return {
+          jsonrpc: "2.0",
+          id,
+          error: { code: METHOD_NOT_FOUND, message: `Method not found: ${req.method}` },
+        };
+    }
+  } catch (err) {
+    if (isNotification) return null;
+    return {
+      jsonrpc: "2.0",
+      id,
+      error: { code: INTERNAL_ERROR, message: err instanceof Error ? err.message : String(err) },
+    };
+  }
+}
+
+/** Parse and dispatch one newline-delimited message. Returns the line to write back, or null. */
+export async function handleLine(line: string): Promise<string | null> {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  let req: JsonRpcRequest;
+  try {
+    req = JSON.parse(trimmed);
+  } catch {
+    // No id is recoverable from unparseable input, so per JSON-RPC the id is null.
+    return JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: PARSE_ERROR, message: "Invalid JSON" } });
+  }
+
+  if (!req || typeof req.method !== "string") {
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      id: req?.id ?? null,
+      error: { code: INVALID_REQUEST, message: "Missing method" },
+    });
+  }
+
+  const res = await handleRequest(req);
+  return res ? JSON.stringify(res) : null;
+}
+
+/**
+ * Run the stdio loop until stdin closes.
+ *
+ * Requests are handled strictly in order. Concurrency would be free wall-clock
+ * here, but two edits to one file interleaving inside one process would
+ * deadlock on the advisory lock (it is not re-entrant), and an agent's edits
+ * are usually sequentially dependent anyway.
+ *
+ * Nothing may be written to stdout but protocol frames — a stray log line
+ * corrupts the stream — so diagnostics go to stderr.
+ */
+export async function runStdioServer(): Promise<void> {
+  let buffer = "";
+  const decoder = new TextDecoder();
+
+  for await (const chunk of Bun.stdin.stream()) {
+    buffer += decoder.decode(chunk as Uint8Array, { stream: true });
+    let nl: number;
+    while ((nl = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, nl);
+      buffer = buffer.slice(nl + 1);
+      const out = await handleLine(line);
+      if (out !== null) process.stdout.write(out + "\n");
+    }
+  }
+
+  // A final frame with no trailing newline still deserves an answer.
+  const out = await handleLine(buffer);
+  if (out !== null) process.stdout.write(out + "\n");
+}

--- a/templates/claude-section.md
+++ b/templates/claude-section.md
@@ -13,6 +13,23 @@ This installs the `hashpilot` CLI and injects the sections below into `~/.claude
 This session has HashPilot Claude active at user scope.
 HashPilot Core (`hashpilot`) is available on PATH.
 
+### Preferred: use the MCP server
+
+If this host speaks MCP, register HashPilot once and use its tools directly
+instead of shelling out:
+
+```bash
+claude mcp add hashpilot -- hashpilot mcp --stdio
+```
+
+The MCP tools mirror the CLI one-for-one (`rename_symbol`, `replace_hash`,
+`route_edit`, `verify_changes`, and the read/search tools), and multi-line
+content with quotes or backticks rides inside JSON rather than through shell
+quoting. Setup for other hosts: `docs/INTEGRATION-MCP.md`.
+
+The CLI commands below remain fully supported and are the fallback when MCP is
+not available in this host.
+
 **Use HashPilot when:** editing existing files, renaming symbols, replacing function bodies, managing imports, batch reading, or verifying changes.
 
 **Skip HashPilot when:** creating new files, deleting files, moving/renaming files, simple one-off edits, or file system operations — use direct commands instead.

--- a/templates/opencode-skill.md
+++ b/templates/opencode-skill.md
@@ -17,6 +17,23 @@ This installs the `hashpilot` CLI and registers the OpenCode skill + subagent.
 
 HashPilot is a global, tool-agnostic structured editing system that improves coding-agent efficiency by preferring syntax-aware edits when possible, hash-anchored edits otherwise, and providing verification batching.
 
+### Preferred: use the MCP server
+
+If your host speaks MCP, register HashPilot once and call its tools directly
+instead of shelling out:
+
+```json
+{ "mcpServers": { "hashpilot": { "command": "hashpilot", "args": ["mcp", "--stdio"] } } }
+```
+
+The MCP tools mirror the CLI one-for-one (`rename_symbol`, `replace_hash`,
+`route_edit`, `verify_changes`, plus the read and search tools), and multi-line
+content with quotes or backticks rides inside JSON rather than through shell
+quoting. Per-host setup lives in `docs/INTEGRATION-MCP.md`.
+
+The CLI commands below remain fully supported and are the fallback when MCP is
+not available.
+
 ## When to Use This Skill
 
 - **Editing supported languages**: Use AST commands for precise symbol-level edits (TypeScript, TSX, JavaScript, Python, Go, Rust)

--- a/templates/pi-skill.md
+++ b/templates/pi-skill.md
@@ -17,6 +17,23 @@ This installs the `hashpilot` CLI and registers the Pi extension with `/hp` slas
 
 You have access to HashPilot structured editing tools that are more reliable and token-efficient than raw text editing.
 
+### Preferred: use the MCP server
+
+If your host speaks MCP, register HashPilot once and call its tools directly
+instead of shelling out:
+
+```json
+{ "mcpServers": { "hashpilot": { "command": "hashpilot", "args": ["mcp", "--stdio"] } } }
+```
+
+The MCP tools mirror the CLI one-for-one (`rename_symbol`, `replace_hash`,
+`route_edit`, `verify_changes`, plus the read and search tools), and multi-line
+content with quotes or backticks rides inside JSON rather than through shell
+quoting. Per-host setup lives in `docs/INTEGRATION-MCP.md`.
+
+The CLI commands below remain fully supported and are the fallback when MCP is
+not available.
+
 ## When to Use
 
 - Editing existing files in supported AST languages (TS/JS/Python/Go/Rust)

--- a/tests/envelope.test.ts
+++ b/tests/envelope.test.ts
@@ -124,6 +124,14 @@ describe("the envelope is uniform across every command", () => {
     });
   }
 
+  /**
+   * `mcp` owns stdout for the whole process: it is a JSON-RPC stream, and an
+   * envelope written into it would corrupt the protocol. It is the one command
+   * that legitimately emits no envelope, and its own framing is covered by
+   * `tests/mcp-server.test.ts`. Any other exemption is a bug.
+   */
+  const NO_ENVELOPE = new Set(["mcp"]);
+
   test("every leaf command in --help is covered by the sweep", () => {
     // Otherwise a new command ships unvalidated and nobody notices.
     const covered = new Set(INVOCATIONS.map(([, args]) => args.slice(0, 2).join(" ")));
@@ -138,6 +146,7 @@ describe("the envelope is uniform across every command", () => {
       .filter((c): c is string => Boolean(c) && c !== "help");
 
     for (const cmd of top) {
+      if (NO_ENVELOPE.has(cmd)) continue;
       if (groups.includes(cmd)) {
         const sub = run([cmd, "--help"]).stdout;
         const leaves = sub

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,0 +1,295 @@
+/**
+ * MCP conformance (#25).
+ *
+ * Two halves. The first drives the real binary over stdio, because the failure
+ * this guards against — a stray write to stdout corrupting the protocol stream
+ * — is invisible to an in-process test. The second calls the dispatcher
+ * directly for the per-tool cases, where spawning a process each time buys
+ * nothing.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { handleLine, callTool, PROTOCOL_VERSION } from "../src/mcp/server";
+import { OPERATIONS } from "../src/core/operations";
+
+/**
+ * Fixtures live under the repo, not in `/tmp`.
+ *
+ * The write boundary confines every edit to the project root, so a fixture in
+ * the system temp dir is refused with PATH_DENIED before any tier runs — the
+ * boundary working as designed, not something for a test to route around with
+ * `--allow-outside-root`.
+ */
+function makeFixtureDir(prefix: string): string {
+  const base = join(import.meta.dir, "..", ".hashpilot-test-tmp");
+  mkdirSync(base, { recursive: true });
+  return mkdtempSync(join(base, prefix));
+}
+
+/** Drive the CLI's `mcp --stdio` and return one parsed response per output line. */
+async function driveServer(requests: unknown[]): Promise<Record<string, unknown>[]> {
+  const proc = Bun.spawn(["bun", "run", "src/cli.ts", "mcp", "--stdio"], {
+    cwd: join(import.meta.dir, ".."),
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, HASHPILOT_NO_TELEMETRY: "1" },
+  });
+  proc.stdin.write(requests.map((r) => JSON.stringify(r)).join("\n") + "\n");
+  proc.stdin.end();
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+  return out
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+describe("mcp server over stdio", () => {
+  test("initialize, notification, and tools/list round-trip on the real binary", async () => {
+    const responses = await driveServer([
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+    ]);
+
+    // The notification must produce no line at all — an answer to a
+    // notification is a protocol violation, and extra frames desync the host.
+    expect(responses.length).toBe(2);
+
+    const init = responses[0] as any;
+    expect(init.id).toBe(1);
+    expect(init.result.protocolVersion).toBe(PROTOCOL_VERSION);
+    expect(init.result.serverInfo.name).toBe("hashpilot");
+    expect(init.result.capabilities.tools).toBeDefined();
+
+    const list = responses[1] as any;
+    expect(list.id).toBe(2);
+    expect(list.result.tools.length).toBe(OPERATIONS.length);
+  }, 30000);
+
+  test("nothing but protocol frames reaches stdout", async () => {
+    // A tool call that touches telemetry, config, and the parser — the paths
+    // most likely to console.log — must still yield exactly one frame.
+    const responses = await driveServer([
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "ast_capabilities", arguments: {} } },
+    ]);
+    expect(responses.length).toBe(1);
+    expect((responses[0] as any).id).toBe(1);
+  }, 30000);
+});
+
+describe("tools/list", () => {
+  test("every operation is advertised with a usable schema", async () => {
+    const res = JSON.parse((await handleLine(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" })))!);
+    const tools = res.result.tools as any[];
+    expect(tools.length).toBe(OPERATIONS.length);
+
+    for (const t of tools) {
+      expect(t.name).toMatch(/^[a-z][a-z0-9_]*$/);
+      expect(t.description.length).toBeGreaterThan(40);
+      expect(t.inputSchema.type).toBe("object");
+      expect(Array.isArray(t.inputSchema.required)).toBe(true);
+      for (const r of t.inputSchema.required) {
+        expect(t.inputSchema.properties[r]).toBeDefined();
+      }
+    }
+  });
+
+  test("every tool description says when NOT to use it", () => {
+    // The common agent failure is picking the wrong tier, not passing a wrong
+    // argument, so a negative case in each description is a hard requirement.
+    for (const op of OPERATIONS) {
+      expect(op.description).toContain("Do NOT");
+    }
+  });
+
+  test("read-only operations are not flagged destructive", async () => {
+    const res = JSON.parse((await handleLine(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" })))!);
+    for (const t of res.result.tools as any[]) {
+      const op = OPERATIONS.find((o) => o.name === t.name)!;
+      expect(t.annotations.readOnlyHint).toBe(!op.mutates);
+    }
+  });
+});
+
+describe("protocol errors vs tool errors", () => {
+  test("unparseable input gets a JSON-RPC parse error with a null id", async () => {
+    const res = JSON.parse((await handleLine("{not json"))!);
+    expect(res.error.code).toBe(-32700);
+    expect(res.id).toBe(null);
+  });
+
+  test("an unknown method is a JSON-RPC error", async () => {
+    const res = JSON.parse((await handleLine(JSON.stringify({ jsonrpc: "2.0", id: 9, method: "nope" })))!);
+    expect(res.error.code).toBe(-32601);
+  });
+
+  test("a blank line produces no response", async () => {
+    expect(await handleLine("   ")).toBe(null);
+  });
+
+  test("an unknown tool is a TOOL error, not a protocol error", async () => {
+    // The distinction matters: a protocol error is the host's problem, a tool
+    // error is something the model can read and recover from.
+    const res = JSON.parse(
+      (await handleLine(JSON.stringify({ jsonrpc: "2.0", id: 5, method: "tools/call", params: { name: "bogus" } })))!
+    );
+    expect(res.error).toBeUndefined();
+    expect(res.result.isError).toBe(true);
+    expect(res.result.structuredContent.error.code).toBe("UNKNOWN_TOOL");
+  });
+
+  test("a missing required argument is rejected before the handler runs", async () => {
+    const r = await callTool("rename_symbol", { file: "x.ts" });
+    expect(r.isError).toBe(true);
+    const err = (r.structuredContent as any).error;
+    expect(err.code).toBe("INVALID_ARGUMENTS");
+    expect(err.message).toContain("oldName");
+    expect(err.message).toContain("newName");
+  });
+
+  test("an empty string counts as present, not missing", async () => {
+    // Deleting a region is `newContent: ""` (#40); treating it as absent would
+    // make deletion impossible over MCP.
+    const r = await callTool("replace_content", {
+      file: "/nonexistent-hashpilot-test.ts",
+      oldContent: "x",
+      newContent: "",
+    });
+    const err = (r.structuredContent as any).error;
+    expect(err?.code).not.toBe("INVALID_ARGUMENTS");
+  });
+});
+
+describe("tool calls against a real file", () => {
+  let dir: string;
+  let file: string;
+
+  beforeAll(() => {
+    dir = makeFixtureDir("hashpilot-mcp-");
+    file = join(dir, "sample.ts");
+    writeFileSync(file, `export function greet(name: string) {\n  return "hi " + name;\n}\n`);
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("read_many returns content and a hash", async () => {
+    const r = await callTool("read_many", { files: [file] });
+    expect(r.isError).toBe(false);
+    const data = (r.structuredContent as any).data;
+    expect(data[0].hash).toMatch(/^[0-9a-f]+$/);
+    expect(data[0].content).toContain("greet");
+  });
+
+  test("find_symbols finds the declaration", async () => {
+    const r = await callTool("find_symbols", { file });
+    const data = (r.structuredContent as any).data;
+    expect(data.some((s: any) => s.name === "greet")).toBe(true);
+  });
+
+  test("rename_symbol edits through the router", async () => {
+    const r = await callTool("rename_symbol", { file, oldName: "greet", newName: "salute", actor: "test" });
+    expect(r.isError).toBe(false);
+    expect(readFileSync(file, "utf8")).toContain("salute");
+  });
+
+  test("a failed edit is isError with a recoverable code, not an exception", async () => {
+    const r = await callTool("rename_symbol", { file, oldName: "nothingNamedThis", newName: "x" });
+    expect(r.isError).toBe(true);
+    const err = (r.structuredContent as any).error;
+    expect(err.code).toBeTruthy();
+    expect(err.code).not.toBe("INTERNAL_ERROR");
+  });
+
+  test("dryRun leaves the file alone", async () => {
+    const before = readFileSync(file, "utf8");
+    await callTool("rename_symbol", { file, oldName: "salute", newName: "hail", dryRun: true });
+    expect(readFileSync(file, "utf8")).toBe(before);
+  });
+});
+
+describe("content fidelity", () => {
+  let dir: string;
+  let file: string;
+
+  beforeAll(() => {
+    dir = makeFixtureDir("hashpilot-mcp-fidelity-");
+    file = join(dir, "fixture.ts");
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("multi-line content with quotes, backticks, and backslashes survives a tool call", async () => {
+    // This is the case the CLI's `@file` indirection exists to dodge. Over MCP
+    // the content rides inside JSON, so it must arrive byte-identical without
+    // any escaping ceremony on the caller's part.
+    const nasty = [
+      "const s = `template ${x} with \\`escaped\\` ticks`;",
+      'const q = "double \\"quoted\\" and \'single\'";',
+      "const re = /a\\\\b\\n[^\"']+/g;",
+      "// tab\there, and a trailing backslash \\\\",
+      "const multi = `line1",
+      "line2",
+      "line3`;",
+    ].join("\n");
+
+    writeFileSync(file, "const placeholder = 1;\n");
+    const original = readFileSync(file, "utf8");
+
+    // Round-trip the payload through the wire exactly as a host would.
+    const wire = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "replace_content",
+        arguments: { file, oldContent: "const placeholder = 1;", newContent: nasty },
+      },
+    });
+    const res = JSON.parse((await handleLine(wire))!);
+    expect(res.result.isError).toBe(false);
+
+    const after = readFileSync(file, "utf8");
+    expect(after).toBe(original.replace("const placeholder = 1;", nasty));
+    expect(after).toContain("\\`escaped\\`");
+    expect(after).toContain("line1\nline2\nline3");
+  });
+
+  test("a payload containing a newline cannot split the JSON-RPC frame", async () => {
+    // The stdio transport is newline-delimited; a literal newline inside a
+    // string is escaped by JSON.stringify, and must stay one frame.
+    const wire = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "read_many", arguments: { files: ["a\nb"] } },
+    });
+    expect(wire.includes("\n")).toBe(false);
+    const out = await handleLine(wire);
+    expect(out!.includes("\n")).toBe(false);
+  });
+  test("a required numeric argument rejects empty strings and arrays", async () => {
+    // `Number("")` and `Number([])` are both 0, so a NaN-only check let these
+    // through, the handler coerced them back to undefined, and the call came
+    // back green — a silent success for a nonsense argument.
+    for (const line of ["", [], null]) {
+      const res = await callTool("read_hash", { file: "package.json", line });
+      expect(res.isError).toBe(true);
+      const payload = JSON.parse((res.content as any)[0].text);
+      expect(payload.error.code).toBe("INVALID_ARGUMENTS");
+    }
+    const ok = await callTool("read_hash", { file: "package.json", line: "1" });
+    expect(ok.isError).toBe(false);
+  });
+
+  test("a missing file reports FILE_NOT_FOUND, not INTERNAL_ERROR", async () => {
+    // INTERNAL_ERROR reads to a model as "the tool is broken" rather than
+    // "fix the path", and it will retry instead of correcting the argument.
+    const res = await callTool("find_symbols", { file: "does/not/exist.ts" });
+    expect(res.isError).toBe(true);
+    expect(JSON.parse((res.content as any)[0].text).error.code).toBe("FILE_NOT_FOUND");
+  });
+});

--- a/tests/operations-parity.test.ts
+++ b/tests/operations-parity.test.ts
@@ -1,0 +1,130 @@
+/**
+ * CLI ↔ MCP parity (#25).
+ *
+ * The MCP surface is derived from `OPERATIONS`. This asserts the other half of
+ * that claim: every operation names a CLI command that actually exists, and
+ * every parameter it declares corresponds to a real argument or option on that
+ * command. A tool that promises a parameter the CLI does not have is a
+ * divergence, and a divergence in an agent-facing contract is silent until an
+ * agent hits it.
+ *
+ * The CLI is inspected through its own `--help`, not by importing `cli.ts` —
+ * importing it would run `program.parse()` on the test runner's argv.
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { join } from "path";
+import { OPERATIONS, inputSchemaFor } from "../src/core/operations";
+
+const REPO = join(import.meta.dir, "..");
+
+async function help(path: string[]): Promise<string> {
+  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...path, "--help"], {
+    cwd: REPO,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const out = (await new Response(proc.stdout).text()) + (await new Response(proc.stderr).text());
+  await proc.exited;
+  return out;
+}
+
+/** camelCase → the kebab-case spelling Commander uses for flags and arguments. */
+function kebab(name: string): string {
+  return name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+}
+
+const helpText = new Map<string, string>();
+
+beforeAll(async () => {
+  // One spawn per distinct command, reused across the assertions below.
+  const paths = [...new Set(OPERATIONS.map((o) => o.cliCommand.join(" ")))];
+  await Promise.all(
+    paths.map(async (p) => helpText.set(p, await help(p.split(" "))))
+  );
+}, 60000);
+
+describe("registry ↔ CLI parity", () => {
+  test("every operation maps to a CLI command that exists", () => {
+    for (const op of OPERATIONS) {
+      const key = op.cliCommand.join(" ");
+      const text = helpText.get(key)!;
+      // Commander prints the ROOT usage when a command path is unknown, so a
+      // usage line naming the command is what proves it resolved.
+      expect(text).toContain(`Usage: hashpilot ${key}`);
+    }
+  });
+
+  test("every declared parameter exists on its CLI command", () => {
+    const problems: string[] = [];
+    for (const op of OPERATIONS) {
+      const text = helpText.get(op.cliCommand.join(" "))!;
+      // Everything before "Options:" is the usage line (positional arguments);
+      // after it are the flags. Both count as the command's parameter surface.
+      for (const p of op.params) {
+        const k = kebab(p.name);
+        const present =
+          text.includes(`--${k}`) ||
+          // Commander spells a default-on boolean as its negation, e.g.
+          // `scopeTests` ← `--no-scope-tests`.
+          text.includes(`--no-${k}`) ||
+          text.includes(`<${k}>`) ||
+          text.includes(`<${k}...>`) ||
+          text.includes(`[${k}]`) ||
+          // Plural positionals: `files` ← `<files...>`, `paths` ← `<paths...>`.
+          text.includes(`<${k}...>`);
+        if (!present) problems.push(`${op.name}.${p.name} (no --${k} or <${k}> on "${op.cliCommand.join(" ")}")`);
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+
+  test("tool names are unique and stable in shape", () => {
+    const names = OPERATIONS.map((o) => o.name);
+    expect(new Set(names).size).toBe(names.length);
+    for (const n of names) expect(n).toMatch(/^[a-z][a-z0-9_]*$/);
+  });
+
+  test("every mutating operation accepts provenance and dryRun", () => {
+    // An MCP caller must not lose the accountability a CLI caller gets.
+    for (const op of OPERATIONS.filter((o) => o.mutates && o.name !== "verify_changes")) {
+      const names = op.params.map((p) => p.name);
+      expect(names).toContain("actor");
+      expect(names).toContain("taskId");
+      expect(names).toContain("reason");
+      expect(names).toContain("dryRun");
+    }
+  });
+
+  test("generated schemas are valid JSON Schema objects", () => {
+    for (const op of OPERATIONS) {
+      const schema = inputSchemaFor(op) as any;
+      expect(schema.type).toBe("object");
+      expect(schema.additionalProperties).toBe(false);
+      for (const p of op.params) {
+        const prop = schema.properties[p.name];
+        expect(prop).toBeDefined();
+        expect(prop.description.length).toBeGreaterThan(10);
+        if (p.type === "string[]") {
+          expect(prop.type).toBe("array");
+          expect(prop.items.type).toBe("string");
+        } else {
+          expect(prop.type).toBe(p.type);
+        }
+      }
+    }
+  });
+
+  test("every edit operation the CLI routes is reachable as a tool", () => {
+    // The operation list `route-edit` documents is the canonical set; if one is
+    // added there and not here, MCP callers silently cannot reach it.
+    const routed = [
+      "rename-symbol", "replace-body", "add-import", "remove-import",
+      "insert-before", "insert-after", "replace-hash", "replace-content",
+    ];
+    const toolNames = new Set(OPERATIONS.map((o) => o.name));
+    for (const r of routed) {
+      expect(toolNames.has(r.replace(/-/g, "_"))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #25.

## What

`hashpilot mcp --stdio` — a newline-delimited JSON-RPC 2.0 server over stdio, protocol revision `2024-11-05`. Methods: `initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`. 16 tools.

## Why it is built this way

- **Tools come from a shared registry, not the server.** `src/core/operations.ts` declares each operation once (name, model-facing description, typed params, handler). A drifted MCP surface is worse than no MCP surface — it disagrees silently with the documented CLI. `tests/operations-parity.test.ts` drives the real Commander `--help` tree and asserts every registry param exists as a real flag or argument.
- **Every edit handler delegates to `routeEdit`.** That is the path that takes the advisory lock, does the compare-and-swap, records the snapshot, and writes provenance. An MCP caller must not get a weaker guarantee than a CLI caller.
- **Protocol errors vs tool errors are kept separate.** JSON-RPC errors (`-32700`/`-32600`/`-32601`/`-32603`) are the host's problem; a failed edit is `isError: true` on a *successful* result, carrying the envelope's `code` and `recovery` for the model to act on.
- **Requests are handled strictly in order.** The advisory lock is not re-entrant, so concurrent handling would deadlock.
- **`mcp` owns stdout** for the whole process — it is the one command that emits no JSON envelope. `tests/envelope.test.ts` carries a documented exemption for it; any other exemption is a bug.
- **No MCP SDK dependency.** The four methods are small, and a dependency would land in every install of a tool whose pitch is dropping into any agent without ceremony.

## Deferred, deliberately

The issue's first checklist item asks for every `cli.ts` action body to be rewritten onto the registry. That is a 38-command refactor touching each command's telemetry and `@file` expansion, and pairing it with a new agent-facing surface in one PR makes both harder to review. The registry is the source of truth for MCP today, and the parity test enforces the "cannot diverge" acceptance criterion in the meantime. Worth its own PR.

## Review findings fixed in this branch

1. **Silent success on a bad numeric argument.** Argument validation checked numbers with a NaN test, but `Number("")` and `Number([])` are both `0` — so `""`/`[]` passed, the handler coerced them back to `undefined`, and the call returned `isError: false`. A green result for a nonsense call. Fixed with a strict `isNumeric()`.
2. **Missing file surfaced as `INTERNAL_ERROR`.** Reads to a model as "the tool is broken, retry" rather than "fix the path". `find_symbols` now returns `FILE_NOT_FOUND`.

Both have regression tests.

## Verification

- `bun test` → **725 pass / 0 fail** across 29 files
- `bun run lint:docs` clean (quickref regenerated, ROADMAP consistent)
- Dogfooded on macOS through a real stdio session: registered with `claude mcp add`, `claude mcp list` reports ✔ Connected; drove `tools/list`, three successful edits, and a deliberate failure; `provenance query` showed both edits with actor/reason and before/after hashes; byte fidelity confirmed for backticks, escaped quotes, regex backslashes, and literal tabs.

## Docs

`docs/INTEGRATION-MCP.md` — copy-paste host configs for Claude Code, Claude Desktop, Cursor, Zed/Continue, and running from a checkout; tool tables; error handling; troubleshooting. Linked from README and `docs/ARCHITECTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)