### PR TITLE
fix(tests): make smoke.sh envelope-aware and gate it in CI (#130)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,18 @@ jobs:
       - name: Run doctor smoke test
         run: bun run src/cli.ts doctor
 
+      # The AST regression suite runs through the *installed* binary, so it is
+      # the only check that exercises the shipped CLI end to end. It was red on
+      # main for as long as it went ungated (#130) — keep it in CI.
+      - name: Put hashpilot on PATH
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          printf '#!/usr/bin/env bash\nexec bun run "%s/src/cli.ts" "$@"\n' "$GITHUB_WORKSPACE" > "$HOME/.local/bin/hashpilot"
+          chmod +x "$HOME/.local/bin/hashpilot"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Run AST smoke test
+        run: bash tests/smoke.sh
+
       # Fails only when a case that passes in bench/results/latest.json stops
       # passing. Cases that are already red (known-issue guards) stay red.
       - name: Run benchmark regression check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ HashPilot is a Bun/TypeScript CLI. The entry point is `src/cli.ts` (the publishe
 - `bun run build` — bundle `src/cli.ts` to `dist/` for distribution.
 - `bun run install-cli` — symlink the CLI into `~/.agentic-tools/bin/` and add that directory to `PATH` via a marked block in your shell rc.
 - `bash scripts/doctor.sh` — check the local installation environment.
-- `bash tests/smoke.sh` — run end-to-end checks against the installed CLI.
+- `bash tests/smoke.sh` — run end-to-end checks against the installed CLI (26 cases, envelope-aware, gated in CI).
 - `bun run lint:docs` — verify the CLI quickref matches `--help` and `ROADMAP.md` is consistent.
 - `bun run gen:cli-quickref` — regenerate the quickref command reference after a CLI change.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ bun test tests/hash-edit.test.ts     # Single test file
 bun test -t "test name pattern"      # Filter by test name
 ```
 
-The smoke test (`bash tests/smoke.sh`) requires the CLI to be installed (`hashpilot` on PATH); run it whenever CLI behavior changes. CI uses semantic-release for automated versioning and publishing, so commits must use Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`) — the prefix drives the release.
+The smoke test (`bash tests/smoke.sh`) requires the CLI to be installed (`hashpilot` on PATH); run it whenever CLI behavior changes. It exercises the shipped binary end to end and asserts on the `data` payload of the apiVersion 1 envelope, so it catches envelope-shape breakage that unit tests miss; CI runs it too, so it must stay green. CI uses semantic-release for automated versioning and publishing, so commits must use Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`) — the prefix drives the release.
 
 Style: strict TypeScript, ES modules, two-space indent; camelCase values, PascalCase types, kebab-case CLI subcommands.
 

--- a/tests/smoke-contract-130.test.ts
+++ b/tests/smoke-contract-130.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const SMOKE = readFileSync(join(REPO_ROOT, "tests", "smoke.sh"), "utf8");
+const CI = readFileSync(join(REPO_ROOT, ".github", "workflows", "ci.yml"), "utf8");
+
+// #130: smoke.sh parsed the pre-envelope output shape and had been failing
+// 23 of 26 cases on main, unnoticed, because nothing ran it. These assertions
+// keep both halves of that fix — envelope-aware parsing and a CI gate — from
+// regressing quietly again.
+describe("#130 — the AST smoke test is envelope-aware and gated", () => {
+  it("unwraps the envelope in one place instead of at each call site", () => {
+    expect(SMOKE).toContain("hp_check()");
+    expect(SMOKE).toContain('e.get(\'apiVersion\') == \'1\'');
+    // A bare `json.load(sys.stdin)['<payload field>']` reads the envelope, not
+    // the payload. The only permitted direct loads are inside the helpers.
+    const naive = SMOKE.match(/json\.load\(sys\.stdin\)\s*\[\s*'(?!data)/g) ?? [];
+    expect(naive).toEqual([]);
+  });
+
+  it("asserts refusals fail rather than merely returning a payload", () => {
+    expect(SMOKE).toContain("hp_check_refusal()");
+    expect(SMOKE).toContain("refusal reported ok:true");
+  });
+
+  it("asks for --include-source when it inspects the post-edit file", () => {
+    for (const line of SMOKE.split("\n")) {
+      if (!line.includes("newSource")) continue;
+      if (line.trimStart().startsWith("#")) continue;
+      expect(line).toContain("--include-source");
+    }
+  });
+
+  it("exits non-zero on failure without wrapping past 255", () => {
+    expect(SMOKE).toContain('[ "$FAIL" -eq 0 ] || exit 1');
+    expect(SMOKE).not.toContain("exit $FAIL");
+  });
+
+  it("runs in CI", () => {
+    expect(CI).toContain("bash tests/smoke.sh");
+  });
+});

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1,14 +1,61 @@
 #!/usr/bin/env bash
 # HashPilot Core — AST Regression Smoke Test
-# Verifies that AST operations work correctly across all supported languages.
-# Usage: ./tests/smoke.sh
+# Verifies that AST operations work correctly across all supported languages,
+# through the *installed* binary rather than the test runner's imports.
+# Usage: ./tests/smoke.sh   (requires `hashpilot` on PATH)
 
 TMP=$(mktemp -d)
 PASS=0
 FAIL=0
 
-ok()   { echo "  PASS: $1"; ((PASS++)); }
-fail() { echo "  FAIL: $1"; ((FAIL++)); }
+ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Every command emits the apiVersion 1 envelope
+# (`{apiVersion, ok, command, data, error, warnings}`), so the payload these
+# assertions care about lives under `data`. `hp` runs a command and prints just
+# that payload; `hp_check` runs a Python expression against it. Keeping the
+# unwrapping in one place is what let this suite silently rot when the envelope
+# landed (#130) — every call site had its own inline `json.load(sys.stdin)`.
+hp() {
+  hashpilot "$@" | python3 -c 'import json,sys; json.dump(json.load(sys.stdin)["data"], sys.stdout)'
+}
+
+# Assert that `hashpilot <args...>` succeeded and its payload satisfies EXPR,
+# where EXPR is a Python expression over `d` (the payload).
+# Usage: hp_check "<expr>" <hashpilot args...>
+hp_check() {
+  local expr="$1"; shift
+  local out status
+  out=$(hashpilot "$@")
+  status=$?
+  [ "$status" -eq 0 ] || return 1
+  echo "$out" | python3 -c "
+import json, sys
+e = json.load(sys.stdin)
+assert e.get('apiVersion') == '1', 'missing envelope'
+assert e.get('ok') is True, e.get('error')
+d = e['data']
+assert ($expr), 'payload assertion failed: ' + json.dumps(d)[:400]
+"
+}
+
+# Assert that `hashpilot <args...>` *failed* cleanly: non-zero exit, ok:false,
+# and a populated error. A refusal that reports success is the failure mode this
+# guards against.
+hp_check_refusal() {
+  local out status
+  out=$(hashpilot "$@")
+  status=$?
+  [ "$status" -ne 0 ] || return 1
+  echo "$out" | python3 -c "
+import json, sys
+e = json.load(sys.stdin)
+assert e.get('ok') is False, 'refusal reported ok:true'
+assert e.get('error'), 'refusal carried no error'
+assert e['data'].get('success') is False, 'refusal payload reported success'
+"
+}
 
 echo "=== HashPilot Core AST Smoke Test ==="
 echo ""
@@ -28,7 +75,7 @@ for pair in \
   "file.rb:null"; do
   file="${pair%%:*}"
   expected="${pair##*:}"
-  result=$(hashpilot route "$file" "rename-symbol" | python3 -c "import json,sys; print(json.load(sys.stdin).get('language') or 'null')")
+  result=$(hp route "$file" "rename-symbol" | python3 -c "import json,sys; print(json.load(sys.stdin).get('language') or 'null')")
   if [ "$result" = "$expected" ]; then ok "$file -> $expected"; else fail "$file -> $result (expected $expected)"; fi
 done
 
@@ -36,85 +83,75 @@ done
 echo ""
 echo "--- Capabilities ---"
 
-LANGS=$(hashpilot ast capabilities | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
-if [ "$LANGS" = "6" ]; then ok "ast capabilities reports 6 languages"; else fail "ast capabilities reports $LANGS languages (expected 6)"; fi
+if hp_check "len(d) == 6" ast capabilities; then
+  ok "ast capabilities reports 6 languages"
+else fail "ast capabilities does not report 6 languages"; fi
 
 # ── 3. find-symbols per language ───────────────────────────────────────
 echo ""
 echo "--- find-symbols ---"
 
-# TypeScript
+FOUND_GREET="any(s['name'] == 'greet' for s in d['symbols'])"
+
 echo 'function greet() {}' > "$TMP/test.ts"
-if hashpilot ast find-symbols "$TMP/test.ts" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d), 'greet not found'"; then
-  ok "TypeScript find-symbols"
-else fail "TypeScript find-symbols"; fi
+if hp_check "$FOUND_GREET" ast find-symbols "$TMP/test.ts"; then ok "TypeScript find-symbols"; else fail "TypeScript find-symbols"; fi
 
-# JavaScript
 echo 'function greet() {}' > "$TMP/test.js"
-if hashpilot ast find-symbols "$TMP/test.js" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
-  ok "JavaScript find-symbols"
-else fail "JavaScript find-symbols"; fi
+if hp_check "$FOUND_GREET" ast find-symbols "$TMP/test.js"; then ok "JavaScript find-symbols"; else fail "JavaScript find-symbols"; fi
 
-# Python
-echo -e 'def greet():\n    pass' > "$TMP/test.py"
-if hashpilot ast find-symbols "$TMP/test.py" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
-  ok "Python find-symbols"
-else fail "Python find-symbols"; fi
+printf 'def greet():\n    pass\n' > "$TMP/test.py"
+if hp_check "$FOUND_GREET" ast find-symbols "$TMP/test.py"; then ok "Python find-symbols"; else fail "Python find-symbols"; fi
 
-# Go
-echo -e 'package main\nfunc greet() {}' > "$TMP/test.go"
-if hashpilot ast find-symbols "$TMP/test.go" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
-  ok "Go find-symbols"
-else fail "Go find-symbols"; fi
+printf 'package main\n\nfunc greet() {}\n' > "$TMP/test.go"
+if hp_check "$FOUND_GREET" ast find-symbols "$TMP/test.go"; then ok "Go find-symbols"; else fail "Go find-symbols"; fi
 
-# Rust
-echo -e 'fn greet() {}' > "$TMP/test.rs"
-if hashpilot ast find-symbols "$TMP/test.rs" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(s['name']=='greet' for s in d)"; then
-  ok "Rust find-symbols"
-else fail "Rust find-symbols"; fi
+printf 'fn greet() {}\n' > "$TMP/test.rs"
+if hp_check "$FOUND_GREET" ast find-symbols "$TMP/test.rs"; then ok "Rust find-symbols"; else fail "Rust find-symbols"; fi
 
 # ── 4. rename-symbol per language ──────────────────────────────────────
 echo ""
 echo "--- rename-symbol ---"
 
 echo 'function greet() { return greet(); }' > "$TMP/test.js"
-if hashpilot ast rename-symbol "$TMP/test.js" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 2"; then
+if hp_check "d['success'] and d['changes'] >= 2" ast rename-symbol "$TMP/test.js" greet sayHello --dry-run; then
   ok "JavaScript rename-symbol"
 else fail "JavaScript rename-symbol"; fi
 
-echo -e 'def greet():\n    return greet()' > "$TMP/test.py"
-if hashpilot ast rename-symbol "$TMP/test.py" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 1"; then
+printf 'def greet():\n    return greet()\n' > "$TMP/test.py"
+if hp_check "d['success'] and d['changes'] >= 1" ast rename-symbol "$TMP/test.py" greet sayHello --dry-run; then
   ok "Python rename-symbol"
 else fail "Python rename-symbol"; fi
 
-echo -e 'package main\nfunc greet() string { return "hi" }' > "$TMP/test.go"
-if hashpilot ast rename-symbol "$TMP/test.go" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 1"; then
+printf 'package main\n\nfunc greet() string { return "hi" }\n' > "$TMP/test.go"
+if hp_check "d['success'] and d['changes'] >= 1" ast rename-symbol "$TMP/test.go" greet sayHello --dry-run; then
   ok "Go rename-symbol"
 else fail "Go rename-symbol"; fi
 
-echo -e 'fn greet() -> &str { "hi" }' > "$TMP/test.rs"
-if hashpilot ast rename-symbol "$TMP/test.rs" greet sayHello --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and d['changes'] >= 1"; then
+printf 'fn greet() -> &str { "hi" }\n' > "$TMP/test.rs"
+if hp_check "d['success'] and d['changes'] >= 1" ast rename-symbol "$TMP/test.rs" greet sayHello --dry-run; then
   ok "Rust rename-symbol"
 else fail "Rust rename-symbol"; fi
 
 # ── 5. Go add-import placement ─────────────────────────────────────────
+# A dry run returns a diff unless `--include-source` is passed, so the checks
+# that inspect the whole post-edit file must ask for it.
 echo ""
 echo "--- Go add-import ---"
 
-echo -e 'package main\n\nfunc main() {}' > "$TMP/go_noimport.go"
-RESULT=$(hashpilot ast add-import "$TMP/go_noimport.go" "fmt" --dry-run 2>&1)
-POS=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('newSource','').find('import'))")
-if [ "$POS" -gt 0 ]; then ok "Go add-import places after package clause (index=$POS)"; else fail "Go add-import at position $POS"; fi
+printf 'package main\n\nfunc main() {}\n' > "$TMP/go_noimport.go"
+if hp_check "d['newSource'].find('import') > 0" ast add-import "$TMP/go_noimport.go" "fmt" --dry-run --include-source; then
+  ok "Go add-import places after package clause"
+else fail "Go add-import placement"; fi
 
 # ── 6. Python from-import ──────────────────────────────────────────────
 echo ""
 echo "--- Python add-import ---"
 
-echo -e 'import os\n\ndef f(): pass' > "$TMP/test_py.py"
-if hashpilot ast add-import "$TMP/test_py.py" "from sys import argv" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and 'from sys' in d.get('newSource','')"; then
+printf 'import os\n\ndef f(): pass\n' > "$TMP/test_py.py"
+if hp_check "d['success'] and 'from sys' in d['newSource']" ast add-import "$TMP/test_py.py" "from sys import argv" --dry-run --include-source; then
   ok "Python from-import"
 else fail "Python from-import"; fi
-if hashpilot ast add-import "$TMP/test_py.py" "json" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success'] and 'import json' in d.get('newSource','')"; then
+if hp_check "d['success'] and 'import json' in d['newSource']" ast add-import "$TMP/test_py.py" "json" --dry-run --include-source; then
   ok "Python simple import"
 else fail "Python simple import"; fi
 
@@ -122,23 +159,23 @@ else fail "Python simple import"; fi
 echo ""
 echo "--- Rust remove-import ---"
 
-echo -e 'use std::collections::HashMap;\n\nfn main() {}' > "$TMP/test_rs.rs"
-if hashpilot ast remove-import "$TMP/test_rs.rs" "HashMap" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['success']"; then
+printf 'use std::collections::HashMap;\n\nfn main() {}\n' > "$TMP/test_rs.rs"
+if hp_check "d['success']" ast remove-import "$TMP/test_rs.rs" "HashMap" --dry-run; then
   ok "Rust remove-import (AST-aware)"
 else fail "Rust remove-import"; fi
-if hashpilot ast remove-import "$TMP/test_rs.rs" "NonExistent" --dry-run | python3 -c "import json,sys; d=json.load(sys.stdin); assert not d['success']"; then
-  ok "Rust remove-import no-op when not found"
+if hp_check_refusal ast remove-import "$TMP/test_rs.rs" "NonExistent" --dry-run; then
+  ok "Rust remove-import refuses cleanly when not found"
 else fail "Rust remove-import no-op"; fi
 
 # ── 8. Unsupported language routing ────────────────────────────────────
 echo ""
 echo "--- Routing ---"
 
-if hashpilot route "file.rb" "rename-symbol" | python3 -c "import json,sys; assert json.load(sys.stdin)['route'] == 'diff'"; then
+if hp_check "d['route'] == 'diff'" route "file.rb" "rename-symbol"; then
   ok "Unsupported .rb routes to diff"
 else fail "Unsupported .rb routing"; fi
 
-if hashpilot route "test.ts" "rename-symbol" | python3 -c "import json,sys; assert json.load(sys.stdin)['route'] == 'ast'"; then
+if hp_check "d['route'] == 'ast'" route "test.ts" "rename-symbol"; then
   ok "Supported .ts routes to ast"
 else fail "Supported .ts routing"; fi
 
@@ -146,4 +183,6 @@ else fail "Supported .ts routing"; fi
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 rm -rf "$TMP"
-exit $FAIL
+# Cap the exit code: a shell exit status is one byte, so a large failure count
+# could otherwise wrap to 0 and report a red run as green.
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #130.

## Problem

On a clean `main`, with the CLI on PATH:

```
$ bash tests/smoke.sh
=== Results: 3 passed, 23 failed ===
```

`tests/smoke.sh` parsed the **pre-envelope** output shape — `json.load(sys.stdin)['route']`, `.get('language')`, `len(...)` — while every command now emits `{apiVersion, ok, command, data, error, warnings}` with the payload under `data`. It had been red for as long as the envelope has existed, and nobody noticed because **nothing runs it**: CI only had a `doctor` step.

That matters more than a stale script normally would. `CLAUDE.md` and `AGENTS.md` both tell contributors to run it on every CLI change, and it is the only check that exercises the **shipped binary end to end** — the closest thing the repo has to an integration test of what users actually install.

## Change

- **One unwrapping point.** `hp`, `hp_check`, and `hp_check_refusal` assert `apiVersion`, `ok`, and the exit status, then hand the assertion the `data` payload. The old per-call-site `json.load(sys.stdin)[...]` is exactly what let this rot invisibly.
- **Fixed the assertions that drifted with the payloads:** `find-symbols` returns `data.symbols` (not a bare list), and a dry run only carries `newSource` when `--include-source` is passed — otherwise it returns a diff with `sourceOmitted: true`.
- **Refusals are now asserted as refusals.** "remove-import when not found" checks non-zero exit **and** `ok:false` **and** a populated `error` **and** `data.success:false`. The old check only confirmed a payload came back, so a refusal that wrongly reported success would have passed.
- **Exit code.** `exit $FAIL` wraps past 255, so a large enough failure count reports a red run as green. Now `[ "$FAIL" -eq 0 ] || exit 1`.
- **CI gate.** A step puts `hashpilot` on PATH and runs the suite in the `Test` job.

## Verification

- `bash tests/smoke.sh` → **26 passed, 0 failed** (was 3/23).
- `shellcheck tests/smoke.sh` → clean.
- `bun test` → **892 pass / 0 fail**.
- `bun run lint:docs` → clean.

## Tests added

`tests/smoke-contract-130.test.ts`:

- the envelope is unwrapped through the helpers, and no call site does a naive `json.load(sys.stdin)['<payload field>']`
- `hp_check_refusal` exists and asserts `ok:false`
- every non-comment line that inspects `newSource` also passes `--include-source`
- the exit path is `[ "$FAIL" -eq 0 ] || exit 1`, not `exit $FAIL`
- CI actually invokes `bash tests/smoke.sh`

## Eval suite

No bench case: the defect is in the *test harness*, not in an edit path, so there is no `correct` / `silent-corruption` / `false-refusal` outcome for the bench to measure. The smoke suite going 26/26 and being gated in CI **is** the measurement here — and it now covers the one thing the bench does not, the installed binary's end-to-end output contract.

## Docs

`CLAUDE.md` and `AGENTS.md` — note that the smoke suite asserts on the envelope's `data` payload, catches envelope-shape breakage unit tests miss, and is now gated in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
