### PR TITLE
feat(dist): publish to npm as @bigknoxy/hashpilot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,18 +72,27 @@ jobs:
         with:
           node-version: 20
 
+      # The tarball name follows the package name, so it changed with the scope
+      # (#96). Take it from npm's own output rather than globbing a name.
       - name: Pack the tarball
-        run: npm pack --pack-destination /tmp
+        run: echo "TARBALL=/tmp/$(npm pack --pack-destination /tmp | tail -1)" >> "$GITHUB_ENV"
 
       - name: Inspect tarball contents
         run: |
-          tar -tzf /tmp/hashpilot-*.tgz | sort
+          tar -tzf "$TARBALL" | sort
           # The bin target must actually be in the package, or the install is broken.
-          tar -tzf /tmp/hashpilot-*.tgz | grep -qx 'package/src/cli-node.cjs'
-          tar -tzf /tmp/hashpilot-*.tgz | grep -qx 'package/src/cli.ts'
+          tar -tzf "$TARBALL" | grep -qx 'package/src/cli-node.cjs'
+          tar -tzf "$TARBALL" | grep -qx 'package/src/cli.ts'
+          # The MCP server is the primary distribution surface; shipping without
+          # it would be a silently useless package.
+          tar -tzf "$TARBALL" | grep -qx 'package/src/mcp/server.ts'
+          # Nothing from the test or bench trees belongs in a published tarball.
+          if tar -tzf "$TARBALL" | grep -qE '^package/(tests|bench)/'; then
+            echo "FAIL: tarball ships tests/ or bench/"; exit 1
+          fi
 
       - name: Install globally without Bun present
-        run: npm i -g /tmp/hashpilot-*.tgz
+        run: npm i -g "$TARBALL"
 
       - name: Assert actionable message, not a stack trace
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  # npm provenance is signed with the workflow's OIDC identity.
+  id-token: write
 
 jobs:
   release:
@@ -41,3 +43,6 @@ jobs:
         run: bun run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Consumed by @semantic-release/npm. Without this secret the npm
+          # publish step fails and no release is cut (#96).
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,7 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": false
+        "npmPublish": true
       }
     ],
     [

--- a/README.md
+++ b/README.md
@@ -129,6 +129,34 @@ curl -fsSL https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/ins
 
 </details>
 
+### Install from npm
+
+```bash
+npm i -g @bigknoxy/hashpilot     # or: npx @bigknoxy/hashpilot doctor
+```
+
+The package name is scoped because the bare `hashpilot` on npm belongs to an
+unrelated project. The **binary is still `hashpilot`** — only the package name is
+scoped. Bun ≥ 1.2 must be on PATH; the npm package does not install it (see the
+runtime support matrix below).
+
+**What you get, and what you don't.** The npm install is the whole CLI, including
+the MCP server — every command works, `doctor` reports `installMode: "package"`,
+and the `~/.agentic-tools` layout checks are skipped rather than failed. What it
+does *not* do is write into your agents' config files: the adapter integrations
+for **Claude Code**, **OpenCode**, and **Pi** are injected by the installer, not
+by npm.
+
+| | `curl … install.sh` | `npm i -g @bigknoxy/hashpilot` |
+|---|---|---|
+| CLI + MCP server | ✅ | ✅ |
+| Auto-installs Bun | ✅ | ❌ (must already be on PATH) |
+| Claude Code / OpenCode / Pi adapters | ✅ | ❌ — run `bun run install-cli` from a checkout, or configure the MCP server directly |
+| Version pinning / `npx` | ❌ | ✅ |
+
+For MCP clients, point at the binary and skip the adapters entirely — see
+[docs/INTEGRATION-MCP.md](docs/INTEGRATION-MCP.md).
+
 ### Install from a checkout (development)
 
 ```bash
@@ -170,6 +198,11 @@ there is no Node-compatible build yet.
 | Bun ≥ 1.2 | ✅ | The only supported runtime. Enforced by `engines.bun`. |
 | Bun < 1.2 | ❌ | `npm`/`bun` warn at install time via `engines`. |
 | Node.js (any version) | ❌ | `hashpilot` exits **127** with an install message pointing at https://bun.sh. |
+
+Installing from npm on a platform with no prebuilt `tree-sitter` binding (notably
+**linux-arm64**) requires a C++20-capable toolchain to build it from source, and
+fails at install time without one. linux-x64, darwin-x64, darwin-arm64, and
+win32-x64 ship prebuilds and need no toolchain.
 
 The `hashpilot` binary is a small CommonJS shim (`src/cli-node.cjs`) that any Node can
 parse. It hands off to Bun and forwards Bun's exit status unchanged, so a Node-only machine

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hashpilot",
+  "name": "@bigknoxy/hashpilot",
   "version": "4.5.3",
   "description": "HashPilot — Global Tool-Agnostic Structured Editing Core for Coding Agents",
   "type": "module",
@@ -43,6 +43,9 @@
   ],
   "author": "bigknoxy",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/bigknoxy/HashPilot/issues"
   },

--- a/tests/packaging.test.ts
+++ b/tests/packaging.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "child_process";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * #96 — the published tarball is a contract. `npm pack` is the only thing that
+ * decides what a user gets from `npx @bigknoxy/hashpilot`, and it is driven by a
+ * hand-maintained `files` array, so a new directory is shipped or dropped
+ * silently. These tests read the same manifest npm does.
+ */
+const ROOT = join(import.meta.dir, "..");
+const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+
+describe("package manifest", () => {
+  test("publishes under the scoped name — the bare `hashpilot` is taken on npm", () => {
+    expect(pkg.name).toBe("@bigknoxy/hashpilot");
+  });
+
+  test("a scoped package needs explicit public access or the publish is rejected", () => {
+    expect(pkg.publishConfig?.access).toBe("public");
+  });
+
+  test("the binary is still called hashpilot — only the package name is scoped", () => {
+    expect(Object.keys(pkg.bin)).toEqual(["hashpilot"]);
+    expect(pkg.bin.hashpilot).toBe("./src/cli-node.cjs");
+  });
+
+  test("semantic-release is configured to publish to npm", () => {
+    const rc = JSON.parse(readFileSync(join(ROOT, ".releaserc.json"), "utf8"));
+    const npmPlugin = rc.plugins.find(
+      (p: unknown) => Array.isArray(p) && p[0] === "@semantic-release/npm",
+    ) as [string, { npmPublish: boolean }] | undefined;
+    expect(npmPlugin).toBeDefined();
+    expect(npmPlugin![1].npmPublish).toBe(true);
+  });
+
+  test("the release workflow passes NPM_TOKEN, without which the publish cannot run", () => {
+    const wf = readFileSync(join(ROOT, ".github", "workflows", "release.yml"), "utf8");
+    expect(wf).toContain("NPM_TOKEN: ${{ secrets.NPM_TOKEN }}");
+    expect(wf).toContain("id-token: write");
+  });
+});
+
+describe("npm pack contents", () => {
+  // One `npm pack --dry-run` for every assertion below; it is the slow part.
+  const packed = (() => {
+    const r = spawnSync("npm", ["pack", "--dry-run", "--json"], { cwd: ROOT, encoding: "utf8" });
+    if (r.status !== 0) throw new Error(`npm pack failed: ${r.stderr}`);
+    return (JSON.parse(r.stdout) as { files: { path: string }[] }[])[0].files.map((f) => f.path);
+  })();
+
+  test.each(["src/", "scripts/", "templates/", "docs/"])("ships %s", (dir) => {
+    expect(packed.some((f) => f.startsWith(dir))).toBe(true);
+  });
+
+  test.each(["LICENSE", "package.json", "tsconfig.json"])("ships %s", (file) => {
+    expect(packed).toContain(file);
+  });
+
+  test("ships the bin shim the `bin` field points at", () => {
+    expect(packed).toContain("src/cli-node.cjs");
+  });
+
+  test("ships the MCP server, which is the primary distribution surface", () => {
+    expect(packed).toContain("src/mcp/server.ts");
+  });
+
+  test.each(["tests/", "bench/", "node_modules/", ".github/"])("does not ship %s", (dir) => {
+    expect(packed.filter((f) => f.startsWith(dir))).toEqual([]);
+  });
+});


### PR DESCRIPTION
Refs #96

## ⚠️ Manual step required before this can publish

**`NPM_TOKEN` must be added to this repo's Actions secrets.** It is not set today (`gh secret list` shows only `GH_TOKEN`). The same account-scoped automation token already used by `bigknoxy/exa-cli` works:

```
gh secret set NPM_TOKEN --repo bigknoxy/HashPilot   # paste an npm Automation token
```

Without it the Semantic Release step fails and no release is cut. Left as `Refs #96` rather than `Closes` until the token is in place and the first publish lands.

## Problem

There was no package-manager install, so no `npx`, no version pinning, and no discovery surface. And `package.json` declared the bare name `hashpilot`, which belongs to an unrelated project on npm (`jmert`, Hedera MCP server) — it could never have published as-is.

## Approach

Modeled on `bigknoxy/exa-cli`, which already publishes under this account:

- `@bigknoxy/hashpilot` with `publishConfig.access: "public"` — a scoped package needs this or the publish is rejected outright. The **binary is still `hashpilot`**; only the package name is scoped.
- The publish goes through `@semantic-release/npm` (`npmPublish: true`), **not** a second `release: [created]` workflow like exa-cli's. HashPilot already runs semantic-release on push to `main`, so adding a separate publish workflow would give it two things cutting releases. `release.yml` gains `NPM_TOKEN` and `id-token: write` for provenance.

## Verification — by packing and installing, not by publishing

`npm pack --dry-run --json`: 73 files, ships `src/` `scripts/` `templates/` `docs/` `LICENSE` `package.json` `tsconfig.json` and the MCP server; ships no `tests/`, `bench/`, `node_modules/`, or `.github/`.

Installed the tarball into a scratch project with `HOME` pointed at an empty directory, so there was no `~/.agentic-tools` tree at all:

```
$ hashpilot doctor        # exit 0
healthy True | mode package | {'pass': 4, 'fail': 0, 'warn': 0, 'skip': 13}
parsers: typescript, tsx, javascript, python, go, rust

$ hashpilot ast add-import t.cjs '{ join } from "path"'
ok True | Added import: { join } from "path"
```

The 13 skips are the `~/.agentic-tools` layout checks, correctly skipped rather than failed (the `installMode: "package"` handling from #136 already covers this). The Bun-absent shim still exits **127** with its install message.

`tests/packaging.test.ts` (18 cases) pins the manifest and the pack contents so a new directory cannot be shipped or dropped silently. `bun test`: 979 pass / 0 fail.

## Also found

Installing from npm on a platform with no prebuilt `tree-sitter` binding — notably **linux-arm64** — fails at install time without a C++20 toolchain, and if the binding is missing at runtime every command dies with a raw `node-gyp-build` stack trace instead of `doctor` reporting the parser failure. Recorded in the README support matrix here; filed separately rather than expanded into this PR.

## Open question for #96

Whether `hashpilot-mcp` (#81) ships inside this package or as a second one. The MCP server is in this tarball, so the default answer is "inside" — worth confirming on #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)