### PR TITLE
fix(doctor): report real health, probe parsers, and exit non-zero on failure (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,35 @@ without parsing text.
 
 Batch commands return the worst code across all items.
 
+### `doctor` reuses codes 1 and 2 with its own meaning
+
+`doctor` is a health report, not an edit, so it maps its result onto the same
+numbers: `0` healthy, `1` warnings only (degraded, still usable), `2` one or
+more checks failed. The overlap with `1` (usage) and `2` (edit failed) is
+deliberate — "non-zero means do not proceed" is the property scripts actually
+branch on, and `scripts/install.sh` fails the install on `2`.
+
+Doctor's checks are scoped to how HashPilot is running (`installMode` in the
+report): `installed`, `source` (a working checkout), or `package` (npm). The
+`~/.agentic-tools` layout checks report `skip` outside an installed copy, and a
+missing agent-host integration (OpenCode, Pi, Claude) is a `skip` too — nobody
+has every host on one machine. **Only a `fail` makes an install unhealthy.**
+Every `fail` carries a `remediation` string: the exact command that fixes it.
+
+```console
+$ hashpilot --format text doctor
+HashPilot 4.4.18 — ✓ healthy (installed install)
+  pass 18  fail 0  warn 0  skip 0
+  ✓ ast-parsers: All 6 tree-sitter parsers load
+  ...
+```
+
+The `ast-parsers` check is the one that catches a class of silent failure:
+`getParser()` swallows tree-sitter load errors and the router then quietly
+downgrades AST edits to diff, so a broken native build shows up only as
+mysteriously worse edits. `doctor` probes every language and reports the real
+error, with `bun install` as the remediation.
+
 ---
 
 ## Where HashPilot Will Write

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -524,8 +524,13 @@ sequenceDiagram
 
 #### `src/doctor.ts` — Installation Health Check
 - Verifies: core files exist, CLI is on PATH, config is valid
-- Checks adapter integrations: Claude Code, OpenCode, Pi
-- Reports: installation status, missing components, version info
+- Checks adapter integrations: Claude Code, OpenCode, Pi — all `skip` when absent, since nobody runs every host
+- Probes every tree-sitter binding (`probeParsers`, `ast-edit.ts`). `getParser()` swallows load errors and the router silently downgrades AST → diff, so this is the only place a broken native build is visible before edit quality drops (#46)
+- Reports: `installMode`, `summary {pass,fail,warn,skip}`, `versions {hashpilot,bun,node}`, `parsers[]`, `configPaths`, and a `remediation` command on every failure
+- **Install-mode scoping** (`detectInstallMode`): `installed` (under `~/.agentic-tools`), `package` (a `node_modules` tree), or `source` (a working checkout). The `~/.agentic-tools` layout checks report `skip` outside an installed copy — without this, `bun run src/cli.ts doctor` in CI would fail on an install that was never meant to exist there
+- **Health**: `healthy` is `fail === 0`. A `skip` means "does not apply here", not "broken"; requiring every check to `pass` marked a good install unhealthy whenever the user had no config file (#46)
+- **Exit code**: `0` healthy · `1` warnings only · `2` failures, set through `finish()` like every other command. The old text path called `console.log` directly, so `doctor` always exited 0 and could not gate anything; `scripts/install.sh` now fails the install on `2`
+- Version comes from `package.json`, not a literal — it read `0.1.0` for the whole 4.x line
 - Single command: `hashpilot doctor`
 
 #### `src/batch-edit.ts` — Batch Editing

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -424,6 +424,23 @@ if command -v hashpilot &>/dev/null || [ -x "$TARGET_DIR/bin/hashpilot" ]; then
   detail "CLI version: ${VER}"
 fi
 
+# Final gate: doctor exits 2 on a broken install, 1 on warnings, 0 when healthy.
+# Telling the user "installed successfully" and letting them discover the
+# breakage on their first edit is the worse outcome (#46).
+if [ -x "$TARGET_DIR/bin/hashpilot" ]; then
+  DOCTOR_OUT=$("$TARGET_DIR/bin/hashpilot" --format text doctor 2>&1)
+  DOCTOR_CODE=$?
+  if [ "$DOCTOR_CODE" -ge 2 ]; then
+    err "Installation is not healthy:"
+    echo "$DOCTOR_OUT"
+    exit 1
+  elif [ "$DOCTOR_CODE" -eq 1 ]; then
+    detail "Doctor: healthy with warnings (run 'hashpilot doctor' for detail)"
+  else
+    detail "Doctor: healthy"
+  fi
+fi
+
 echo ""
 printf "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
 printf "${GREEN} HashPilot v${HASHPILOT_VERSION} installed successfully${NC}\n"

--- a/src/commands/maintenance.ts
+++ b/src/commands/maintenance.ts
@@ -15,24 +15,12 @@ export function register(program: Command): void {
     .command("doctor")
     .description("Verify HashPilot installation health")
 
-    .action((opts) => {
+    .action(() => {
+      // Both formats go through finish(): it is the only place that sets the
+      // process exit code, and the old console.log bypass is why `doctor`
+      // always exited 0 no matter how broken the install was (#46).
       const report = doctor();
-      if (getOutputFormat() === "json") {
-        finish(report);
-        return;
-      }
-      const summaryParts: string[] = [];
-      const pass = report.checks.filter((c) => c.status === "pass").length;
-      const fail = report.checks.filter((c) => c.status === "fail").length;
-      const warn = report.checks.filter((c) => c.status === "warn").length;
-      const skip = report.checks.filter((c) => c.status === "skip").length;
-      summaryParts.push(`HashPilot Doctor — ${report.healthy ? "HEALTHY" : "ISSUES FOUND"}`);
-      summaryParts.push(`  Pass: ${pass}  Fail: ${fail}  Warn: ${warn}  Skip: ${skip}`);
-      for (const check of report.checks) {
-        const icon = check.status === "pass" ? "✓" : check.status === "fail" ? "✗" : check.status === "warn" ? "!" : "·";
-        summaryParts.push(`  ${icon} ${check.name}: ${check.message}`);
-      }
-      console.log(summaryParts.join("\n"));
+      finish(report, report.exitCode as ExitCode);
     });
 
   program

--- a/src/core/ast-edit.ts
+++ b/src/core/ast-edit.ts
@@ -30,6 +30,17 @@ const EXTENSION_MAP: [string, string][] = [
   [".rs", "rust"],
 ];
 
+/** Every language with a tree-sitter binding, in `ast capabilities` order. */
+export const AST_LANGUAGES = ["typescript", "tsx", "javascript", "python", "go", "rust"] as const;
+
+/**
+ * Why a parser failed to initialize, keyed by language. `getParser` returns
+ * `null` on failure and the router then silently falls back to hash/diff, so
+ * without this the only symptom of a broken native build is mysteriously worse
+ * edits. `doctor` reads this to report the real reason (#46).
+ */
+const PARSER_ERRORS: Record<string, string> = {};
+
 function getParser(lang: string): Parser | null {
   if (SUPPORTED_LANGUAGES[lang]) return SUPPORTED_LANGUAGES[lang].parser;
   try {
@@ -59,8 +70,31 @@ function getParser(lang: string): Parser | null {
     SUPPORTED_LANGUAGES[lang] = { parser: p, extensions: [] };
     return p;
   } catch (e) {
+    PARSER_ERRORS[lang] = e instanceof Error ? e.message : String(e);
     return null;
   }
+}
+
+/** One language's tree-sitter binding status, as reported by `doctor`. */
+export interface ParserProbe {
+  lang: string;
+  loaded: boolean;
+  /** Present only when the binding failed to initialize. */
+  error?: string;
+}
+
+/**
+ * Attempt to initialize every supported language's parser and report the
+ * outcome. This is the only way to distinguish "HashPilot routed to diff
+ * because the operation is unsupported" from "HashPilot routed to diff because
+ * tree-sitter never loaded" (#46).
+ */
+export function probeParsers(): ParserProbe[] {
+  return AST_LANGUAGES.map((lang): ParserProbe => {
+    const parser = getParser(lang);
+    if (parser) return { lang, loaded: true };
+    return { lang, loaded: false, error: PARSER_ERRORS[lang] || "parser returned null" };
+  });
 }
 
 /**

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { loadConfig } from "./config";
 import { diskUsage, DISK_WARN_BYTES } from "./telemetry";
+import { probeParsers } from "./ast-edit";
+import pkg from "../../package.json" with { type: "json" };
 
 const HOME = process.env.HOME || "/root";
 const AGENTIC_TOOLS = join(HOME, ".agentic-tools");
@@ -22,30 +24,88 @@ export interface DoctorCheck {
   name: string;
   status: "pass" | "fail" | "warn" | "skip";
   message: string;
+  /** Exact command that fixes this check. Required on every `fail` (#46). */
+  remediation?: string;
 }
+
+/**
+ * How this HashPilot is being run. The `~/.agentic-tools` layout checks only
+ * mean something for an `installed` copy — reporting them as failures when a
+ * contributor runs `bun run src/cli.ts doctor` from a checkout, or when a user
+ * installed via `npm i -g`, is a false alarm that makes the exit code useless
+ * as a gate (#46).
+ */
+export type InstallMode = "installed" | "source" | "package";
 
 export interface DoctorReport {
   checks: DoctorCheck[];
+  /** True when no check failed. Warnings and skips do not make an install unhealthy. */
   healthy: boolean;
   timestamp: string;
   version: string;
+  installMode: InstallMode;
+  summary: { pass: number; fail: number; warn: number; skip: number };
+  versions: Record<string, string>;
+  parsers: { lang: string; loaded: boolean; error?: string }[];
+  configPaths: { global: string; project: string; inUse: string[] };
+  /**
+   * 0 healthy · 1 warnings only · 2 one or more failures. Doctor is meant to be
+   * a CI gate and the installer's final verification step, so the health has to
+   * reach the shell (#46).
+   */
+  exitCode: 0 | 1 | 2;
+  errorCode?: string;
+  message?: string;
+  recovery?: string;
 }
 
-const HASH_VERSION = "0.1.0";
+const HASH_VERSION: string = pkg.version;
 const CLAUDE_MARKER = "HashPilot Claude — Structured Editing Integration";
 
-function checkFile(path: string, label: string): DoctorCheck {
+function checkFile(path: string, label: string, remediation?: string): DoctorCheck {
   if (existsSync(path)) {
     return { name: label, status: "pass", message: `Found: ${path}` };
   }
-  return { name: label, status: "fail", message: `Missing: ${path}` };
+  return { name: label, status: "fail", message: `Missing: ${path}`, remediation };
 }
 
-function checkDir(path: string, label: string): DoctorCheck {
-  if (existsSync(path)) {
-    return { name: label, status: "pass", message: `Found: ${path}` };
-  }
-  return { name: label, status: "fail", message: `Missing: ${path}` };
+const checkDir = checkFile;
+
+/**
+ * A check that only applies to an installed layout. Outside one it reports
+ * `skip` with the reason, so `bun run src/cli.ts doctor` in a checkout and
+ * `hashpilot doctor` from an npm install both stay exit 0 (#46).
+ */
+function whenInstalled(mode: InstallMode, label: string, run: () => DoctorCheck): DoctorCheck {
+  if (mode === "installed") return run();
+  return {
+    name: label,
+    status: "skip",
+    message: mode === "source"
+      ? "Running from a source checkout — installed layout not expected"
+      : "Running from an npm package — ~/.agentic-tools layout not expected",
+  };
+}
+
+/**
+ * An adapter integration that is simply not installed is not a broken
+ * HashPilot. Nobody has every agent host on one machine, so a missing Pi
+ * extension used to fail an otherwise-perfect install (#46).
+ */
+function checkOptionalFile(path: string, label: string, what: string): DoctorCheck {
+  if (existsSync(path)) return { name: label, status: "pass", message: `Found: ${path}` };
+  return { name: label, status: "skip", message: `${what} not installed` };
+}
+
+/**
+ * Where this HashPilot is running from. `installed` means the script lives
+ * under `~/.agentic-tools`; `package` means a node_modules tree (npm install);
+ * anything else is a working checkout.
+ */
+export function detectInstallMode(dir: string = import.meta.dir): InstallMode {
+  if (dir.startsWith(AGENTIC_TOOLS + "/")) return "installed";
+  if (dir.includes("/node_modules/")) return "package";
+  return existsSync(CORE_DIR) ? "installed" : "source";
 }
 
 function checkWritable(path: string, label: string): DoctorCheck {
@@ -65,47 +125,84 @@ function checkWritable(path: string, label: string): DoctorCheck {
 export function doctor(): DoctorReport {
   const checks: DoctorCheck[] = [];
   const timestamp = new Date().toISOString();
+  const installMode = detectInstallMode();
+  const install = (label: string, run: () => DoctorCheck) => checks.push(whenInstalled(installMode, label, run));
 
-  // 1. Core directory
-  checks.push(checkDir(CORE_DIR, "core-directory"));
+  // 1-3. Installed layout: core files, launcher, PATH, and a live CLI probe.
+  install("core-directory", () => checkDir(CORE_DIR, "core-directory", "Reinstall: curl -fsSL https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/install.sh | bash"));
+  install("core-cli.ts", () => checkFile(join(CORE_DIR, "src", "cli.ts"), "core-cli.ts", "Reinstall HashPilot"));
+  install("core-package.json", () => checkFile(join(CORE_DIR, "package.json"), "core-package.json", "Reinstall HashPilot"));
+  install("cli-launcher", () => checkFile(CLI_LAUNCHER, "cli-launcher", "Run `bun run install-cli`"));
+  install("bin-on-path", checkPathEntry);
+  install("cli-executable", checkCLIExecutable);
 
-  // 2. Core files — check a few critical files
-  checks.push(checkFile(join(CORE_DIR, "src", "cli.ts"), "core-cli.ts"));
-  checks.push(checkFile(join(CORE_DIR, "package.json"), "core-package.json"));
-
-  // 3. CLI launcher, and whether a fresh shell can actually find it
-  checks.push(checkFile(CLI_LAUNCHER, "cli-launcher"));
-  checks.push(checkPathEntry());
-
-  // 4. Check CLI works
-  checks.push(checkCLIExecutable());
-
-  // 5. Config file
+  // 4. Config
   checks.push(...checkConfig());
 
-  // 6. Claude integration
+  // 5. Agent host integrations — optional by nature.
   checks.push(checkClaudeIntegration());
+  checks.push(checkOptionalFile(OPENCODE_SKILL, "opencode-skill", "OpenCode"));
+  checks.push(checkOptionalFile(OPENCODE_AGENT, "opencode-agent", "OpenCode"));
+  checks.push(checkOptionalFile(PI_EXTENSION, "pi-extension", "Pi"));
+  checks.push(checkOptionalFile(PI_SKILL, "pi-skill", "Pi"));
 
-  // 7. OpenCode integration
-  checks.push(checkFile(OPENCODE_SKILL, "opencode-skill"));
-  checks.push(checkFile(OPENCODE_AGENT, "opencode-agent"));
-
-  // 8. Pi integration
-  checks.push(checkFile(PI_EXTENSION, "pi-extension"));
-  checks.push(checkFile(PI_SKILL, "pi-skill"));
-
-  // 9. Telemetry directory writable
+  // 6. Telemetry store
   checks.push(checkWritable(LOG_DIR, "telemetry-writable"));
-
-  // 10. Telemetry footprint
   checks.push(checkTelemetrySize());
+  install("manifest", () => checkFile(MANIFEST, "manifest", "Reinstall HashPilot"));
 
-  // 11. Manifest
-  checks.push(checkFile(MANIFEST, "manifest"));
+  // 7. tree-sitter bindings. `getParser` swallows load errors and the router
+  // silently downgrades AST -> diff, so this is the only place a broken native
+  // build is visible before edit quality quietly drops (#46).
+  const parsers = probeParsers();
+  const broken = parsers.filter((p) => !p.loaded);
+  checks.push(
+    broken.length === 0
+      ? { name: "ast-parsers", status: "pass", message: `All ${parsers.length} tree-sitter parsers load` }
+      : {
+          name: "ast-parsers",
+          status: "fail",
+          message: `${broken.length}/${parsers.length} parsers failed to load: ${broken.map((p) => `${p.lang} (${p.error})`).join(", ")}`,
+          remediation: "Run `bun install` to rebuild the tree-sitter native bindings",
+        },
+  );
 
-  const healthy = checks.every((c) => c.status === "pass");
+  const summary = {
+    pass: checks.filter((c) => c.status === "pass").length,
+    fail: checks.filter((c) => c.status === "fail").length,
+    warn: checks.filter((c) => c.status === "warn").length,
+    skip: checks.filter((c) => c.status === "skip").length,
+  };
+  // A skip is "does not apply here", not "broken". Requiring every check to
+  // pass marked a perfectly good install unhealthy whenever the user had no
+  // config file or no Pi (#46).
+  const healthy = summary.fail === 0;
+  const exitCode: 0 | 1 | 2 = summary.fail > 0 ? 2 : summary.warn > 0 ? 1 : 0;
 
-  return { checks, healthy, timestamp, version: HASH_VERSION };
+  const failed = checks.filter((c) => c.status === "fail");
+  return {
+    checks,
+    healthy,
+    timestamp,
+    version: HASH_VERSION,
+    installMode,
+    summary,
+    versions: { hashpilot: HASH_VERSION, bun: Bun.version, node: process.versions.node },
+    parsers,
+    configPaths: {
+      global: CONFIG_FILE,
+      project: join(process.cwd(), ".hashpilot.json"),
+      inUse: [CONFIG_FILE, join(process.cwd(), ".hashpilot.json")].filter((p) => existsSync(p)),
+    },
+    exitCode,
+    ...(failed.length > 0
+      ? {
+          errorCode: "DOCTOR_FAILED",
+          message: `${failed.length} check(s) failed: ${failed.map((c) => c.name).join(", ")}`,
+          recovery: failed.find((c) => c.remediation)?.remediation,
+        }
+      : {}),
+  };
 }
 
 /**

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -230,7 +230,7 @@ function checkTelemetrySize(): DoctorCheck {
  * fresh shell while every other check passed. Report that as its own failure
  * with the exact line to add.
  */
-function checkPathEntry(): DoctorCheck {
+export function checkPathEntry(): DoctorCheck {
   const entries = (process.env.PATH || "").split(":").filter(Boolean);
   if (entries.includes(BIN_DIR)) {
     return { name: "bin-on-path", status: "pass", message: `${BIN_DIR} is on PATH` };

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -135,13 +135,18 @@ export function registerRenderer(command: string, fn: (p: ResultPayload) => void
 
 /* ── Common renderer registrations ───────────────────────────────────── */
 
-// doctor — a checklist: print P/N checks + overall ✓/✗
+// doctor — a checklist. Reads `status`/`message`, the fields DoctorCheck
+// actually has; the original read `ok`/`detail`, so every check rendered as a
+// nameless failure (#46).
 registerRenderer("doctor", (p) => {
-  const checks = (p.checks || []) as { name: string; ok: boolean; detail?: string }[];
-  const overall = p.success ? "✓ all passed" : "✗ " + checks.filter((c) => !c.ok).length + " failed";
-  write(overall + "\n");
+  const checks = (p.checks || []) as { name: string; status: string; message: string; remediation?: string }[];
+  const s = (p.summary || {}) as Record<string, number>;
+  const glyph: Record<string, string> = { pass: "✓", fail: "✗", warn: "!", skip: "·" };
+  write(`HashPilot ${p.version} — ${p.healthy ? "✓ healthy" : "✗ issues found"} (${p.installMode} install)\n`);
+  write(`  pass ${s.pass ?? 0}  fail ${s.fail ?? 0}  warn ${s.warn ?? 0}  skip ${s.skip ?? 0}\n`);
   for (const c of checks) {
-    write(`  ${c.ok ? "✓" : "✗"} ${c.name}${c.detail ? " — " + c.detail : ""}\n`);
+    write(`  ${glyph[c.status] || "?"} ${c.name}: ${c.message}\n`);
+    if (c.remediation) write(`      fix: ${c.remediation}\n`);
   }
 });
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -24,8 +24,10 @@ export {
   firstParseError,
   setAllowParseErrors,
   getAllowParseErrors,
+  probeParsers,
+  AST_LANGUAGES,
 } from "./ast-edit";
-export type { ParseIssue } from "./ast-edit";
+export type { ParseIssue, ParserProbe } from "./ast-edit";
 export type { ASTEditResult, SymbolInfo, LanguageCapability } from "./ast-edit";
 export { verifyChanges, recordVerifyBaseline } from "./verify";
 export type { VerifyResult, VerifyOptions, ToolRun, RecordBaselineResult } from "./verify";
@@ -109,8 +111,8 @@ export {
 export type { SnapshotRecord, ChangeSetSummary, UndoResult, UndoFileResult, SnapshotRetention } from "./snapshot";
 export { createChangeSet, buildProvenanceFields, provenanceQuery, changeSetQuery, formatProvenanceHuman } from "./provenance";
 export type { ProvenanceInput, ProvenanceEntry, ChangeSetResult } from "./provenance";
-export { doctor } from "./doctor";
-export type { DoctorReport, DoctorCheck } from "./doctor";
+export { doctor, detectInstallMode } from "./doctor";
+export type { DoctorReport, DoctorCheck, InstallMode } from "./doctor";
 export { escapeRegex } from "./utils";
 export {
   assertWritable,

--- a/tests/cli-contract.test.ts
+++ b/tests/cli-contract.test.ts
@@ -196,7 +196,9 @@ describe("--format output mode (#19 B16)", () => {
    // CI=true forces JSON even without a TTY
   test("CI=true forces JSON", () => {
     const res = run(["--format", "json", "doctor"]);
-    expect(JSON.parse(res.stdout).ok).toBe(true);
+    // Assert the envelope, not `ok`: since #46 doctor's health depends on the
+    // machine it runs on, and this test is about format resolution.
+    expect(JSON.parse(res.stdout).command).toBe("doctor");
    });
 
    // --format text emits human-readable output (not valid JSON)
@@ -205,7 +207,7 @@ describe("--format output mode (#19 B16)", () => {
     // Should fail JSON parse (text output)
     expect(() => JSON.parse(res.stdout)).toThrow();
     // But should contain the doctor summary
-    expect(res.stdout).toContain("HashPilot Doctor");
+    expect(res.stdout).toContain("HashPilot");
    });
 
    // --json deprecated alias still works but warns on stderr
@@ -220,7 +222,7 @@ describe("--format output mode (#19 B16)", () => {
   test("--format text out-prioritises --json (explicit over deprecated)", () => {
     const res = run(["--format", "text", "--json", "doctor"]);
     // text mode wins (explicit --format takes priority in resolveFormat)
-    expect(res.stdout).toContain("HashPilot Doctor");
+    expect(res.stdout).toContain("HashPilot");
    });
 });
 

--- a/tests/doctor-health-46.test.ts
+++ b/tests/doctor-health-46.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { detectInstallMode } from "../src/core/index";
+
+const CLI = join(import.meta.dir, "..", "src", "cli.ts");
+const homes: string[] = [];
+
+/**
+ * `doctor` reads HOME at module load, so every case runs the real CLI in a
+ * subprocess with a synthetic HOME. That is also the only way to observe the
+ * exit code, which is the whole point of #46.
+ */
+async function doctorIn(home: string, args: string[] = []) {
+  const proc = Bun.spawn(["bun", "run", CLI, ...args, "doctor"], {
+    env: { ...process.env, HOME: home },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { stdout, stderr, code: await proc.exited };
+}
+
+function home(): string {
+  const dir = mkdtempSync(join(tmpdir(), "hp-doctor-46-"));
+  homes.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const d of homes.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("install mode detection (#46)", () => {
+  test("a node_modules path is an npm package install", () => {
+    expect(detectInstallMode("/usr/lib/node_modules/hashpilot/dist")).toBe("package");
+  });
+
+  test("a path under ~/.agentic-tools is an installed copy", () => {
+    expect(detectInstallMode(join(process.env.HOME || "/root", ".agentic-tools", "structured-editing", "src"))).toBe(
+      "installed",
+    );
+  });
+});
+
+describe("doctor exit codes (#46)", () => {
+  // The two CI steps that run doctor have no ~/.agentic-tools. If layout
+  // checks failed there instead of skipping, this whole feature would turn CI
+  // red on merge.
+  test("a source checkout with no install is healthy and exits 0", async () => {
+    const { stdout, code } = await doctorIn(home(), ["--format", "text"]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("healthy");
+    expect(stdout).toContain("(source install)");
+  });
+
+  test("a broken installed layout exits 2 and names the failures", async () => {
+    const h = home();
+    mkdirSync(join(h, ".agentic-tools", "structured-editing"), { recursive: true });
+    const { stdout, code } = await doctorIn(h, ["--format", "text"]);
+    expect(code).toBe(2);
+    expect(stdout).toContain("issues found");
+    expect(stdout).toContain("core-cli.ts");
+    // Every failure carries the command that fixes it.
+    expect(stdout).toContain("fix:");
+  });
+
+  test("warnings alone exit 1 — degraded, not broken", async () => {
+    const h = home();
+    mkdirSync(join(h, ".config", "hashpilot"), { recursive: true });
+    writeFileSync(
+      join(h, ".config", "hashpilot", "config.json"),
+      JSON.stringify({ telemetry: { enabled: "yes" } }),
+    );
+    const { stdout, code } = await doctorIn(h, ["--format", "text"]);
+    expect(code).toBe(1);
+    expect(stdout).toContain("healthy");
+  });
+});
+
+describe("doctor report contents (#46)", () => {
+  test("JSON reports the real package version, never a hardcoded literal", async () => {
+    const { stdout, code } = await doctorIn(home(), ["--format", "json"]);
+    expect(code).toBe(0);
+    const env = JSON.parse(stdout);
+    const pkg = await Bun.file(join(import.meta.dir, "..", "package.json")).json();
+    expect(env.data.version).toBe(pkg.version);
+    expect(env.data.versions.hashpilot).toBe(pkg.version);
+    expect(env.data.versions.bun).toBe(Bun.version);
+  });
+
+  test("a skip never makes an install unhealthy", async () => {
+    const { stdout } = await doctorIn(home(), ["--format", "json"]);
+    const report = JSON.parse(stdout).data;
+    expect(report.summary.skip).toBeGreaterThan(0);
+    expect(report.summary.fail).toBe(0);
+    expect(report.healthy).toBe(true);
+  });
+
+  test("tree-sitter bindings are probed per language", async () => {
+    const { stdout } = await doctorIn(home(), ["--format", "json"]);
+    const report = JSON.parse(stdout).data;
+    expect(report.parsers).toHaveLength(6);
+    expect(report.parsers.every((p: { loaded: boolean }) => p.loaded)).toBe(true);
+    expect(report.checks.find((c: { name: string }) => c.name === "ast-parsers").status).toBe("pass");
+  });
+
+  test("the failure envelope carries a DOCTOR_FAILED error with recovery", async () => {
+    const h = home();
+    mkdirSync(join(h, ".agentic-tools", "structured-editing"), { recursive: true });
+    const { stdout, code } = await doctorIn(h, ["--format", "json"]);
+    expect(code).toBe(2);
+    const env = JSON.parse(stdout);
+    expect(env.ok).toBe(false);
+    expect(env.error.code).toBe("DOCTOR_FAILED");
+    expect(env.error.recovery).toBeTruthy();
+  });
+
+  test("text output goes to stdout, leaving stderr clean", async () => {
+    const { stdout, stderr } = await doctorIn(home(), ["--format", "text"]);
+    expect(stdout).toContain("HashPilot");
+    expect(stderr.trim()).toBe("");
+  });
+});

--- a/tests/doctor-path.test.ts
+++ b/tests/doctor-path.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { join } from "path";
-import { doctor } from "../src/core/doctor";
+import { checkPathEntry } from "../src/core/doctor";
 
 const BIN_DIR = join(process.env.HOME || "/root", ".agentic-tools", "bin");
 const ORIGINAL_PATH = process.env.PATH;
 
-function pathCheck() {
-  return doctor().checks.find((c) => c.name === "bin-on-path")!;
-}
+// Call the check directly rather than digging it out of a full `doctor()`
+// report: since #46 the layout checks report `skip` outside an installed
+// layout, and CI has no ~/.agentic-tools. This test is about the PATH logic.
+const pathCheck = checkPathEntry;
 
 afterEach(() => {
   process.env.PATH = ORIGINAL_PATH;


### PR DESCRIPTION
Closes #46.

## The problem

`doctor` could not gate anything. Four independent defects, all of which made it *report* health it had not established:

1. **Always exited 0.** The text path in `src/commands/maintenance.ts` built a string and called `console.log`, bypassing `finish()` — the only place the process exit code is set. `scripts/install.sh` and both CI steps that run doctor could only ever observe success.
2. **`healthy` miscounted skips.** `checks.every(c => c.status === "pass")` meant "no config file" or "Pi not installed" marked a healthy install unhealthy. Those are skips, not failures.
3. **Hardcoded version.** `const HASH_VERSION = "0.1.0"` — wrong for the entire 4.x line, and the version is the first thing anyone reads off a health report.
4. **The registered text renderer was broken.** `src/core/format.ts` read `c.ok` / `c.detail`; `DoctorCheck` has `status` / `message`. It was dead code hidden behind the console.log bypass — reaching it rendered every check as a nameless failure. Fixing (1) would have exposed (4).

Plus the gap the issue asks for: nothing verified the tree-sitter bindings. `getParser()` catches load errors and returns `null`, and the router silently downgrades AST → diff, so a broken native build presents as mysteriously worse edits and nothing else.

## The change

| Before | After |
|---|---|
| always exit 0 | `0` healthy · `1` warnings · `2` failures, via `finish()` |
| `healthy` = every check passed | `healthy` = `fail === 0` |
| `version: "0.1.0"` | reads `package.json`; adds `versions {hashpilot, bun, node}` |
| missing OpenCode/Pi = `fail` | = `skip` |
| no parser check | `ast-parsers` probes all 6 languages and reports the real load error |
| no fix guidance | `remediation` on every failure; `DOCTOR_FAILED` + `recovery` in the envelope |
| renderer read nonexistent fields | reads `status`/`message`, prints the summary line and `fix:` hints |

New report fields: `installMode`, `summary {pass,fail,warn,skip}`, `versions`, `parsers[]`, `configPaths {global, project, inUse}`, `exitCode`.

## Why CI stays green

This is the part that would otherwise turn CI red on merge. Two workflow steps run doctor and require exit 0 in environments with **no** `~/.agentic-tools`:

- `.github/workflows/ci.yml:41` — `bun run src/cli.ts doctor` from a source checkout
- `.github/workflows/ci.yml:109` — `hashpilot doctor` from a packed npm install

`detectInstallMode()` classifies the run as `installed` (under `~/.agentic-tools`), `package` (a `node_modules` tree), or `source`, and the layout checks report `skip` outside an installed copy. Verified locally with a synthetic `HOME`:

```
$ HOME=<empty> bun run src/cli.ts --format text doctor; echo $?
HashPilot 4.4.18 — ✓ healthy (source install)
  pass 4  fail 0  warn 0  skip 13
0

$ HOME=<broken install> bun run src/cli.ts --format text doctor; echo $?
HashPilot 4.4.18 — ✗ issues found (installed install)
  pass 5  fail 6  warn 0  skip 6
  ✗ core-cli.ts: Missing: .../structured-editing/src/cli.ts
      fix: Reinstall HashPilot
2
```

The `ci.yml:91` assertion that `hashpilot doctor` exits **127** with a "requires Bun" message when Bun is absent is untouched — that path never reaches this code.

## Exit code overlap — flagging deliberately

The issue specifies 0/1/2. `ExitCode` already assigns `1 = USAGE` and `2 = EDIT_FAILED`. I followed the issue rather than deviate silently: doctor is a report, not an edit, and the property scripts actually branch on is "non-zero means do not proceed". The specific meaning is documented in the README's Exit Codes section under its own heading. Say the word if you'd rather doctor use codes outside the existing band.

One more deliberate deviation: doctor's **failure** output still renders as text in text mode, where the contract says error payloads are always JSON. Doctor's failure output *is* its product — a human running `doctor` on a broken machine needs the checklist, not an envelope. JSON mode is unaffected and carries the full `DOCTOR_FAILED` error.

## Verification

- `bun test` — **920 pass / 0 fail** (was 910; +10 new)
- `bash tests/smoke.sh` — 26 passed / 0 failed
- `bun run lint:docs` — clean; `gen:cli-quickref` produced no diff (no new flags)
- `shellcheck scripts/install.sh` — no new findings at CI severity

New file `tests/doctor-health-46.test.ts` (10 tests). Each spawns the real CLI with a synthetic `HOME` — the only way to observe an exit code, which is the entire point of the issue:

- source checkout with no install → healthy, exit 0, `(source install)`
- broken installed layout → exit 2, names the failures, prints `fix:`
- warnings only (non-boolean `telemetry.enabled`) → exit 1, still healthy
- version matches `package.json`; `versions.bun` matches `Bun.version`
- a skip never makes an install unhealthy
- all 6 parsers probed and loaded
- failure envelope carries `DOCTOR_FAILED` with `recovery`
- text → stdout, stderr clean
- `detectInstallMode` unit cases for `package` and `installed`

**No bench case.** `bench/types.ts` cases are a starting file + one routed edit + an assertion on post-edit disk bytes. Doctor performs no edit and touches no source file, so there is nothing for the harness to assert on. The eval-suite value here is negative-space coverage (does a health check correctly refuse to claim health), which the exit-code tests above cover directly.

## Also filed

#135 — `tests/locking-multiprocess.test.ts` is flaky. Reproduced on clean `main` with no local changes (3 consecutive failures after one clean pass), so it is unrelated to this PR, but it is the test that proves the multi-agent safety claim and a flaky proof is not a proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
