### PR TITLE
fix(mcp): derive self-reported version from package.json

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -2,7 +2,11 @@
 # HashPilot Doctor — Standalone installation health check
 # Can run even when CLI is not on PATH.
 
-HASHPILOT_VERSION="0.1.0"
+# Derive the version from package.json rather than hardcoding a stale literal
+# here (#156). This script is standalone (runs before the CLI is installed),
+# so it reads package.json directly instead of importing any TS module.
+HASHPILOT_VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$(dirname "$0")/../package.json" 2>/dev/null | head -1)"
+HASHPILOT_VERSION="${HASHPILOT_VERSION:-unknown}"
 # shellcheck disable=SC2034
 BOLD='\033[1m'
 DIM='\033[2m'

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -5,7 +5,13 @@
 # Derive the version from package.json rather than hardcoding a stale literal
 # here (#156). This script is standalone (runs before the CLI is installed),
 # so it reads package.json directly instead of importing any TS module.
-HASHPILOT_VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$(dirname "$0")/../package.json" 2>/dev/null | head -1)"
+# Resolve the script's real directory (not just dirname "$0") so this still
+# works if invoked via a relative path from another cwd or through a symlink —
+# the same lesson #157/#158 learned the hard way for install.sh. This script
+# is documented to run from a local checkout (`bash scripts/doctor.sh`), not
+# curl-piped, so $0 is always a real path here and this resolution is safe.
+HASHPILOT_SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd 2>/dev/null)"
+HASHPILOT_VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${HASHPILOT_SCRIPT_DIR:-.}/../package.json" 2>/dev/null | head -1)"
 HASHPILOT_VERSION="${HASHPILOT_VERSION:-unknown}"
 # shellcheck disable=SC2034
 BOLD='\033[1m'

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,6 +13,13 @@
 
 import { OPERATIONS, getOperation, inputSchemaFor } from "../core/operations";
 import { API_VERSION, setCommand, takeWarnings } from "../core/envelope";
+// Single source of truth for the version. Bun inlines this JSON import at
+// build time, so any bundle carries the real published version instead of a
+// stale env-var fallback (#156).
+import pkg from "../../package.json" with { type: "json" };
+
+/** The package version, echoed back in `initialize`'s `serverInfo`. */
+const SERVER_VERSION: string = pkg.version;
 
 /** The MCP revision we implement. Echoed back in `initialize`. */
 export const PROTOCOL_VERSION = "2024-11-05";
@@ -223,7 +230,7 @@ export async function handleRequest(req: JsonRpcRequest): Promise<JsonRpcRespons
           result: {
             protocolVersion: PROTOCOL_VERSION,
             capabilities: { tools: { listChanged: false } },
-            serverInfo: { name: "hashpilot", version: process.env.HASHPILOT_VERSION || "dev" },
+            serverInfo: { name: "hashpilot", version: SERVER_VERSION },
           },
         };
 


### PR DESCRIPTION
## Summary
- The MCP server's `initialize` response reported `serverInfo.version` from `process.env.HASHPILOT_VERSION || "dev"` — an env var nothing in the published package sets, so real installs always logged `"dev"` instead of the actual version.
- `scripts/doctor.sh` had the same class of bug: a hardcoded `HASHPILOT_VERSION="0.1.0"` literal that had gone stale relative to `package.json` (now at 4.5.3).
- Note: `src/cli.ts --version` and `src/core/doctor.ts` were already correct (they import `package.json` directly and Bun inlines it at build time), so this PR brings the remaining two version self-reports in line with that existing, correct pattern.

## Root cause
Two separate spots derived their runtime version string from something other than `package.json`:
1. `src/mcp/server.ts` — env var fallback that's never actually set.
2. `scripts/doctor.sh` — a literal string that wasn't updated on release bumps.

Fixed by importing `package.json` in `src/mcp/server.ts` (same `import pkg from "../../package.json" with { type: "json" }` pattern as `src/cli.ts`), and by having `doctor.sh` read the version out of `package.json` at run time via `sed` (mirroring the existing pattern already used in `scripts/install.sh`), since it's a standalone bash script that must run before the CLI/Bun toolchain is available.

## Test plan
- [x] `bun test` — 983 pass / 0 fail
- [x] `bun run lint:docs` — passes
- [x] `bash scripts/doctor.sh` now prints `HashPilot Doctor v4.5.3`, matching `package.json`
- [x] `bun run src/cli.ts --version` prints `4.5.3`, matching `package.json` (unchanged — was already correct)
- [x] Manually confirmed `src/mcp/server.ts`'s `initialize` response now returns the real package version instead of `"dev"`

Note: `bun run build && bun run dist/cli.js --version` fails in this sandbox with `Cannot find module '.../prebuilds/linux-arm64/tree-sitter-rust.node'` — confirmed this is a **pre-existing, unrelated** arm64 native-module bundling issue (reproduces identically on `main` before this change) tracked separately as issue #145 / B56. The shipped `bin` entry (`src/cli-node.cjs`) runs `bun run src/cli.ts` directly and never executes `dist/cli.js`, so this doesn't affect the actual published package's version self-report.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)