### PR TITLE
fix(install): resolve version from SOURCE_DIR, not $0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,6 +101,7 @@ Catching up to what competitors already ship: MCP distribution, interactivity, p
 | [#40](../../issues/40) | B38 — Empty-string `newContent` unroutable; hash-tier deletion impossible | 39 | P3 | correctness |
 | [#46](../../issues/46) | B44 — `doctor` inverts stdout/stderr and always exits 0 | 39 | P3 | cli |
 | [#49](../../issues/49) | B47 — `gh-pages` publishes the entire repository | 39 | P3 | ops |
+| [#157](../../issues/157) | B58 — Install script version banner always shows `vunknown` under curl-pipe install | 38 | P3 | ops |
 | [#57](../../issues/57) | B52 — `grep-many` args are positional but read as flags; Commander errors escape the JSON envelope | 38 | P3 | cli |
 | [#39](../../issues/39) | B37 — Symbol search silently truncates at depth 10 | 37 | P3 | correctness |
 | [#45](../../issues/45) | B43 — Publish a config JSON Schema; add `config validate` and `init` | 37 | P3 | cli |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -eu
 
-# Read the version from package.json so the installer can never drift from the
-# released version. Falls back to "unknown" rather than a stale literal.
-HASHPILOT_VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$(dirname "$0")/../package.json" 2>/dev/null | head -1)"
-HASHPILOT_VERSION="${HASHPILOT_VERSION:-unknown}"
 # shellcheck disable=SC2034
 BOLD='\033[1m'
 DIM='\033[2m'
@@ -52,6 +48,13 @@ if [ -z "$SOURCE_DIR" ]; then
   SOURCE_DIR="$CLONE_DIR"
   detail "Extracted to $CLONE_DIR"
 fi
+
+# Read the version from package.json so the installer can never drift from the
+# released version. Falls back to "unknown" rather than a stale literal. Read
+# only now that SOURCE_DIR is resolved, so this works in both local-clone mode
+# and remote (curl-pipe) mode, where $0 doesn't point at the source tree.
+HASHPILOT_VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$SOURCE_DIR/package.json" 2>/dev/null | head -1)"
+HASHPILOT_VERSION="${HASHPILOT_VERSION:-unknown}"
 
 # ── Parse arguments ──────────────────────────────────────────────────────
 TARGET_DIR="${HOME}/.agentic-tools"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -60,6 +60,28 @@ assert e['data'].get('success') is False, 'refusal payload reported success'
 echo "=== HashPilot Core AST Smoke Test ==="
 echo ""
 
+# ── 0. Install script version banner (#157 / B58) ──────────────────────
+# Local-clone mode: `bash scripts/install.sh --help` resolves SOURCE_DIR to
+# the repo root and prints the version before any actual install work runs,
+# so this is a fast, non-destructive way to check that the printed version
+# matches package.json's "version" field. Remote (curl-pipe) mode reads the
+# same $HASHPILOT_VERSION variable from the same $SOURCE_DIR/package.json
+# lookup once SOURCE_DIR is set to the downloaded tarball dir — see
+# scripts/install.sh — so it isn't re-verified here with a live GitHub
+# release; this local-clone assertion plus that code-level guarantee is the
+# intended coverage per issue #157.
+echo "--- Install script version banner ---"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKG_VERSION=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$REPO_ROOT/package.json" | head -1)
+INSTALL_HELP_OUTPUT=$(bash "$REPO_ROOT/scripts/install.sh" --help 2>&1)
+
+if [ -n "$PKG_VERSION" ] && echo "$INSTALL_HELP_OUTPUT" | grep -qF "HashPilot Installer v${PKG_VERSION}"; then
+  ok "install.sh prints package.json version ($PKG_VERSION) in local-clone mode"
+else
+  fail "install.sh version banner (expected v${PKG_VERSION}, got: $(echo "$INSTALL_HELP_OUTPUT" | grep 'HashPilot Installer' || echo 'no match'))"
+fi
+
 # ── 1. Language detection ──────────────────────────────────────────────
 echo "--- Language detection ---"
 


### PR DESCRIPTION
## Bug

`scripts/install.sh` computed `HASHPILOT_VERSION` at the very top of the
script (line 6, before this fix) via `$(dirname "$0")/../package.json`,
before the script had resolved `SOURCE_DIR` (local clone vs. remote
curl-pipe download to a temp dir, at lines ~21-50).

Under the documented install command:

```
curl -fsSL https://raw.githubusercontent.com/bigknoxy/HashPilot/main/scripts/install.sh | bash
```

`$0` is `bash`, so `dirname "$0"` never resolves to a directory containing
`package.json`. The lookup silently produced nothing, the `${HASHPILOT_VERSION:-unknown}`
fallback kicked in, and the final install banner always printed:

```
HashPilot vunknown installed successfully
```

## Fix

- Moved the `HASHPILOT_VERSION` computation from the top of the script to
  right after the `SOURCE_DIR`/`REMOTE_MODE` resolution block, so it runs
  once the correct source directory is known in both modes.
- Changed the `package.json` lookup to read from `$SOURCE_DIR/package.json`
  instead of `$(dirname "$0")/../package.json`. This works correctly in:
  - **Local-clone mode**: `SOURCE_DIR` = repo root.
  - **Remote mode**: `SOURCE_DIR` = the downloaded/extracted release
    tarball directory.
- Kept the `${HASHPILOT_VERSION:-unknown}` fallback for the genuine failure
  case (package.json missing/unparsable even from the resolved `SOURCE_DIR`).
- No other script behavior changed.

## Tests

- `bash -n scripts/install.sh` and `bash -n tests/smoke.sh` — syntax OK.
- Verified locally: `bash scripts/install.sh --help` now prints
  `HashPilot Installer v4.5.3`, matching `package.json`'s version — this
  exercises the exact local-clone code path (SOURCE_DIR resolution +
  version read) without doing a real install (the `--help` branch exits
  before any prerequisite checks or file copying).
- Extended `tests/smoke.sh` with a new, non-destructive check ("Install
  script version banner") that runs `install.sh --help` in local-clone
  mode and asserts the printed version matches `package.json`. Remote
  (curl-pipe) mode isn't separately re-verified with a live GitHub
  release — per the issue's own guidance, that's covered by (a) this
  local-clone assertion and (b) code inspection confirming remote mode
  now reads the same `$HASHPILOT_VERSION` variable via the same
  `$SOURCE_DIR/package.json` lookup, just with `SOURCE_DIR` pointing at
  the extracted tarball instead of the repo root.
- `bun run lint:docs` — passes (CLI quickref + ROADMAP lint both clean).
- `bun test` — 983 pass, 0 fail.
- Added the ROADMAP.md row for B58/#157 (was tracked in the issue but
  missing from the table).

Closes #157

Addresses backlog item B58.