### PR TITLE
test(#110): stop bun test from leaving scratch dirs under tests/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ mobile-*.png
 
 # Test scratch directories
 tests/__tmp_*/
+tests/tmp/
 
 # Local task tracking
 tasks/

--- a/tests/cas-locking.test.ts
+++ b/tests/cas-locking.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, afterAll } from "bun:test";
-import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "fs";
+import { rmdirSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { computeHash } from "../src/core/read";
 import { acquireLock, acquireSortedLocks, LOCK_TIMEOUT_MS, lockPathFor, LockAcquireError, pruneStaleLocks } from "../src/core/locking";
 import { routeEdit } from "../src/core/router";
+
+// #110: each describe removes its own fixture, but the shared parent dirs were
+// left behind and dirtied `git status` after every run. Sweep them at file end.
+afterAll(() => {
+  try { rmSync("tests/tmp/cas-locking", { recursive: true, force: true }); } catch { /* ignore */ }
+  try { rmdirSync("tests/tmp"); } catch { /* non-empty or already gone */ }
+});
 
 function makeTestDir(name: string): { dir: string; cleanup: () => void } {
   const dir = join("tests/tmp/cas-locking", name);

--- a/tests/intent.test.ts
+++ b/tests/intent.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, afterAll } from "bun:test";
 import { parseIntent, findSymbolDefinition, findReferences, generatePlan, UnsupportedIntentError, resolveReferences } from "../src/core/intent";
 import { executePlan, executeIntent } from "../src/core/plan-executor";
 import type { VerifyResult } from "../src/core/verify";
@@ -8,6 +8,7 @@ import { simulateCrashAfterTempWrite } from "../src/core/paths";
 import { exitCodeFor } from "../src/core/exit-codes";
 
 const TMP_DIR = join(import.meta.dir, "__tmp_intent_tests__");
+const B15 = join(import.meta.dir, "__tmp_b15__");
 
 const FILE_A = join(TMP_DIR, "a.ts");
 const FILE_B = join(TMP_DIR, "b.ts");
@@ -70,6 +71,15 @@ export function helper(data: string): string {
 function cleanup() {
   try { rmSync(TMP_DIR, { recursive: true, force: true }); } catch {}
 }
+
+// #110: several describe blocks call setup() without a matching afterEach, so
+// the fixture tree outlived the run and dirtied the working copy. A file-level
+// afterAll guarantees the scratch dirs are gone no matter which block created
+// them or whether a test threw partway through.
+afterAll(() => {
+  cleanup();
+  try { rmSync(B15, { recursive: true, force: true }); } catch {}
+});
 
 // ── parseIntent ──────────────────────────────────────────────────────
 
@@ -1068,8 +1078,6 @@ describe("executePlan verification / rollback correctness", () => {
 // foo(1)"). These tests pin the syntactic behavior: exactly the genuine
 // references, decoys excluded, and unsupported languages reported as
 // `unresolved` rather than guessed.
-
-const B15 = join(import.meta.dir, "__tmp_b15__");
 
 function b15write(rel: string, content: string) {
   const abs = join(B15, rel);

--- a/tests/locking-multiprocess.test.ts
+++ b/tests/locking-multiprocess.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from "fs";
+import { rmdirSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from "fs";
 import { join, resolve, dirname } from "path";
 import { acquireLock, lockPathFor, pruneStaleLocks, LockAcquireError } from "../src/core/locking";
 
@@ -8,6 +8,13 @@ import { acquireLock, lockPathFor, pruneStaleLocks, LockAcquireError } from "../
 // when the two callers disagree about the current working directory.
 
 const LOCKING_MODULE = resolve("src/core/locking.ts");
+
+// #110: each describe removes its own fixture, but the shared parent dirs were
+// left behind and dirtied `git status` after every run. Sweep them at file end.
+afterAll(() => {
+  try { rmSync("tests/tmp/locking-mp", { recursive: true, force: true }); } catch { /* ignore */ }
+  try { rmdirSync("tests/tmp"); } catch { /* non-empty or already gone */ }
+});
 
 function makeTestDir(name: string): { dir: string; nested: string; cleanup: () => void } {
   const dir = resolve("tests/tmp/locking-mp", name);

--- a/tests/scratch-hygiene.test.ts
+++ b/tests/scratch-hygiene.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import { join, resolve } from "path";
+
+// #110: `bun test` used to leave `tests/__tmp_intent_tests__/` and `tests/tmp/`
+// behind, so every run dirtied the working copy and the next run started from
+// stale fixtures. The guard is functional: run the owning test files in a child
+// process and assert the scratch trees are gone when it exits. .gitignore
+// covers the same roots as a backstop for a run that dies before afterAll fires.
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+
+async function runTestFile(file: string): Promise<number> {
+  const proc = Bun.spawn(["bun", "test", file], {
+    cwd: REPO_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, HASHPILOT_TELEMETRY: "0" },
+  });
+  return await proc.exited;
+}
+
+describe("test scratch hygiene (#110)", () => {
+  it("intent tests leave no scratch tree under tests/", async () => {
+    await runTestFile("tests/intent.test.ts");
+    expect(existsSync(join(REPO_ROOT, "tests/__tmp_intent_tests__"))).toBe(false);
+    expect(existsSync(join(REPO_ROOT, "tests/__tmp_b15__"))).toBe(false);
+  }, 120_000);
+
+  it("locking tests leave no tests/tmp tree behind", async () => {
+    await runTestFile("tests/cas-locking.test.ts");
+    expect(existsSync(join(REPO_ROOT, "tests/tmp/cas-locking"))).toBe(false);
+    expect(existsSync(join(REPO_ROOT, "tests/tmp"))).toBe(false);
+  }, 120_000);
+
+  it("gitignore covers both scratch roots", () => {
+    const ignore = readFileSync(join(REPO_ROOT, ".gitignore"), "utf8");
+    expect(ignore).toContain("tests/__tmp_*/");
+    expect(ignore).toContain("tests/tmp/");
+  });
+});


### PR DESCRIPTION
Closes #110.

## Problem

`bun test` left scratch state in the working copy:

- `tests/__tmp_intent_tests__/` — populated with `a.ts`, `b.ts`, `app.ts`, `utils.ts`, `package.json`, `tsconfig.json`. Four `describe` blocks in `tests/intent.test.ts` register `afterEach(cleanup)`, but `parseIntent`, `generatePlan`, and `executePlan verification / rollback correctness` call `setup()` with no matching cleanup.
- `tests/tmp/cas-locking/` and `tests/tmp/locking-mp/` — each `describe` removed its own fixture directory, but nothing removed the shared parents, so the empty trees survived every run.

Consequence: `git status` was never clean after a test run, and the next run started from stale fixtures instead of a fresh tree.

## Fix

- **`tests/intent.test.ts`** — file-level `afterAll` removing both `TMP_DIR` and the `B15` fixture, so the sweep happens regardless of which block created the tree or whether a test threw partway through. `B15`'s declaration is hoisted above the hook; its paths and the literal path assertions are unchanged.
- **`tests/cas-locking.test.ts`, `tests/locking-multiprocess.test.ts`** — file-level `afterAll` that removes the file's subtree and `rmdir`s `tests/tmp` when it is empty (ignored when another file still owns it).
- **`.gitignore`** — `tests/tmp/` added next to the existing `tests/__tmp_*/`, as a backstop for a run killed before `afterAll` fires.

## Verification

`tests/scratch-hygiene.test.ts` (3 tests) is functional rather than static: it runs `tests/intent.test.ts` and `tests/cas-locking.test.ts` in child processes and asserts the scratch trees are absent when the child exits, plus asserts the gitignore backstop.

Falsification — with the three test files and `.gitignore` stashed, all **3 fail**; with the fixes, all 3 pass.

Full suite: **856 pass / 0 fail**, and `git status --porcelain` is empty afterward (previously it was not). `bun run lint:docs` passes.

## Eval suite

No bench case. The bench harness models edit correctness (`correct` / `silent-corruption` / `false-refusal`); this defect is test-harness hygiene with no HashPilot edit path involved, so there is nothing for a case to assert. The regression is pinned by the functional guard above instead.

No `src/` change, so no README/ARCHITECTURE update is required by the Docs Verify gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
