### PR TITLE
fix(install): put ~/.agentic-tools/bin on PATH from install-cli

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ HashPilot is a Bun/TypeScript CLI. The entry point is `src/cli.ts` (the publishe
 - `bun test -t "pattern"` — run tests matching a name.
 - `bun run src/cli.ts doctor` — exercise the CLI directly during development.
 - `bun run build` — bundle `src/cli.ts` to `dist/` for distribution.
-- `bun run install-cli` — symlink the CLI into `~/.agentic-tools/bin/`.
+- `bun run install-cli` — symlink the CLI into `~/.agentic-tools/bin/` and add that directory to `PATH` via a marked block in your shell rc.
 - `bash scripts/doctor.sh` — check the local installation environment.
 - `bash tests/smoke.sh` — run end-to-end checks against the installed CLI.
 - `bun run lint:docs` — verify the CLI quickref matches `--help` and `ROADMAP.md` is consistent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ knowing up front:
 bun install                 # Install dependencies (Bun 1.2+)
 bun test                    # Run all tests
 bun run build               # Bundle src/cli.ts to dist/
-bun run install-cli         # Symlink CLI into ~/.agentic-tools/bin/
+bun run install-cli         # Symlink CLI into ~/.agentic-tools/bin/ and add it to your shell rc PATH
 bun run src/cli.ts doctor   # Exercise the CLI directly without installing
 bash scripts/doctor.sh      # Check local installation environment
 bun run lint:docs           # CLI quickref matches --help + ROADMAP.md is consistent

--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ curl -fsSL https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/ins
 
 </details>
 
+### Install from a checkout (development)
+
+```bash
+bun install
+bun run install-cli   # symlinks the launcher AND adds ~/.agentic-tools/bin to your shell rc
+exec $SHELL -l        # or: export PATH="$HOME/.agentic-tools/bin:$PATH"
+hashpilot doctor
+```
+
+`install-cli` writes a marked block (`# >>> hashpilot path >>>`) into the rc file
+for your current `$SHELL`; `hashpilot uninstall` removes it. `doctor`'s
+`bin-on-path` check reports when the directory is missing from `PATH`, so a
+launcher that exists but cannot be resolved is a visible failure rather than a
+silent one.
+
 ### Upgrade
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "bun test",
     "build": "bun build src/cli.ts --outdir dist --target bun",
-    "install-cli": "mkdir -p ~/.agentic-tools/bin && ln -sf $(pwd)/src/cli-node.cjs ~/.agentic-tools/bin/hashpilot",
+    "install-cli": "bash scripts/install-cli.sh",
     "semantic-release": "semantic-release",
     "gen:cli-quickref": "bun run scripts/gen-cli-quickref.ts",
     "gen:cli-quickref:check": "bun run scripts/gen-cli-quickref.ts --check",

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Dev install: symlink the CLI launcher into ~/.agentic-tools/bin and make sure
+# that directory is actually on PATH.
+#
+# The symlink alone is not an install. Before this script, `bun run install-cli`
+# created the link and stopped, so `hashpilot` was not a runnable command in a
+# fresh shell and `doctor` reported a broken installation. PATH wiring lives in
+# scripts/install.sh for the full install; this is the same block, so the two
+# paths converge on one marker and `scripts/uninstall.sh` removes either.
+set -euo pipefail
+
+BIN_DIR="${HOME}/.agentic-tools/bin"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LAUNCHER="${REPO_ROOT}/src/cli-node.cjs"
+
+mkdir -p "$BIN_DIR"
+ln -sf "$LAUNCHER" "$BIN_DIR/hashpilot"
+echo "Linked $BIN_DIR/hashpilot -> $LAUNCHER"
+
+# Stale symlink from the pre-3.1 binary name; leaving it makes `doctor` and the
+# manifest disagree about what is installed.
+if [ -L "$BIN_DIR/structured-edit" ]; then
+  rm -f "$BIN_DIR/structured-edit"
+  echo "Removed stale symlink: $BIN_DIR/structured-edit"
+fi
+
+detect_rc() {
+  if [ -n "${HASHPILOT_SHELL_RC:-}" ]; then echo "$HASHPILOT_SHELL_RC"; return; fi
+  case "${SHELL:-}" in
+    */zsh) echo "${HOME}/.zshrc"; return ;;
+    */bash) [ -f "${HOME}/.bashrc" ] && { echo "${HOME}/.bashrc"; return; } ;;
+  esac
+  for f in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.profile"; do
+    if [ -f "$f" ]; then echo "$f"; return; fi
+  done
+  echo "${HOME}/.bashrc"
+}
+
+RC_FILE=$(detect_rc)
+PATH_MARKER_START="# >>> hashpilot path >>>"
+PATH_MARKER_END="# <<< hashpilot path <<<"
+PATH_LINE="export PATH=\"\$HOME/.agentic-tools/bin:\$PATH\""
+
+if grep -q "$PATH_MARKER_START" "$RC_FILE" 2>/dev/null; then
+  echo "PATH entry already present in $RC_FILE"
+else
+  {
+    echo ""
+    echo "$PATH_MARKER_START"
+    echo "$PATH_LINE"
+    echo "$PATH_MARKER_END"
+  } >> "$RC_FILE"
+  echo "Added PATH entry to $RC_FILE"
+fi
+
+case ":${PATH}:" in
+  *":${BIN_DIR}:"*) echo "hashpilot is on PATH in this shell." ;;
+  *) echo "Run this to use hashpilot in the current shell:"
+     echo "  export PATH=\"\$HOME/.agentic-tools/bin:\$PATH\"" ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,6 +206,13 @@ detect_rc() {
     echo "$HASHPILOT_SHELL_RC"
     return
   fi
+  # Prefer the rc file for the shell the user actually runs. Picking the first
+  # existing file instead puts the PATH line in ~/.bashrc on a macOS zsh box,
+  # where no interactive shell ever reads it.
+  case "${SHELL:-}" in
+    */zsh) echo "${HOME}/.zshrc"; return ;;
+    */bash) [ -f "${HOME}/.bashrc" ] && { echo "${HOME}/.bashrc"; return; } ;;
+  esac
   for f in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.profile"; do
     if [ -f "$f" ]; then
       echo "$f"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -167,9 +167,12 @@ log "Removing PATH entries..."
 for rc in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.profile"; do
   if [[ -f "$rc" ]]; then
     if grep -q "# >>> hashpilot path >>>" "$rc" 2>/dev/null; then
-      sed -i '/^# >>> hashpilot path >>>/,/^# <<< hashpilot path <<</d' "$rc"
+      # BSD sed (macOS) requires an explicit backup suffix after -i; GNU sed
+      # accepts the empty one, so `-i ''` is not portable either. Pick per-platform.
+      if sed --version >/dev/null 2>&1; then SED_INPLACE=(sed -i); else SED_INPLACE=(sed -i ''); fi
+      "${SED_INPLACE[@]}" '/^# >>> hashpilot path >>>/,/^# <<< hashpilot path <<</d' "$rc"
       # Clean up trailing blank lines
-      sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$rc" 2>/dev/null || true
+      "${SED_INPLACE[@]}" -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$rc" 2>/dev/null || true
       detail "Removed PATH entry from $rc"
       REMOVED=$((REMOVED+1))
     fi

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -72,8 +72,9 @@ export function doctor(): DoctorReport {
   checks.push(checkFile(join(CORE_DIR, "src", "cli.ts"), "core-cli.ts"));
   checks.push(checkFile(join(CORE_DIR, "package.json"), "core-package.json"));
 
-  // 3. CLI launcher on PATH
+  // 3. CLI launcher, and whether a fresh shell can actually find it
   checks.push(checkFile(CLI_LAUNCHER, "cli-launcher"));
+  checks.push(checkPathEntry());
 
   // 4. Check CLI works
   checks.push(checkCLIExecutable());
@@ -103,11 +104,30 @@ export function doctor(): DoctorReport {
   return { checks, healthy, timestamp, version: HASH_VERSION };
 }
 
+/**
+ * The launcher existing is not the same as it being runnable. `install-cli`
+ * used to create the symlink and stop, leaving `hashpilot` unresolvable in a
+ * fresh shell while every other check passed. Report that as its own failure
+ * with the exact line to add.
+ */
+function checkPathEntry(): DoctorCheck {
+  const entries = (process.env.PATH || "").split(":").filter(Boolean);
+  if (entries.includes(BIN_DIR)) {
+    return { name: "bin-on-path", status: "pass", message: `${BIN_DIR} is on PATH` };
+  }
+  return {
+    name: "bin-on-path",
+    status: "fail",
+    message: `${BIN_DIR} is not on PATH. Run \`bun run install-cli\`, or add: export PATH="$HOME/.agentic-tools/bin:$PATH"`,
+  };
+}
+
 function checkCLIExecutable(): DoctorCheck {
   try {
-    const proc = Bun.spawnSync(["hashpilot", "--version"], {
-      env: { ...process.env, PATH: `${BIN_DIR}:${process.env.PATH || ""}` },
-    });
+    // Invoke the launcher by absolute path: this check is about whether the
+    // CLI runs at all. PATH resolution is `checkPathEntry`'s job, and injecting
+    // BIN_DIR here is what used to hide a broken install.
+    const proc = Bun.spawnSync([CLI_LAUNCHER, "--version"]);
     if (proc.exitCode === 0) {
       return { name: "cli-executable", status: "pass", message: `CLI works: ${proc.stdout.toString().trim()}` };
     }

--- a/tests/doctor-path.test.ts
+++ b/tests/doctor-path.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { join } from "path";
+import { doctor } from "../src/core/doctor";
+
+const BIN_DIR = join(process.env.HOME || "/root", ".agentic-tools", "bin");
+const ORIGINAL_PATH = process.env.PATH;
+
+function pathCheck() {
+  return doctor().checks.find((c) => c.name === "bin-on-path")!;
+}
+
+afterEach(() => {
+  process.env.PATH = ORIGINAL_PATH;
+});
+
+describe("doctor — bin directory on PATH", () => {
+  test("fails, with the fix, when the bin dir is missing from PATH", () => {
+    // The symlink existing is not an install: before this check, `install-cli`
+    // linked the launcher and stopped, so `hashpilot` was unresolvable in a
+    // fresh shell while doctor reported the launcher as fine.
+    process.env.PATH = (ORIGINAL_PATH || "")
+      .split(":")
+      .filter((p) => p !== BIN_DIR)
+      .join(":");
+    const check = pathCheck();
+    expect(check.status).toBe("fail");
+    expect(check.message).toContain("install-cli");
+  });
+
+  test("passes when the bin dir is on PATH", () => {
+    process.env.PATH = `${BIN_DIR}:${ORIGINAL_PATH || ""}`;
+    expect(pathCheck().status).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Problem

`bun run install-cli` — the development install documented in `CLAUDE.md` and `AGENTS.md` — only created the launcher symlink. Nothing added `~/.agentic-tools/bin` to `PATH`; only `scripts/install.sh` did that. Result: `which hashpilot` fails in a fresh shell after a documented install.

`doctor` hid the failure. `checkCLIExecutable` spawned the CLI with `BIN_DIR` injected into `PATH`, so the probe passed on a machine where the user's own shell could not resolve the binary.

## Changes

- **`scripts/install-cli.sh`** (new) replaces the inline npm script: symlinks the launcher, removes the pre-3.1 `structured-edit` symlink, and appends the same marked PATH block (`# >>> hashpilot path >>>`) that `scripts/install.sh` uses — so `uninstall.sh` cleans up either install path.
- **`detect_rc`** in both scripts now prefers the rc file for the user's `$SHELL`. Choosing the first existing file wrote the PATH line into `~/.bashrc` on a macOS zsh box, where no interactive shell reads it.
- **`doctor`** gains a `bin-on-path` check with the exact fix in its message, and runs the launcher by absolute path. PATH resolution and "does the CLI run" are now separate, honest signals.
- **`uninstall.sh`** selects the `sed -i` form per platform; the GNU form silently failed to strip the PATH block on macOS.

## Verification

- `bun test` → **727 pass / 0 fail** (30 files), including a new `tests/doctor-path.test.ts`.
- `bun run lint:docs` clean.
- Live on macOS/zsh: `bun run install-cli` → new login shell resolves `hashpilot`, `hashpilot --version` → `4.2.1`, `doctor`'s `bin-on-path` flips to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)