### PR TITLE
fix: monorepo relative-path module-system detection + bench coverage gap

### DIFF
--- a/bench/cases/ast.ts
+++ b/bench/cases/ast.ts
@@ -372,4 +372,48 @@ export const astCases: BenchCase[] = [
       "no extension, package.json, or in-file signal settles which module system Node will use, and emitting either syntax risks a file that does not load (#139)",
     tags: ["add-import", "javascript", "ambiguity", "139"],
   },
+  // ── #139/#142: the actual failure class, not just the extension shortcut ──
+  // The cases above all settle the module system via `.cjs`/`.mjs` or in-file
+  // markers. #139 itself was a *bare* `.js` file whose only signal is the
+  // nearest `package.json` — the code path these two cases exercise. Both
+  // assert with `assertLoads`: a real `node` subprocess actually loads the
+  // post-edit file, so a result that merely parses under tree-sitter (import
+  // and require share a grammar) but crashes at runtime cannot slip through
+  // on a string match alone.
+  {
+    id: "ast-add-import-bare-js-package-json-cjs",
+    description:
+      "add-import into a bare .js file with no in-file markers, governed only by a sibling package.json with no \"type\" field (#139's original failure class)",
+    file: "bare.js",
+    source: ["function util() {", "  return 1;", "}", "", "module.exports = { util };", ""].join("\n"),
+    extraFiles: {
+      // No "type" field: CommonJS per Node's own default. This is the only
+      // signal available — the file itself has neither require() nor import.
+      "package.json": '{"name":"pkg"}',
+    },
+    edit: { operation: "add-import", importSpec: '{ join } from "path"' },
+    expected: ['const { join } = require("path");', "function util() {", "  return 1;", "}", "", "module.exports = { util };", ""].join("\n"),
+    assertLoads: true,
+    tags: ["add-import", "javascript", "commonjs", "139", "142"],
+  },
+  {
+    id: "ast-add-import-bare-js-monorepo-relative-cjs",
+    description:
+      "add-import into a bare .js file addressed by a relative path from a monorepo subpackage, with the nearest package.json several directories above cwd (#161)",
+    file: "packages/pkgA/src/bare.js",
+    source: ["function util() {", "  return 1;", "}", "", "module.exports = { util };", ""].join("\n"),
+    extraFiles: {
+      // Sits at the monorepo root, above cwd — only reachable if the
+      // ancestor walk resolves the relative startDir before comparing
+      // against the filesystem root (#161).
+      "package.json": '{"name":"monorepo"}',
+    },
+    // Runner chdir's here and addresses the file as "src/bare.js" — the
+    // exact relative-path shape #161 reported.
+    cwdSubdir: "packages/pkgA",
+    edit: { operation: "add-import", importSpec: '{ join } from "path"' },
+    expected: ['const { join } = require("path");', "function util() {", "  return 1;", "}", "", "module.exports = { util };", ""].join("\n"),
+    assertLoads: true,
+    tags: ["add-import", "javascript", "commonjs", "monorepo", "161", "142"],
+  },
 ];

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,26 +1,26 @@
 {
   "harnessVersion": "1",
-  "hashpilotVersion": "4.4.11",
-  "commit": "c72fddb",
-  "generatedAt": "2026-08-19T18:48:32.143Z",
+  "hashpilotVersion": "4.5.3",
+  "commit": "ea5e0c3",
+  "generatedAt": "2026-09-03T20:24:57.677Z",
   "totals": {
-    "cases": 34,
-    "correct": 25,
+    "cases": 42,
+    "correct": 32,
     "silentCorruption": 0,
     "falseRefusal": 0,
-    "correctRefusal": 9,
+    "correctRefusal": 10,
     "harnessError": 0,
     "correctnessRate": 1,
     "silentCorruptionRate": 0,
-    "totalElapsedMs": 51
+    "totalElapsedMs": 851
   },
   "byRoute": {
     "ast": {
-      "cases": 16,
-      "correct": 12,
+      "cases": 24,
+      "correct": 19,
       "silentCorruption": 0,
       "falseRefusal": 0,
-      "correctRefusal": 4
+      "correctRefusal": 5
     },
     "hash": {
       "cases": 9,
@@ -59,6 +59,13 @@
       "falseRefusal": 0,
       "correctRefusal": 0
     },
+    "javascript": {
+      "cases": 8,
+      "correct": 7,
+      "silentCorruption": 0,
+      "falseRefusal": 0,
+      "correctRefusal": 1
+    },
     "unknown": {
       "cases": 18,
       "correct": 13,
@@ -74,7 +81,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 7,
+      "elapsed_ms": 36,
       "tags": [
         "rename",
         "typescript"
@@ -87,7 +94,7 @@
       "language": "python",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 3,
+      "elapsed_ms": 39,
       "tags": [
         "rename",
         "python"
@@ -100,7 +107,7 @@
       "language": "go",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 3,
+      "elapsed_ms": 32,
       "tags": [
         "rename",
         "go"
@@ -126,7 +133,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 2,
+      "elapsed_ms": 20,
       "tags": [
         "replace-body",
         "typescript"
@@ -139,7 +146,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 2,
+      "elapsed_ms": 21,
       "tags": [
         "insert",
         "typescript"
@@ -152,7 +159,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 2,
+      "elapsed_ms": 19,
       "tags": [
         "import",
         "typescript",
@@ -166,7 +173,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 18,
       "tags": [
         "import",
         "typescript",
@@ -180,7 +187,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 16,
       "tags": [
         "import",
         "typescript"
@@ -193,7 +200,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 2,
+      "elapsed_ms": 18,
       "tags": [
         "import",
         "typescript",
@@ -207,7 +214,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": true,
-      "elapsed_ms": 1,
+      "elapsed_ms": 2,
       "tags": [
         "parse-gate",
         "typescript"
@@ -220,7 +227,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 2,
+      "elapsed_ms": 16,
       "knownIssue": 39,
       "tags": [
         "rename",
@@ -235,7 +242,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 12,
       "tags": [
         "rename",
         "typescript",
@@ -249,7 +256,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 9,
       "tags": [
         "rename",
         "typescript",
@@ -263,7 +270,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 0,
+      "elapsed_ms": 3,
       "tags": [
         "insert-after",
         "typescript",
@@ -278,7 +285,7 @@
       "language": "typescript",
       "route": "ast",
       "unparseable": false,
-      "elapsed_ms": 0,
+      "elapsed_ms": 1,
       "tags": [
         "insert-after",
         "typescript",
@@ -288,12 +295,135 @@
       "outcome": "correct-refusal"
     },
     {
+      "id": "ast-add-import-cjs-named",
+      "description": "add-import into a .cjs file emits require, not an ESM import",
+      "language": "javascript",
+      "route": "ast",
+      "unparseable": false,
+      "elapsed_ms": 34,
+      "tags": [
+        "add-import",
+        "javascript",
+        "commonjs",
+        "139"
+      ],
+      "outcome": "correct"
+    },
+    {
+      "id": "ast-add-import-cjs-default",
+      "description": "a default-form spec becomes a whole-module require in CommonJS",
+      "language": "javascript",
+      "route": "ast",
+      "unparseable": false,
+      "elapsed_ms": 31,
+      "tags": [
+        "add-import",
+        "javascript",
+        "commonjs",
+        "139"
+      ],
+      "outcome": "correct"
+    },
+    {
+      "id": "ast-add-import-cjs-merge",
+      "description": "a second binding for an already-required module merges instead of duplicating",
+      "language": "javascript",
+      "route": "ast",
+      "unparseable": false,
+      "elapsed_ms": 23,
+      "tags": [
+        "add-import",
+        "javascript",
+        "commonjs",
+        "139"
+      ],
+      "outcome": "correct"
+    },
+    {
+      "id": "ast-add-import-mjs-stays-esm",
+      "description": "add-import into a .mjs file still emits an ESM import statement",
+      "language": "javascript",
+      "route": "ast",
+      "unparseable": false,
+      "elapsed_ms": 38,
+      "tags": [
+        "add-import",
+        "javascript",
+        "esm",
+        "139"
+      ],
+      "outcome": "correct"
+    },
+    {
+      "id": "ast-remove-import-cjs-roundtrip",
+      "description": "remove-import takes out a require binding and leaves the rest of the destructure",
+      "language": "javascript",
+      "route": "ast",
+      "unparseable": false,
+      "elapsed_ms": 31,
+      "tags": [
+        "remove-import",
+        "javascript",
+        "commonjs",
+        "139"
+      ],
+      "outcome": "correct"
+    },
+    {
+      "id": "ast-add-import-js-mixed-refused",
+      "description": "a JavaScript file mixing require and import refuses rather than guessing a module system",
+      "language": "javascript",
+      "route": "ast",
+      "unparseable": false,
+      "elapsed_ms": 1,
+      "tags": [
+        "add-import",
+        "javascript",
+        "ambiguity",
+        "139"
+      ],
+      "outcome": "correct-refusal"
+    },
+    {
+      "id": "ast-add-import-bare-js-package-json-cjs",
+      "description": "add-import into a bare .js file with no in-file markers, governed only by a sibling package.json with no \"type\" field (#139's original failure class)",
+      "language": "javascript",
+      "route": "ast",
+      "unparseable": false,
+      "elapsed_ms": 31,
+      "tags": [
+        "add-import",
+        "javascript",
+        "commonjs",
+        "139",
+        "142"
+      ],
+      "outcome": "correct"
+    },
+    {
+      "id": "ast-add-import-bare-js-monorepo-relative-cjs",
+      "description": "add-import into a bare .js file addressed by a relative path from a monorepo subpackage, with the nearest package.json several directories above cwd (#161)",
+      "language": "javascript",
+      "route": "ast",
+      "unparseable": false,
+      "elapsed_ms": 60,
+      "tags": [
+        "add-import",
+        "javascript",
+        "commonjs",
+        "monorepo",
+        "161",
+        "142"
+      ],
+      "outcome": "correct"
+    },
+    {
       "id": "hash-replace-exact",
       "description": "replace a line range whose hash still matches",
       "language": "unknown",
       "route": "hash",
       "unparseable": false,
-      "elapsed_ms": 2,
+      "elapsed_ms": 27,
       "tags": [
         "hash"
       ],
@@ -305,7 +435,7 @@
       "language": "unknown",
       "route": "hash",
       "unparseable": false,
-      "elapsed_ms": 3,
+      "elapsed_ms": 51,
       "tags": [
         "hash",
         "chaining"
@@ -318,7 +448,7 @@
       "language": "unknown",
       "route": "hash",
       "unparseable": false,
-      "elapsed_ms": 2,
+      "elapsed_ms": 43,
       "tags": [
         "hash",
         "chaining"
@@ -344,7 +474,7 @@
       "language": "unknown",
       "route": "hash",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 12,
       "tags": [
         "hash",
         "relocation"
@@ -357,7 +487,7 @@
       "language": "unknown",
       "route": "hash",
       "unparseable": false,
-      "elapsed_ms": 2,
+      "elapsed_ms": 22,
       "tags": [
         "hash",
         "multiline"
@@ -370,7 +500,7 @@
       "language": "unknown",
       "route": "hash",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 20,
       "tags": [
         "hash",
         "deletion"
@@ -383,7 +513,7 @@
       "language": "unknown",
       "route": "hash",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 21,
       "tags": [
         "hash",
         "unicode"
@@ -409,7 +539,7 @@
       "language": "unknown",
       "route": "diff",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 18,
       "tags": [
         "diff"
       ],
@@ -421,7 +551,7 @@
       "language": "unknown",
       "route": "diff",
       "unparseable": false,
-      "elapsed_ms": 0,
+      "elapsed_ms": 1,
       "tags": [
         "diff",
         "ambiguity"
@@ -434,7 +564,7 @@
       "language": "unknown",
       "route": "diff",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 0,
       "tags": [
         "diff"
       ],
@@ -446,7 +576,7 @@
       "language": "unknown",
       "route": "diff",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 15,
       "knownIssue": 32,
       "tags": [
         "diff",
@@ -460,7 +590,7 @@
       "language": "unknown",
       "route": "diff",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 13,
       "tags": [
         "diff",
         "reserved-tokens",
@@ -474,7 +604,7 @@
       "language": "unknown",
       "route": "diff",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 17,
       "tags": [
         "diff",
         "reserved-tokens",
@@ -488,7 +618,7 @@
       "language": "unknown",
       "route": "diff",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 43,
       "tags": [
         "diff",
         "multiline"
@@ -501,7 +631,7 @@
       "language": "unknown",
       "route": "diff",
       "unparseable": false,
-      "elapsed_ms": 1,
+      "elapsed_ms": 33,
       "tags": [
         "diff",
         "encoding"

--- a/bench/runner.ts
+++ b/bench/runner.ts
@@ -19,8 +19,9 @@
  */
 
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
 import { routeEdit } from "../src/core/router";
 import { computeLineRangeHashOf } from "./hash-util";
 import { detectLanguage, firstParseError } from "../src/core/ast-edit";
@@ -37,10 +38,35 @@ const ALL_CASES: BenchCase[] = [...astCases, ...hashCases, ...diffCases];
 
 const RESULTS_PATH = join(import.meta.dir, "results", "latest.json");
 
+/**
+ * Actually run a post-edit JavaScript file under Node and require it to exit
+ * cleanly. tree-sitter parses both `import` and `require` in the same
+ * grammar, so a passing parse check (and even a byte-for-byte `expected`
+ * match against a hand-typed string) can still hide a file that Node itself
+ * refuses to load — the exact shape of #139. This is a real `node <file>`
+ * subprocess, run from the file's own directory so its real ancestor
+ * `package.json` governs module resolution exactly as it would for a caller.
+ */
+function nodeLoadError(path: string): string | null {
+  const res = spawnSync(process.execPath, [path], { cwd: dirname(path), timeout: 10_000, encoding: "utf8" });
+  if (res.error) return `node could not be spawned: ${res.error.message}`;
+  if (res.status !== 0) return `node exited ${res.status}: ${(res.stderr || res.stdout || "").trim().slice(0, 500)}`;
+  return null;
+}
+
 async function runCase(c: BenchCase, workRoot: string): Promise<CaseResult> {
-  const path = join(workRoot, c.id, c.file);
+  const caseRoot = join(workRoot, c.id);
+  const path = join(caseRoot, c.file);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, c.source);
+
+  if (c.extraFiles) {
+    for (const [rel, content] of Object.entries(c.extraFiles)) {
+      const extraPath = join(caseRoot, rel);
+      mkdirSync(dirname(extraPath), { recursive: true });
+      writeFileSync(extraPath, content);
+    }
+  }
 
   const language = detectLanguage(c.file) || "unknown";
   const started = Date.now();
@@ -50,105 +76,129 @@ async function runCase(c: BenchCase, workRoot: string): Promise<CaseResult> {
     edit.oldHash = computeLineRangeHashOf(c.source, c.hashRange.start, c.hashRange.end);
   }
 
-  let routed;
-  try {
-    routed = await routeEdit({ filePath: path, ...edit });
-  } catch (err) {
-    return {
-      id: c.id,
-      description: c.description,
-      language,
-      route: "n/a",
-      outcome: "harness-error",
-      unparseable: false,
-      elapsed_ms: Date.now() - started,
-      detail: `routeEdit threw: ${err instanceof Error ? err.message : String(err)}`,
-      knownIssue: c.knownIssue,
-      tags: c.tags,
-    };
+  // Reproduces bugs that only manifest for relative-path input (#161): chdir
+  // into `cwdSubdir` and address the target relative to it instead of by its
+  // usual absolute path. Always restored, even on an early return.
+  const prevCwd = process.cwd();
+  let editFilePath = path;
+  if (c.cwdSubdir) {
+    const cwdAbs = join(caseRoot, c.cwdSubdir);
+    mkdirSync(cwdAbs, { recursive: true });
+    process.chdir(cwdAbs);
+    editFilePath = relative(cwdAbs, path);
   }
 
-  // A chained case re-edits the same region using only what the first edit
-  // returned, with no intervening read (#101).
-  if (c.chain && routed.result?.success === true) {
-    const first: any = routed.result;
+  try {
+    let routed;
     try {
-      routed = await routeEdit({
-        filePath: path,
-        operation: "replace-hash",
-        method: "hash",
-        oldHash: first.newHash,
-        range: first.newRange,
-        newContent: c.chain.newContent,
-      });
+      routed = await routeEdit({ filePath: editFilePath, ...edit });
     } catch (err) {
       return {
         id: c.id,
         description: c.description,
         language,
-        route: "hash",
+        route: "n/a",
         outcome: "harness-error",
         unparseable: false,
         elapsed_ms: Date.now() - started,
-        detail: `chained routeEdit threw: ${err instanceof Error ? err.message : String(err)}`,
+        detail: `routeEdit threw: ${err instanceof Error ? err.message : String(err)}`,
         knownIssue: c.knownIssue,
         tags: c.tags,
       };
     }
-  }
 
-  const elapsed_ms = Date.now() - started;
-  const after = existsSync(path) ? readFileSync(path, "utf8") : "";
-  const route = routed.route ?? "unknown";
-  const succeeded = routed.result?.success === true;
-  const unparseable = firstParseError(after, c.file) !== null;
+    // A chained case re-edits the same region using only what the first edit
+    // returned, with no intervening read (#101).
+    if (c.chain && routed.result?.success === true) {
+      const first: any = routed.result;
+      try {
+        routed = await routeEdit({
+          filePath: editFilePath,
+          operation: "replace-hash",
+          method: "hash",
+          oldHash: first.newHash,
+          range: first.newRange,
+          newContent: c.chain.newContent,
+        });
+      } catch (err) {
+        return {
+          id: c.id,
+          description: c.description,
+          language,
+          route: "hash",
+          outcome: "harness-error",
+          unparseable: false,
+          elapsed_ms: Date.now() - started,
+          detail: `chained routeEdit threw: ${err instanceof Error ? err.message : String(err)}`,
+          knownIssue: c.knownIssue,
+          tags: c.tags,
+        };
+      }
+    }
 
-  const base = { id: c.id, description: c.description, language, route, unparseable, elapsed_ms, knownIssue: c.knownIssue, tags: c.tags };
-  const classify = (outcome: Outcome, detail?: string): CaseResult => ({ ...base, outcome, detail });
+    const elapsed_ms = Date.now() - started;
+    const after = existsSync(path) ? readFileSync(path, "utf8") : "";
+    const route = routed.route ?? "unknown";
+    const succeeded = routed.result?.success === true;
+    const unparseable = firstParseError(after, c.file) !== null;
 
-  // Refusal cases: failure plus an untouched file is the passing outcome.
-  if (c.expectRefusal) {
-    if (!succeeded && after === c.source) return classify("correct-refusal");
-    if (succeeded) {
+    const base = { id: c.id, description: c.description, language, route, unparseable, elapsed_ms, knownIssue: c.knownIssue, tags: c.tags };
+    const classify = (outcome: Outcome, detail?: string): CaseResult => ({ ...base, outcome, detail });
+
+    // Refusal cases: failure plus an untouched file is the passing outcome.
+    if (c.expectRefusal) {
+      if (!succeeded && after === c.source) return classify("correct-refusal");
+      if (succeeded) {
+        return classify(
+          "silent-corruption",
+          `expected a refusal (${c.expectRefusal}) but the edit reported success`
+        );
+      }
+      return classify("silent-corruption", "the edit was refused but the file was modified anyway");
+    }
+
+    // Dry-run cases: the payload is the thing under test. A preview that hands
+    // back the whole file when it promised a diff is the #98 regression, and it
+    // costs the caller a context window, so it counts as a failed case.
+    if (c.expectPreview) {
+      const r: any = routed.result;
+      if (!succeeded) return classify("false-refusal", r?.message || "dry run refused with no message");
+      if (after !== c.source) return classify("silent-corruption", "a dry run wrote to disk");
+      if (c.expectPreview === "diff") {
+        if (r.newSource !== undefined) return classify("silent-corruption", "dry run returned the whole file instead of a diff");
+        if (typeof r.diff !== "string" || !r.diff.includes("@@")) return classify("false-refusal", "dry run returned no usable diff");
+        if (r.diff.length >= c.source.length) return classify("false-refusal", `preview (${r.diff.length}B) is no cheaper than the file (${c.source.length}B)`);
+      } else if (typeof r.newSource !== "string") {
+        return classify("false-refusal", "includeSource did not return the post-edit file");
+      }
+      return classify("correct");
+    }
+
+    // Edit cases.
+    if (!succeeded) {
+      if (after !== c.source) {
+        return classify("silent-corruption", "the edit reported failure but the file was modified");
+      }
+      return classify("false-refusal", routed.result?.message || "refused with no message");
+    }
+    if (after !== c.expected) {
       return classify(
         "silent-corruption",
-        `expected a refusal (${c.expectRefusal}) but the edit reported success`
+        unparseable
+          ? "reported success; the result does not parse"
+          : `reported success; result differs from expected\n--- expected\n${c.expected}\n--- actual\n${after}`
       );
     }
-    return classify("silent-corruption", "the edit was refused but the file was modified anyway");
-  }
-
-  // Dry-run cases: the payload is the thing under test. A preview that hands
-  // back the whole file when it promised a diff is the #98 regression, and it
-  // costs the caller a context window, so it counts as a failed case.
-  if (c.expectPreview) {
-    const r: any = routed.result;
-    if (!succeeded) return classify("false-refusal", r?.message || "dry run refused with no message");
-    if (after !== c.source) return classify("silent-corruption", "a dry run wrote to disk");
-    if (c.expectPreview === "diff") {
-      if (r.newSource !== undefined) return classify("silent-corruption", "dry run returned the whole file instead of a diff");
-      if (typeof r.diff !== "string" || !r.diff.includes("@@")) return classify("false-refusal", "dry run returned no usable diff");
-      if (r.diff.length >= c.source.length) return classify("false-refusal", `preview (${r.diff.length}B) is no cheaper than the file (${c.source.length}B)`);
-    } else if (typeof r.newSource !== "string") {
-      return classify("false-refusal", "includeSource did not return the post-edit file");
+    if (c.assertLoads) {
+      const loadError = nodeLoadError(path);
+      if (loadError) {
+        return classify("silent-corruption", `reported success and matched expected bytes, but Node fails to load the result: ${loadError}`);
+      }
     }
     return classify("correct");
+  } finally {
+    if (c.cwdSubdir) process.chdir(prevCwd);
   }
-
-  // Edit cases.
-  if (!succeeded) {
-    if (after !== c.source) {
-      return classify("silent-corruption", "the edit reported failure but the file was modified");
-    }
-    return classify("false-refusal", routed.result?.message || "refused with no message");
-  }
-  if (after === c.expected) return classify("correct");
-  return classify(
-    "silent-corruption",
-    unparseable
-      ? "reported success; the result does not parse"
-      : `reported success; result differs from expected\n--- expected\n${c.expected}\n--- actual\n${after}`
-  );
 }
 
 function tally(results: CaseResult[], key: (r: CaseResult) => string) {

--- a/bench/types.ts
+++ b/bench/types.ts
@@ -82,6 +82,32 @@ export interface BenchCase {
    * promised a diff is the regression #98 was filed for.
    */
   expectPreview?: "diff" | "source";
+  /**
+   * Extra files written into the case's scratch root before the edit runs
+   * (relative path -> content). Used to plant a `package.json` above or
+   * beside the target file so module-system detection has something real to
+   * find (#139, #142) — the target file itself stays a single-purpose
+   * fixture.
+   */
+  extraFiles?: Record<string, string>;
+  /**
+   * Directory, relative to the case's scratch root, to `process.chdir()`
+   * into before calling `routeEdit`, addressing `file` by a *relative* path
+   * computed from that directory instead of the usual absolute path. Exists
+   * to reproduce bugs that only manifest for relative-path input, such as
+   * the monorepo ancestor-walk gap in #161 — routing the identical edit by
+   * absolute path from the same cwd must produce the same result.
+   */
+  cwdSubdir?: string;
+  /**
+   * After a `correct` outcome, actually run the resulting JavaScript file
+   * under Node (not just tree-sitter) and require the process to exit
+   * cleanly. tree-sitter parses both `import` and `require` in the same
+   * grammar, so a byte-for-byte `expected` match can still hide a file that
+   * reports `ok: true` and then fails to load — the exact shape of #139.
+   * This is the assertion the string-equality check alone cannot make.
+   */
+  assertLoads?: boolean;
   /** Free-form tags for slicing the report (e.g. "grouped-import", "unicode"). */
   tags?: string[];
   /**

--- a/src/core/module-system.ts
+++ b/src/core/module-system.ts
@@ -13,7 +13,7 @@
  * nearest `package.json`, and a content sniff, none of which need a parse.
  */
 import { readFileSync } from "node:fs";
-import { dirname, join, parse as parsePath } from "node:path";
+import { dirname, join, parse as parsePath, resolve } from "node:path";
 
 export type ModuleSystem = "esm" | "cjs";
 
@@ -36,10 +36,16 @@ export interface ModuleSystemVerdict {
  * A `package.json` that exists but declares no `type` is not silence: the field
  * defaults to `"commonjs"` per Node's own resolution rules, so that is a real
  * CJS signal.
+ *
+ * `startDir` is absolutized against `process.cwd()` before the walk begins
+ * (#161): `path.parse()` reports `root: ""` for a relative path, which would
+ * otherwise never equal `dir` and let the walk run past the real filesystem
+ * root — silently stopping at `cwd` instead of reaching a monorepo root
+ * `package.json` that sits above it.
  */
 export function nearestPackageType(startDir: string): { system: ModuleSystem; path: string } | null {
-  const { root } = parsePath(startDir);
-  let dir = startDir;
+  let dir = resolve(startDir);
+  const { root } = parsePath(dir);
   // Bounded by the filesystem root; `dirname("/") === "/"` terminates the walk.
   for (;;) {
     const candidate = join(dir, "package.json");

--- a/tests/module-system.test.ts
+++ b/tests/module-system.test.ts
@@ -96,6 +96,52 @@ describe("detectModuleSystem — package.json", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  /**
+   * #161 — `path.parse().root` is `""` for a relative path, so the ancestor
+   * walk's stop condition (`dir === root`) never fired against a relative
+   * `startDir`: the walk quietly stopped at `cwd` instead of continuing to
+   * the real filesystem root. In a monorepo, that means a relative-path
+   * lookup from a subpackage misses a `package.json` that sits above `cwd`
+   * and falls through to the wrong default, while the identical absolute
+   * path correctly finds it.
+   */
+  test("relative and absolute paths from a monorepo subpackage agree (#161)", () => {
+    const root = sandbox({
+      "package.json": '{"name":"monorepo"}', // no "type" field: CommonJS per Node's default
+      "packages/pkgA/src/bare.js": "",
+    });
+    const prevCwd = process.cwd();
+    try {
+      process.chdir(join(root, "packages/pkgA"));
+      const relative = detectModuleSystem("src/bare.js", "");
+      const absolute = detectModuleSystem(join(root, "packages/pkgA/src/bare.js"), "");
+      expect(relative).toEqual(absolute);
+      expect(relative.system).toBe("cjs");
+      expect(relative.signal).toBe("package.json");
+    } finally {
+      process.chdir(prevCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("nearestPackageType itself agrees on a relative vs. absolute startDir", () => {
+    const root = sandbox({
+      "package.json": '{"name":"monorepo"}',
+      "packages/pkgA/src/bare.js": "",
+    });
+    const prevCwd = process.cwd();
+    try {
+      process.chdir(join(root, "packages/pkgA"));
+      const relative = nearestPackageType("src");
+      const absolute = nearestPackageType(join(root, "packages/pkgA/src"));
+      expect(relative).toEqual(absolute);
+      expect(relative?.system).toBe("cjs");
+    } finally {
+      process.chdir(prevCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("detectModuleSystem — content sniff", () => {


### PR DESCRIPTION
## Summary

- **#161 (B60)**: `nearestPackageType` (`src/core/module-system.ts`) walked ancestor directories comparing `dir === root`, where `root = parsePath(startDir).root`. For a relative `startDir`, `root` is `""`, so the stop condition never fired and the walk quietly stopped at `cwd` instead of continuing to the real filesystem root. In a monorepo, a relative-path lookup from a subpackage therefore missed a `package.json` above `cwd` and fell through to the wrong module-system default (ESM), while the identical absolute path resolved correctly (CJS). Fixed by absolutizing `startDir` with `path.resolve()` at the top of `nearestPackageType`, so the fix applies regardless of how any caller (`detectModuleSystem`, `add-import`, or anything else) reaches it.
- **#142**: `bench/` claimed ~100% correctness while missing the exact hole #139 (and now #161) lived in — a bare `.js` file whose module system is settled only by a sibling/ancestor `package.json`, not by extension or in-file markers. Added two new AST bench cases exercising that path directly, plus new opt-in `BenchCase` fields (`extraFiles`, `cwdSubdir`, `assertLoads`) so a case can plant a `package.json`, address its target by a relative path from a subdirectory (reproducing the #161 monorepo shape), and — critically — actually run the post-edit file under a real `node` subprocess instead of trusting a string-equality match alone. tree-sitter parses `import` and `require` in the same grammar, so "parses" was never proof the file loads; `assertLoads` closes that specific gap.

## Changes

- `src/core/module-system.ts`: absolutize `startDir` in `nearestPackageType` before the ancestor walk.
- `tests/module-system.test.ts`: two new regression tests — `detectModuleSystem` and `nearestPackageType` return identical, correct results for relative vs. absolute paths from a monorepo subpackage cwd.
- `bench/types.ts`: document three new opt-in `BenchCase` fields (`extraFiles`, `cwdSubdir`, `assertLoads`).
- `bench/runner.ts`: implement the three fields — write extra fixture files, chdir + relative-path addressing for a case, and a real `node <file>` load check after a byte-for-byte match.
- `bench/cases/ast.ts`: two new cases — `ast-add-import-bare-js-package-json-cjs` and `ast-add-import-bare-js-monorepo-relative-cjs` — both tagged `139`/`161`/`142`, both asserting `assertLoads: true`.
- `bench/results/latest.json`: regenerated baseline (`bun run bench --write`) including the two new cases.

## Test plan

- [x] `bun test tests/module-system.test.ts` — 16 pass, including both new #161 regression tests.
- [x] `bun test` — 983-984 pass depending on run; the only failures observed (`B19 — verify-changes security hardening`, a `record size cap` / `concurrent writers` log flake, and a large-output timeout test) are pre-existing and reproduce identically on `main` with this branch's changes stashed out — confirmed via `git stash` + rerun. None touch module-system or bench.
- [x] `bun run bench` — full run completes in ~0.8-1.4s (fast enough to run directly, not just wire-and-inspect). 42 cases, 0 silent corruption, 100% correctness, including the two new cases.
- [x] `bun run lint:docs` — passes (`CLI-QUICKREF.md` up to date, `ROADMAP.md` consistent; neither references #161/#142 so no rows needed updating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)