### PR TITLE
fix(install): stop the installer overwriting the checkout through a symlink

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,6 +88,7 @@ Catching up to what competitors already ship: MCP distribution, interactivity, p
 
 | # | Item | Score | Pri | Area |
 |---|------|-------|-----|------|
+| [#96](../../issues/96) | Distribution — publish to npm under a scoped name (`hashpilot` is taken) | 46 | P2 | distribution |
 | [#37](../../issues/37) | B35 — Installer hygiene: template injection, unpinned clone, rc clobber, `rsync --delete` | 45 | P3 | security |
 | [#44](../../issues/44) | B42 — Shell completions, help examples, `intent --schema`, `explain` | 44 | P3 | cli |
 | [#38](../../issues/38) | B36 — `insert-before/after` can splice a statement into a parameter list | 42 | P3 | correctness |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -185,6 +185,11 @@ detail "Dependencies installed"
 # ── Create CLI launcher ──────────────────────────────────────────────────
 log "Creating CLI launcher..."
 mkdir -p "$TARGET_DIR/bin"
+# Remove any existing entry before writing. A development install
+# (`bun run install-cli`) leaves this path as a symlink into the checkout, and
+# `>` follows a symlink — so writing straight to it overwrites the repo's own
+# src/cli-node.cjs instead of replacing the launcher.
+rm -f "$TARGET_DIR/bin/hashpilot"
 cat > "$TARGET_DIR/bin/hashpilot" << 'LAUNCHER'
 #!/bin/bash
 exec bun run "$HOME/.agentic-tools/structured-editing/src/cli.ts" "$@"

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -6,11 +6,19 @@ import { join } from "path";
 const TMP_DIR = join(import.meta.dir, "__tmp_test_config__");
 
 describe("loadConfig", () => {
+  // `loadConfig` merges ~/.config/hashpilot/config.json when it exists, so on a
+  // machine where HashPilot is actually installed these tests read the
+  // developer's real config and the "returns defaults" assertions fail. Point
+  // HOME at the temp dir so the global layer is genuinely absent.
+  const REAL_HOME = process.env.HOME;
+
   beforeEach(() => {
     mkdirSync(TMP_DIR, { recursive: true });
+    process.env.HOME = TMP_DIR;
   });
 
   afterEach(() => {
+    process.env.HOME = REAL_HOME;
     rmSync(TMP_DIR, { recursive: true, force: true });
   });
 

--- a/tests/install-script.test.ts
+++ b/tests/install-script.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const installSh = readFileSync(join(import.meta.dir, "..", "scripts", "install.sh"), "utf8");
+
+describe("install.sh — CLI launcher", () => {
+  test("removes an existing launcher entry before writing the new one", () => {
+    // `bun run install-cli` leaves ~/.agentic-tools/bin/hashpilot as a symlink
+    // into the checkout. `>` follows symlinks, so writing the launcher without
+    // unlinking first overwrote the repo's own src/cli-node.cjs — observed on a
+    // real machine, not hypothetical.
+    const rmIdx = installSh.indexOf('rm -f "$TARGET_DIR/bin/hashpilot"');
+    const catIdx = installSh.indexOf('cat > "$TARGET_DIR/bin/hashpilot"');
+    expect(rmIdx).toBeGreaterThan(-1);
+    expect(catIdx).toBeGreaterThan(-1);
+    expect(rmIdx).toBeLessThan(catIdx);
+  });
+
+  test("a redirect through a symlink still writes to the link target", () => {
+    // Guards the assumption the fix rests on: if this ever stopped being true,
+    // the `rm -f` above would be unnecessary and the test above misleading.
+    const dir = join(import.meta.dir, "..", ".hashpilot-test-tmp");
+    const target = join(dir, "launcher-target.txt");
+    const link = join(dir, "launcher-link");
+    Bun.spawnSync(["mkdir", "-p", dir]);
+    Bun.spawnSync(["rm", "-f", target, link]);
+    Bun.spawnSync(["bash", "-c", `echo original > "${target}"; ln -sf "${target}" "${link}"; echo replaced > "${link}"`]);
+    expect(readFileSync(target, "utf8").trim()).toBe("replaced");
+    Bun.spawnSync(["rm", "-f", target, link]);
+  });
+});


### PR DESCRIPTION
## What

Found while dogfooding a fresh install of v4.3.1.

`scripts/install.sh` wrote the launcher with `cat > \"\$TARGET_DIR/bin/hashpilot\"`. After a development install (`bun run install-cli`) that path is a **symlink into the checkout**, and shell redirection follows symlinks — so running the full installer on a developer machine overwrote the repository's own `src/cli-node.cjs` with the two-line bash launcher. Observed on a real machine; the file had to be restored with `git checkout --`.

Fix: `rm -f` the path before the heredoc.

## Also in here

- `tests/install-script.test.ts` — pins the `rm -f` before `cat >` ordering, plus a behavioral test proving a redirect through a symlink writes to the link target.
- `tests/config.test.ts` — isolate `HOME`. `loadConfig` merges `~/.config/hashpilot/config.json`, so the "returns defaults" assertions failed on any machine where HashPilot is installed. Green in CI, red after dogfooding.
- `ROADMAP.md` — add #96 (publish to npm). The bare name `hashpilot` is taken on the registry by an unrelated Hedera MCP package, so this needs a scoped name.

## Verification

- `bun test` → 729 pass / 0 fail
- Re-ran `bun run install-cli` then `bash scripts/install.sh`: launcher is a regular file, checkout clean.
- Fresh install verified from a clean login shell outside the repo: `hashpilot doctor` → HEALTHY, 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)