### PR TITLE
fix(install): stop the doctor gate from silently aborting the installer (#137)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -428,8 +428,15 @@ fi
 # Telling the user "installed successfully" and letting them discover the
 # breakage on their first edit is the worse outcome (#46).
 if [ -x "$TARGET_DIR/bin/hashpilot" ]; then
-  DOCTOR_OUT=$("$TARGET_DIR/bin/hashpilot" --format text doctor 2>&1)
-  DOCTOR_CODE=$?
+  # Two traps, both hit on the first real install:
+  #   1. `set -e` aborts the whole script when a command substitution exits
+  #      non-zero, so a plain assignment turned "doctor found something" into
+  #      a silent exit 2 with no message. Capture the code with `|| ...`.
+  #   2. The PATH entry was just written to the shell rc, which this process
+  #      never sourced, so `bin-on-path` fails at exactly the moment it cannot
+  #      yet succeed. Export the real PATH for the check.
+  DOCTOR_CODE=0
+  DOCTOR_OUT=$(PATH="$TARGET_DIR/bin:$PATH" "$TARGET_DIR/bin/hashpilot" --format text doctor 2>&1) || DOCTOR_CODE=$?
   if [ "$DOCTOR_CODE" -ge 2 ]; then
     err "Installation is not healthy:"
     echo "$DOCTOR_OUT"

--- a/tests/install-script.test.ts
+++ b/tests/install-script.test.ts
@@ -30,3 +30,29 @@ describe("install.sh — CLI launcher", () => {
     Bun.spawnSync(["rm", "-f", target, link]);
   });
 });
+
+describe("install.sh — doctor gate (#137)", () => {
+  test("captures doctor's exit code instead of letting set -e abort", () => {
+    // The gate ran as a bare `DOCTOR_OUT=$(... doctor ...)`. Under `set -e` a
+    // non-zero command substitution kills the script, so a doctor finding
+    // ended the installer at exit 2 with no message at all — after every file
+    // had already been written.
+    expect(installSh).toContain("set -eu");
+    expect(installSh).toMatch(/DOCTOR_OUT=\$\([^\n]*doctor[^\n]*\) \|\| DOCTOR_CODE=\$\?/);
+  });
+
+  test("set -e really does abort on a failing command substitution", () => {
+    // Guards the assumption the fix rests on.
+    const bare = Bun.spawnSync(["bash", "-c", "set -e; OUT=$(exit 3); echo reached"]);
+    expect(bare.stdout.toString()).not.toContain("reached");
+    const guarded = Bun.spawnSync(["bash", "-c", "set -e; CODE=0; OUT=$(exit 3) || CODE=$?; echo reached-$CODE"]);
+    expect(guarded.stdout.toString()).toContain("reached-3");
+  });
+
+  test("doctor runs with the freshly installed bin dir on PATH", () => {
+    // The PATH entry is written to the shell rc, which the installer process
+    // never sources — so `bin-on-path` would fail at exactly the moment it
+    // cannot yet succeed, reporting a healthy install as broken.
+    expect(installSh).toContain('PATH="$TARGET_DIR/bin:$PATH" "$TARGET_DIR/bin/hashpilot" --format text doctor');
+  });
+});


### PR DESCRIPTION
Fixes #137.

## What broke

Dogfooding the v4.5.1 release: `bash scripts/install.sh` wrote every file, printed `CLI version: 4.5.1`, then exited **2 with no output at all** — no banner, no error. The install itself was fine.

## Why

The #46 doctor gate had two bugs that only appear on a real install:

1. `install.sh` runs under `set -eu`. A bare `DOCTOR_OUT=$(... doctor ...)` assignment aborts the script when the substitution exits non-zero, so `DOCTOR_CODE=$?` and every branch below it were unreachable. The gate could never report anything.
2. The gate ran doctor with the installer's own PATH. The PATH entry had just been written to the user's shell rc, which this process never sourced — so `bin-on-path` failed at exactly the moment it cannot yet succeed. That is the non-zero exit that tripped (1).

## Fix

`DOCTOR_CODE=0` + `|| DOCTOR_CODE=$?`, and run doctor with `PATH="$TARGET_DIR/bin:$PATH"`.

## Verification

- Before: `bash scripts/install.sh` → `exit=2`, output ends at `CLI version`.
- After: `exit=0`, output includes `→ Doctor: healthy` and the success banner.
- `shellcheck -S warning scripts/install.sh` clean.
- 3 new tests in `tests/install-script.test.ts`: the gate must use the `|| DOCTOR_CODE=$?` form, must inject the bin dir into PATH, and a behavioral test proving `set -e` really does abort on a failing command substitution (guards the assumption the fix rests on).

No `src/` change, so no bench case and no Docs Verify surface — the behavior is installer-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
