### PR TITLE
feat(cli): add --quiet, --verbose, and --no-color output control (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,32 @@ apply only the steps it could compute.
 
 ---
 
+## Output Control
+
+Global flags, valid on every command:
+
+| Flag | Effect |
+|------|--------|
+| `--format json\|text` | JSON if piped or in CI, text on a TTY (default) |
+| `-q, --quiet` | Drop the text-mode success line. **Never** suppresses the JSON envelope |
+| `-v, --verbose` | Routing and timing diagnostics, written to **stderr** |
+| `--no-color` | Disable ANSI color (`NO_COLOR` and `TERM=dumb` are honored too) |
+
+Color is veto-only — there is no flag that forces it on. It appears only with
+`--format text` on a TTY, so **JSON output is never colorized** and a piped
+stdout stays byte-clean. `--quiet` wins over `--verbose` when both are passed.
+
+Because verbose output goes to stderr, `hashpilot --verbose ... | jq` still works:
+
+```bash
+hashpilot --verbose route-edit src/app.ts rename-symbol \
+  --old-name greet --new-name hello --dry-run | jq .data
+# stderr: [verbose] route: ast for rename-symbol on src/app.ts (Language 'typescript' supports AST operations)
+# stderr: [verbose] result: ok via ast in 3ms
+```
+
+---
+
 ## Output Envelope
 
 Every command writes the same JSON shape to stdout, so an adapter has one parse path:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -415,6 +415,23 @@ sequenceDiagram
   `3` stale/precondition (retryable), `4` verify failed, `5` I/O, `70` internal.
 - `finish(payload)` prints JSON and sets the code; batch commands take the worst.
 
+#### `src/core/output.ts` — Verbosity and Color (#47)
+- Global flags `-q, --quiet`, `-v, --verbose`, `--no-color`, resolved once in the
+  CLI's `preAction` hook via `configureOutput()` and read from anywhere after that.
+- **Color is veto-only.** There is no `--color` force flag, so an escape sequence
+  can never enter a pipe. It requires *all* of: `--format text`, a TTY stdout,
+  `NO_COLOR` unset, `TERM !== "dumb"`, and no `--no-color`. JSON output is
+  therefore never colorized — the apiVersion 1 envelope stays byte-clean.
+- `--quiet` beats `--verbose` when both are passed; the quieter ask is the safer
+  one. It drops the text-mode success line and all verbose diagnostics, but never
+  the JSON envelope: a caller who asked for JSON and got silence cannot tell
+  success from a crash.
+- `verboseLog()` writes to **stderr** only, so `--verbose` never corrupts a
+  stdout parse. `routeEdit` emits the chosen tier, the reasons behind it, and the
+  elapsed time — routing being the most opaque decision HashPilot makes.
+- Glyph colorization happens at exactly one `write()` choke point in `format.ts`,
+  so no renderer has to know whether color is on.
+
 #### `src/redact.ts` — Credential Scrubbing
 - `redactSecrets(text)`: replaces credential shapes (AWS, OpenAI, Anthropic,
   GitHub, Slack, Google, JWT, private-key blocks, auth headers, connection-string

--- a/docs/CLI-QUICKREF.md
+++ b/docs/CLI-QUICKREF.md
@@ -164,6 +164,9 @@ hashpilot [options] [command]
 | `--allow-parse-errors` | Edit a file that already has syntax errors (the post-edit parse check still applies) |
 | `--format <fmt>` | Output format: json or text (default: json if piped/CI, text if TTY) |
 | `--json` | [deprecated: use --format json] Force JSON output (default: false) |
+| `-q, --quiet` | Suppress the human-readable success line (the JSON envelope is never suppressed) |
+| `-v, --verbose` | Write routing and timing diagnostics to stderr |
+| `--no-color` | Disable ANSI color in text output (also honors NO_COLOR) |
 
 ### Command groups
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import {
   enableTelemetry,
   resolveTelemetryEnabled,
   setOutputFormat,
+  configureOutput,
   resolveFormat,
   TelemetryReadError,
 } from "./core/index";
@@ -54,6 +55,9 @@ program
   .option("--allow-parse-errors", "Edit a file that already has syntax errors (the post-edit parse check still applies)")
     .option("--format <fmt>", "Output format: json or text (default: json if piped/CI, text if TTY)")
     .option("--json", "[deprecated: use --format json] Force JSON output", false)
+  .option("-q, --quiet", "Suppress the human-readable success line (the JSON envelope is never suppressed)")
+  .option("-v, --verbose", "Write routing and timing diagnostics to stderr")
+  .option("--no-color", "Disable ANSI color in text output (also honors NO_COLOR)")
   .hook("preAction", (thisCommand, actionCommand) => {
     // Name the running subcommand so the envelope can report it. Walk up so
     // nested commands read as "telemetry show", not "show".
@@ -65,6 +69,15 @@ program
     const globals = thisCommand.opts();
     const { format, warnDeprecate } = resolveFormat(globals, { ci: process.env.CI === "true" || process.env.CI === "1" });
     setOutputFormat(format, path.join(" "));
+    // Color and verbosity resolve from the same globals, after the format is
+    // known: color is text-mode only, so JSON output can never carry escapes (#47).
+    configureOutput({
+      quiet: Boolean(globals.quiet),
+      verbose: Boolean(globals.verbose),
+      color: globals.color,
+      format,
+      isTTY: Boolean(process.stdout.isTTY),
+    });
     if (warnDeprecate) process.stderr.write("[deprecation] --json is deprecated; use --format json\n");
     const config = loadConfig();
     configureWriteBoundary({

--- a/src/core/exit-codes.ts
+++ b/src/core/exit-codes.ts
@@ -1,6 +1,7 @@
 import { ErrorCode, recordEvent, getRecordedEventCount } from "./telemetry";
 import { wrap, currentCommandName } from "./envelope";
 import { resolveFormat, renderText, OutputFormat } from "./format";
+import { isQuiet } from "./output";
 
 /**
  * Process exit codes. Agents branch on these, so the numbers are a contract —
@@ -166,6 +167,13 @@ export function finish(payload: unknown, code?: ExitCode): void {
   recordFallbackEvent(exit);
     // In text mode: success payloads get the compact renderer; errors always emit JSON.
   if (outputFormat === "text" && (payload as { success?: boolean }).success !== false) {
+      // `--quiet` drops the human-readable success line. It deliberately does not
+      // drop the JSON envelope below: that is the apiVersion 1 contract, and a
+      // caller who asked for JSON and got silence cannot tell ok from a crash (#47).
+    if (isQuiet()) {
+      process.exitCode = exit;
+      return;
+    }
       // `wrap()` produces { apiVersion, ok, command, data, ... }; `data` carries
       // the per-command payload. Render `data` when present, else the raw payload.
     const data = (payload as { data?: Record<string, unknown> }).data;

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -10,9 +10,20 @@
  * `text` mode is a human convenience layer that must never replace it.
  */
 
+import { colorizeGlyphs } from "./output";
+
 /* ── Output format type ──────────────────────────────────────────────── */
 
 export type OutputFormat = "json" | "text";
+
+/**
+ * Single stdout choke point for every renderer (#47). Status glyphs are
+ * colorized here — and only here — so no renderer has to know whether color is
+ * enabled, and so an escape sequence can never reach a JSON path.
+ */
+function write(text: string): void {
+  process.stdout.write(colorizeGlyphs(text));
+}
 
 /**
  * Resolve the output format from an explicit option, CI detection, and TTY state.
@@ -71,10 +82,17 @@ export function renderText(command: string, payload: ResultPayload): void {
   }
 }
 
-/** Generic renderer: print a single-line summary of the result. */
+/**
+ * Generic renderer: print a single-line summary of the result.
+ *
+ * `finish()` only reaches a renderer when `success !== false`, so a payload with
+ * no `success` field at all (every read-only command: find-symbols, route,
+ * capabilities) is a success. Testing `payload.success` for truthiness instead
+ * marked all of them "✗ error" (#132).
+ */
 function renderGenericDump(payload: ResultPayload): void {
   const lines: string[] = [];
-  lines.push(payload.success ? "✓ ok" : "✗ " + (String(payload.errorCode || "error")));
+  lines.push(payload.success !== false ? "✓ ok" : "✗ " + (String(payload.errorCode || "error")));
   for (const [k, v] of Object.entries(payload)) {
     if (k === "success" || k === "apiVersion" || k === "error") continue;
     if (v === null || v === undefined) continue;
@@ -90,7 +108,7 @@ function renderGenericDump(payload: ResultPayload): void {
       break;
     }
   }
-  process.stdout.write(lines.join("\n") + "\n");
+  write(lines.join("\n") + "\n");
 }
 
 /** Compact one-line summary of a value for inline display. */
@@ -121,9 +139,9 @@ export function registerRenderer(command: string, fn: (p: ResultPayload) => void
 registerRenderer("doctor", (p) => {
   const checks = (p.checks || []) as { name: string; ok: boolean; detail?: string }[];
   const overall = p.success ? "✓ all passed" : "✗ " + checks.filter((c) => !c.ok).length + " failed";
-  process.stdout.write(overall + "\n");
+  write(overall + "\n");
   for (const c of checks) {
-    process.stdout.write(`  ${c.ok ? "✓" : "✗"} ${c.name}${c.detail ? " — " + c.detail : ""}\n`);
+    write(`  ${c.ok ? "✓" : "✗"} ${c.name}${c.detail ? " — " + c.detail : ""}\n`);
   }
 });
 
@@ -142,18 +160,18 @@ registerRenderer("read-hash", (p) => printReadResult(p));
 /** Shared renderer for any "read" variant: show line count + hash. */
 function printReadResult(p: ResultPayload) {
   if (p.error) {
-    process.stdout.write("✗ " + p.error + "\n");
+    write("✗ " + p.error + "\n");
     return;
   }
   const lines = (p.lines as string[]) || (p.content ? [p.content] : []);
   const n = lines.length;
   const hash = p.hash || p.lineHash || "";
   const filePath = p.file || p.path || "";
-  process.stdout.write(
+  write(
     `${filePath ? basePath(filePath) + ": " : ""}${n} line${n === 1 ? "" : "s"}${hash ? "  " + hash.slice(0, 8) : ""}\n`
   );
   if (lines.length > 0 && lines.length <= 5) {
-    for (const l of lines) process.stdout.write("  " + l + "\n");
+    for (const l of lines) write("  " + l + "\n");
   }
 }
 
@@ -165,9 +183,9 @@ registerRenderer("structured-edit", (p) => printEditResult(p));
 registerRenderer("edit-many", (p) => {
   const results = (p.results || []) as ResultPayload[];
   const ok = results.filter((r) => r.success).length;
-  process.stdout.write(`${ok}/${results.length} edits succeeded\n`);
+  write(`${ok}/${results.length} edits succeeded\n`);
   for (const r of results.filter((r) => !r.success)) {
-    process.stdout.write("✗ " + basePath(r.file || r.path || "?") + ": " + (r.error || "failed") + "\n");
+    write("✗ " + basePath(r.file || r.path || "?") + ": " + (r.error || "failed") + "\n");
   }
 });
 
@@ -175,30 +193,30 @@ registerRenderer("edit-many", (p) => {
 function printEditResult(p: ResultPayload) {
   const f = p.file || p.path || "";
   const route = p.route || "?";
-  process.stdout.write(
+  write(
     `${p.success ? "✓" : "✗"} ${route} ${f ? basePath(f) : ""}${p.line ? ":" + p.line : ""}\n`
   );
-  if (!p.success) process.stdout.write("  " + (p.error || p.message || "failed") + "\n");
+  if (!p.success) write("  " + (p.error || p.message || "failed") + "\n");
 }
 
 // grep / grep-many — print N matches across M files
 registerRenderer("grep", (p) => {
   const r = p.results || p;
   const matches = (r?.matches || []) as unknown[];
-  process.stdout.write(`${matches.length} match${matches.length === 1 ? "" : "es"}\n`);
+  write(`${matches.length} match${matches.length === 1 ? "" : "es"}\n`);
   for (const m of (matches as any[]).slice(0, 10)) {
-    process.stdout.write(
+    write(
       "  " + basePath(m.file || m.path || "?") + ":" + (m.line || "?") + "  " + truncate(m.content, 60) + "\n"
     );
   }
-  if (matches.length > 10) process.stdout.write(`  … ${matches.length - 10} more\n`);
+  if (matches.length > 10) write(`  … ${matches.length - 10} more\n`);
 });
 registerRenderer("grep-many", (p) => {
   const r = p.results || p;
   const matches = (r?.matches || []) as unknown[];
-  process.stdout.write(`${matches.length} match${matches.length === 1 ? "" : "es"}\n`);
+  write(`${matches.length} match${matches.length === 1 ? "" : "es"}\n`);
   for (const m of (matches as any[]).slice(0, 10)) {
-    process.stdout.write(
+    write(
       "  " + basePath(m.file || m.path || "?") + ":" + (m.line || "?") + "  " + truncate(m.content, 60) + "\n"
     );
   }
@@ -207,9 +225,9 @@ registerRenderer("grep-many", (p) => {
 // symbol-lookup
 registerRenderer("symbol-lookup", (p) => {
   const results = (p.results || p.symbols || []) as ResultPayload[];
-  process.stdout.write(`${results.length} symbol${results.length === 1 ? "" : "s"}` + "\n");
+  write(`${results.length} symbol${results.length === 1 ? "" : "s"}` + "\n");
   for (const r of results.slice(0, 10)) {
-    process.stdout.write(
+    write(
       `  ${r.name || r.symbol || "?"}  ${r.kind || "?"}  ${basePath(r.file || r.path || "")}:${r.line || "?"}\n`
     );
   }
@@ -218,17 +236,17 @@ registerRenderer("symbol-lookup", (p) => {
 // intent
 registerRenderer("intent", (p) => {
   const plan = p.plan as ResultPayload | undefined;
-  if (p.success) {
-    process.stdout.write("✓ plan succeeded\n");
-    if (plan?.impactSummary) process.stdout.write("  " + plan.impactSummary + "\n");
+  if (p.success !== false) {
+    write("✓ plan succeeded\n");
+    if (plan?.impactSummary) write("  " + plan.impactSummary + "\n");
   } else {
-    process.stdout.write("✗ " + (p.errorCode || p.error || "failed") + "\n");
+    write("✗ " + (p.errorCode || p.error || "failed") + "\n");
   }
   const unresolved = plan?.unresolved;
   if (Array.isArray(unresolved) && unresolved.length > 0) {
-    process.stdout.write(`  ${unresolved.length} unresolved item(s):\n`);
+    write(`  ${unresolved.length} unresolved item(s):\n`);
     for (const u of unresolved as ResultPayload[]) {
-      process.stdout.write("    " + basePath(u.file || "") + ": " + (u.reason || "") + "\n");
+      write("    " + basePath(u.file || "") + ": " + (u.reason || "") + "\n");
     }
   }
 });
@@ -237,12 +255,12 @@ registerRenderer("intent", (p) => {
 registerRenderer("verify", (p) => {
   // "no checks ran" is its own line: printing "all checks passed" over an empty
   // check set is exactly the false green of #106.
-  if (p.overall === "skipped") process.stdout.write("⚠ no checks ran — nothing was verified\n");
-  else if (p.success) process.stdout.write("✓ all checks passed\n");
-  else process.stdout.write("✗ " + (p.errorCode || "checks failed") + "\n");
+  if (p.overall === "skipped") write("⚠ no checks ran — nothing was verified\n");
+  else if (p.success !== false) write("✓ all checks passed\n");
+  else write("✗ " + (p.errorCode || "checks failed") + "\n");
   const checks = (p.checks || p.results || []) as ResultPayload[];
   for (const c of checks.slice(0, 5)) {
-    process.stdout.write(`  ${c.overall === "pass" || c.success ? "✓" : "✗"} ${c.command || c.name || "?"}\n`);
+    write(`  ${c.overall === "pass" || c.success ? "✓" : "✗"} ${c.command || c.name || "?"}\n`);
   }
 });
 
@@ -253,15 +271,15 @@ registerRenderer("verify-changes", (p) => {
   if (p.overall === "skipped") {
     // Never "all checks passed" over an empty check set — that false green is
     // the whole of #106.
-    process.stdout.write("⚠ no checks ran — nothing was verified\n");
-    process.stdout.write("  " + String(p.message || "") + "\n");
+    write("⚠ no checks ran — nothing was verified\n");
+    write("  " + String(p.message || "") + "\n");
     return;
   }
   const mark = p.overall === "pass" ? "✓" : "✗";
-  process.stdout.write(`${mark} ${p.overall} (${ran.length} check${ran.length === 1 ? "" : "s"}: ${ran.join(", ")})\n`);
+  write(`${mark} ${p.overall} (${ran.length} check${ran.length === 1 ? "" : "s"}: ${ran.join(", ")})\n`);
   for (const name of ran) {
     const run = p[name] as ResultPayload | undefined;
-    if (run) process.stdout.write(`  ${run.passed ? "✓" : "✗"} ${name}\n`);
+    if (run) write(`  ${run.passed ? "✓" : "✗"} ${name}\n`);
   }
 });
 
@@ -269,9 +287,9 @@ registerRenderer("verify-changes", (p) => {
 registerRenderer("telemetry-show", (p) => {
   const events = (p.events || p) as ResultPayload[];
   const arr = Array.isArray(events) ? events : [events];
-  process.stdout.write(`${arr.length} event${arr.length === 1 ? "" : "s"}\n`);
+  write(`${arr.length} event${arr.length === 1 ? "" : "s"}\n`);
   for (const e of arr.slice(0, 10)) {
-    process.stdout.write(
+    write(
       "  " +
         (e.operation || "?") +
         " " +
@@ -283,26 +301,26 @@ registerRenderer("telemetry-show", (p) => {
     );
   }
 });
-registerRenderer("telemetry-export", (p) => process.stdout.write("✓ exported " + (p.count || 0) + " event(s)\n"));
-registerRenderer("telemetry-prune", (p) => process.stdout.write("✓ pruned " + (p.count || 0) + " event(s)\n"));
+registerRenderer("telemetry-export", (p) => write("✓ exported " + (p.count || 0) + " event(s)\n"));
+registerRenderer("telemetry-prune", (p) => write("✓ pruned " + (p.count || 0) + " event(s)\n"));
 
 // route-query
 registerRenderer("route", (p) => {
-  process.stdout.write((p.success ? "✓ " + (p.route || "ok") : "✗ " + (p.errorCode || "routing failed")) + "\n");
+  write((p.success !== false ? "✓ " + (p.route || "ok") : "✗ " + (p.errorCode || "routing failed")) + "\n");
 });
 
 // ast-capabilities
 registerRenderer("ast-capabilities", (p) => {
   const langs = (p.languages || []) as string[];
-  process.stdout.write(`${langs.length} language(s) supported\n`);
+  write(`${langs.length} language(s) supported\n`);
 });
 
 // health / telemetry-summary
 registerRenderer("health", (p) => {
-  process.stdout.write((p.success ? "✓ " : "✗ ") + (p.message || "") + "\n");
+  write((p.success !== false ? "✓ " : "✗ ") + (p.message || "") + "\n");
 });
 registerRenderer("telemetry-summary", (p) => {
-  process.stdout.write((p.success ? "✓ " : "✗ ") + (p.message || JSON.stringify(Object.keys(p)).slice(0, 120)) + "\n");
+  write((p.success !== false ? "✓ " : "✗ ") + (p.message || JSON.stringify(Object.keys(p)).slice(0, 120)) + "\n");
 });
 
 // ── helpers ────────────────────────────────────────────────────────────

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -136,3 +136,16 @@ export { normalizePath, pathsEqual } from "./path-normalize";
 export { decodeText, encodeText, readDecoded } from "./encoding";
 export type { FileEncoding } from "./encoding";
 export { resolveContent } from "./resolve-content";
+export {
+  configureOutput,
+  resetOutput,
+  resolveColor,
+  resolveVerbosity,
+  getVerbosity,
+  isQuiet,
+  isVerbose,
+  colorEnabled,
+  verboseLog,
+  colorizeGlyphs,
+} from "./output";
+export type { Verbosity, OutputOptions } from "./output";

--- a/src/core/output.ts
+++ b/src/core/output.ts
@@ -1,0 +1,122 @@
+/**
+ * Output control: verbosity and color (#47).
+ *
+ * Three global flags plus one environment variable decide how much the CLI
+ * prints and whether it prints in color:
+ *
+ *   --quiet / -q     suppress non-essential output; errors still print
+ *   --verbose / -v   diagnostic detail on **stderr** (never stdout)
+ *   --no-color       disable ANSI color; `NO_COLOR` (any non-empty value) does
+ *                    the same, as does a non-TTY stdout
+ *
+ * Two rules are load-bearing rather than cosmetic:
+ *
+ * 1. **JSON output is never colorized.** ANSI escapes in a piped envelope
+ *    corrupt machine parsing, which makes this a correctness concern, not a
+ *    styling one. Color is gated on `format === "text"` here so no renderer has
+ *    to remember it.
+ * 2. **Verbose output goes to stderr.** Diagnostics on stdout would land inside
+ *    the JSON an agent is parsing.
+ *
+ * `--quiet` deliberately does **not** suppress the JSON envelope: that envelope
+ * is the apiVersion 1 contract, and a caller that asked for JSON and got silence
+ * cannot tell success from a crash. It suppresses text-mode success rendering
+ * and verbose diagnostics.
+ */
+import chalk, { type ChalkInstance } from "chalk";
+import type { OutputFormat } from "./format";
+
+export type Verbosity = "quiet" | "normal" | "verbose";
+
+let verbosity: Verbosity = "normal";
+let colorOn = false;
+
+export interface OutputOptions {
+  quiet?: boolean;
+  verbose?: boolean;
+  /** Commander sets this to `false` when `--no-color` is passed. */
+  color?: boolean;
+  format?: OutputFormat;
+  isTTY?: boolean;
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * Decide whether ANSI color may be emitted.
+ *
+ * Every one of these is a veto; none of them is an override. `--color` is not a
+ * flag, so there is deliberately no way to force color into a pipe.
+ */
+export function resolveColor(opts: OutputOptions = {}): boolean {
+  const env = opts.env ?? process.env;
+  if (opts.color === false) return false;
+  // NO_COLOR: any non-empty value disables color (no-color.org).
+  if ((env.NO_COLOR ?? "") !== "") return false;
+  if (env.TERM === "dumb") return false;
+  // Rule 1: the machine-readable envelope stays byte-clean.
+  if ((opts.format ?? "json") !== "text") return false;
+  const isTTY = opts.isTTY ?? process.stdout.isTTY;
+  return Boolean(isTTY);
+}
+
+/** Resolve verbosity. `--quiet` wins over `--verbose` — the quieter ask is the safer one. */
+export function resolveVerbosity(opts: OutputOptions = {}): Verbosity {
+  if (opts.quiet) return "quiet";
+  if (opts.verbose) return "verbose";
+  return "normal";
+}
+
+/** Called once by the CLI's preAction hook. */
+export function configureOutput(opts: OutputOptions = {}): void {
+  verbosity = resolveVerbosity(opts);
+  colorOn = resolveColor(opts);
+}
+
+/** Reset to defaults. Tests use this; the CLI configures once per process. */
+export function resetOutput(): void {
+  verbosity = "normal";
+  colorOn = false;
+}
+
+export function getVerbosity(): Verbosity {
+  return verbosity;
+}
+export function isQuiet(): boolean {
+  return verbosity === "quiet";
+}
+export function isVerbose(): boolean {
+  return verbosity === "verbose";
+}
+export function colorEnabled(): boolean {
+  return colorOn;
+}
+
+/**
+ * Emit a diagnostic line on stderr, only under `--verbose`.
+ *
+ * Callers pass a thunk when the message costs something to build, so the
+ * formatting work does not happen on the default path.
+ */
+export function verboseLog(message: string | (() => string)): void {
+  if (verbosity !== "verbose") return;
+  const text = typeof message === "function" ? message() : message;
+  process.stderr.write(paint(chalk.dim, "[verbose] " + text) + "\n");
+}
+
+/** Apply a chalk style, or return the string untouched when color is off. */
+export function paint(style: ChalkInstance, text: string): string {
+  return colorOn ? style(text) : text;
+}
+
+/**
+ * Colorize the status glyphs a renderer emits. Applied at the single write
+ * choke point in `format.ts` so no individual renderer has to know about color,
+ * and so nothing can leak an escape into a non-text path.
+ */
+export function colorizeGlyphs(text: string): string {
+  if (!colorOn) return text;
+  return text
+    .replace(/✓/g, chalk.green("✓"))
+    .replace(/✗/g, chalk.red("✗"))
+    .replace(/⚠/g, chalk.yellow("⚠"));
+}

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -21,6 +21,7 @@ import { addWarning } from "./envelope";
 import { acquireLock, LOCK_TIMEOUT_MS, LockAcquireError } from "./locking";
 import { readDecoded } from "./encoding";
 import { toPreview } from "./diff-engine";
+import { verboseLog } from "./output";
 
 export type EditRoute = "ast" | "hash" | "diff";
 
@@ -196,6 +197,11 @@ export async function routeEdit(params: {
   }
 
   routeReason = `${explanation.reasons.join("; ")}${fallback ? `; ${fallback}` : ""}`;
+
+  // `--verbose` explains the tier choice on stderr. Routing is the single most
+  // opaque decision HashPilot makes, and a silent AST->diff downgrade is exactly
+  // what an agent needs to see while debugging (#47).
+  verboseLog(() => `route: ${route} for ${operation} on ${filePath} (${routeReason})`);
 
   // Compare-and-swap alone cannot close the single-file race: between the hash
   // compare and `safeWrite` another writer can land, and CAS then reports success
@@ -410,6 +416,8 @@ export async function routeEdit(params: {
 
   // A dry run previews; it does not dump the file back at the caller (#98).
   const payload = dryRun ? toPreview(result, editSource, filePath, includeSource) : result;
+
+  verboseLog(() => `result: ${result.success ? "ok" : "failed"} via ${route} in ${elapsed}ms`);
 
   return { route, routeReason, fallback, result: payload, elapsed_ms: elapsed, explanation };
 }

--- a/tests/output-control-47.test.ts
+++ b/tests/output-control-47.test.ts
@@ -1,0 +1,166 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import {
+  resolveColor,
+  resolveVerbosity,
+  configureOutput,
+  resetOutput,
+  isQuiet,
+  isVerbose,
+  colorEnabled,
+} from "../src/core/index";
+
+const CLI = join(import.meta.dir, "..", "src", "cli.ts");
+// Match the ESC byte explicitly: a bare bracket pattern would also match the
+// literal text "[0m", so it could pass on output containing no escape at all.
+const ANSI = /\u001b\[[0-9;]*m/;
+
+function workspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "hp-output-47-"));
+  writeFileSync(join(dir, "a.ts"), 'export function greet(n: string) {\n  return "hi " + n;\n}\n');
+  return dir;
+}
+
+async function run(args: string[], cwd: string, env: Record<string, string> = {}) {
+  const proc = Bun.spawn(["bun", "run", CLI, ...args], {
+    cwd,
+    env: { ...process.env, NO_COLOR: "", ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { stdout, stderr, code: await proc.exited };
+}
+
+afterEach(() => resetOutput());
+
+describe("color resolution (#47)", () => {
+  test("color requires text format, a TTY, and no NO_COLOR", () => {
+    expect(resolveColor({ format: "text", isTTY: true, env: {} })).toBe(true);
+  });
+
+  test("JSON output is never colorized, even on a TTY", () => {
+    expect(resolveColor({ format: "json", isTTY: true, env: {} })).toBe(false);
+  });
+
+  test("a non-TTY stdout disables color so pipes stay clean", () => {
+    expect(resolveColor({ format: "text", isTTY: false, env: {} })).toBe(false);
+  });
+
+  test("NO_COLOR disables color", () => {
+    expect(resolveColor({ format: "text", isTTY: true, env: { NO_COLOR: "1" } })).toBe(false);
+  });
+
+  test("an empty NO_COLOR is not set, per the spec", () => {
+    expect(resolveColor({ format: "text", isTTY: true, env: { NO_COLOR: "" } })).toBe(true);
+  });
+
+  test("TERM=dumb disables color", () => {
+    expect(resolveColor({ format: "text", isTTY: true, env: { TERM: "dumb" } })).toBe(false);
+  });
+
+  test("--no-color (color === false) vetoes everything else", () => {
+    expect(resolveColor({ format: "text", isTTY: true, color: false, env: {} })).toBe(false);
+  });
+});
+
+describe("verbosity resolution (#47)", () => {
+  test("defaults to normal", () => {
+    expect(resolveVerbosity({})).toBe("normal");
+  });
+
+  test("--quiet beats --verbose — the quieter ask is the safer one", () => {
+    expect(resolveVerbosity({ quiet: true, verbose: true })).toBe("quiet");
+  });
+
+  test("configureOutput publishes the resolved state", () => {
+    configureOutput({ verbose: true, format: "text", isTTY: true, env: {} });
+    expect(isVerbose()).toBe(true);
+    expect(isQuiet()).toBe(false);
+    expect(colorEnabled()).toBe(true);
+  });
+
+  test("resetOutput returns to the default", () => {
+    configureOutput({ quiet: true });
+    resetOutput();
+    expect(isQuiet()).toBe(false);
+    expect(colorEnabled()).toBe(false);
+  });
+});
+
+describe("CLI end to end (#47)", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  test("JSON output carries no ANSI escapes under any flag combination", async () => {
+    const dir = workspace();
+    dirs.push(dir);
+    for (const flags of [[], ["--verbose"], ["--quiet"], ["--no-color"]]) {
+      const { stdout } = await run([...flags, "--format", "json", "ast", "find-symbols", "a.ts"], dir);
+      expect(ANSI.test(stdout)).toBe(false);
+      expect(JSON.parse(stdout).ok).toBe(true);
+    }
+  });
+
+  test("--quiet suppresses the text success line but never the JSON envelope", async () => {
+    const dir = workspace();
+    dirs.push(dir);
+    const text = await run(["--quiet", "--format", "text", "ast", "find-symbols", "a.ts"], dir);
+    expect(text.stdout.trim()).toBe("");
+    expect(text.code).toBe(0);
+
+    const json = await run(["--quiet", "--format", "json", "ast", "find-symbols", "a.ts"], dir);
+    expect(JSON.parse(json.stdout).ok).toBe(true);
+  });
+
+  test("--verbose diagnostics go to stderr, leaving stdout parseable", async () => {
+    const dir = workspace();
+    dirs.push(dir);
+    const { stdout, stderr } = await run(
+      [
+        "--verbose", "--format", "json", "route-edit", "a.ts", "rename-symbol",
+        "--old-name", "greet", "--new-name", "hello", "--dry-run",
+      ],
+      dir,
+    );
+    expect(stderr).toContain("[verbose]");
+    expect(stderr).toContain("route: ast");
+    expect(JSON.parse(stdout).ok).toBe(true);
+  });
+
+  test("without --verbose nothing is written to stderr", async () => {
+    const dir = workspace();
+    dirs.push(dir);
+    const { stderr } = await run(["--format", "json", "ast", "find-symbols", "a.ts"], dir);
+    expect(stderr).not.toContain("[verbose]");
+  });
+});
+
+describe("text mode success marking (#132)", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  // Read-only payloads carry no `success` field. `finish()` only reaches a
+  // renderer when success !== false, so absent must render as a success.
+  test.each([
+    ["ast find-symbols", ["ast", "find-symbols", "a.ts"]],
+    ["route", ["route", "a.ts", "rename-symbol"]],
+    ["ast capabilities", ["ast", "capabilities"]],
+  ])("%s renders as a success in text mode", async (_name, args) => {
+    const dir = workspace();
+    dirs.push(dir);
+    const { stdout, code } = await run(["--format", "text", ...(args as string[])], dir);
+    expect(code).toBe(0);
+    expect(stdout).toContain("✓");
+    expect(stdout).not.toContain("✗");
+  });
+});


### PR DESCRIPTION
Closes #47. Also closes #132.

## What

Three global flags — `-q, --quiet`, `-v, --verbose`, `--no-color` — plus a new
`src/core/output.ts` that resolves them once in the CLI's `preAction` hook.

| Flag | Effect |
|------|--------|
| `-q, --quiet` | Drop the text-mode success line. **Never** suppresses the JSON envelope |
| `-v, --verbose` | Routing and timing diagnostics, written to **stderr** |
| `--no-color` | Disable ANSI color (`NO_COLOR` and `TERM=dumb` honored too) |

The issue asked to "use `chalk` or remove it". This uses it.

## Three design decisions worth reviewing

**Color is veto-only.** There is no `--color` flag that forces color on. Color
requires *all* of: `--format text`, a TTY stdout, `NO_COLOR` unset,
`TERM !== "dumb"`, and no `--no-color`. Any one of those vetoes it. The
consequence is the property that matters: an ANSI escape can never reach a pipe
or a JSON payload, so the apiVersion 1 envelope stays byte-clean regardless of
what flags an agent passes.

**`--quiet` does not silence the JSON envelope.** It drops only the
human-readable text success line. Suppressing JSON would break the adapter
contract, and a caller who requested JSON and received silence cannot
distinguish success from a crash.

**`--verbose` goes to stderr.** So `hashpilot --verbose ... | jq` still parses.
`routeEdit` emits the chosen tier, the reasons behind it, and elapsed time:

```
$ hashpilot --verbose route-edit a.ts rename-symbol --old-name greet --new-name hello --dry-run | jq .ok
[verbose] route: ast for rename-symbol on a.ts (Language 'typescript' supports AST operations)
[verbose] result: ok via ast in 3ms
true
```

Routing is the most opaque decision HashPilot makes, and a silent AST→diff
downgrade is exactly the thing an agent needs visibility into while debugging.

Glyph colorization happens at exactly one `write()` choke point in `format.ts`,
so no renderer has to know whether color is enabled — and no renderer can leak
an escape onto a JSON path.

## Bundled fix: #132

Found while verifying text output. `hashpilot --format text ast find-symbols a.ts`
printed:

```
✗ error
  symbols: 1 item
  truncated: false
```

on a command that succeeded with exit 0. `finish()` only calls `renderText()`
when `payload.success !== false`, so reaching a renderer *is* the success
signal — but `renderGenericDump` and five registered renderers tested
`payload.success` for **truthiness**. Read-only payloads (`find-symbols`,
`route`, `ast capabilities`, `health`, `telemetry-summary`) carry no `success`
key at all, so `undefined` was falsy and every one of them rendered as a
failure. Text mode is the TTY default, so this was what a human saw.

Fixed by testing `success !== false`, matching the invariant `finish()` already
enforces. Verified present on `main` before the change (`git stash`) so this is
not a regression introduced here.

Filed #133 for the two remaining text-renderer defects found in the same sweep
(`ast capabilities` dumps `0: ...`, `read-many` prints `undefined lines`) rather
than widen this PR.

## Verification

- `bun test` — **910 pass / 0 fail** across 47 files (18 new)
- `bash tests/smoke.sh` — 26 passed / 0 failed
- `bun run lint:docs` — clean; `gen:cli-quickref` regenerated
- `hashpilot -V` still resolves to `--version`, not `--verbose` (Commander is case-sensitive)

New tests in `tests/output-control-47.test.ts`:

- color resolution across all seven veto paths, including empty `NO_COLOR`
  (which per spec means *unset*, not *disabled*)
- `--quiet` beats `--verbose`
- **JSON output contains no ANSI escapes under any flag combination** — the
  load-bearing invariant, checked against a regex anchored on the literal ESC byte
- `--quiet` empties text stdout but leaves `ok: true` JSON intact
- `--verbose` writes to stderr while stdout stays `JSON.parse`-able
- no stderr output without `--verbose`
- #132 regression: `find-symbols`, `route`, and `ast capabilities` each render
  a success glyph and no failure glyph in text mode

No bench case added. The harness (`bench/types.ts`) models a routed edit and
asserts the file bytes on disk afterwards; both changes here affect only how a
result is rendered and never touch the file, so there is no outcome for it to
classify. Same rationale applied to previous refactor-only items.

## Docs

`README.md` gains an Output Control section with the flag table and the veto
rule; `docs/ARCHITECTURE.md` gains a `src/core/output.ts` module entry stating
the two load-bearing invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
