### PR TITLE
fix(plan-executor): run rollback accounting even when the snapshot pass fails for all files

### DIFF
--- a/src/core/plan-executor.ts
+++ b/src/core/plan-executor.ts
@@ -290,7 +290,15 @@ export async function executePlan(
   // it did. A step that failed is the root cause; "verification-failed" is the
   // case where every step applied but a check (test/lint/typecheck) failed.
   let revertReason: "verification-failed" | "step-failure" | undefined;
-  if ((stepFailed || verifyFailed) && doRevert && !dryRun && originals.size > 0) {
+  // Gated on (stepFailed || verifyFailed) && doRevert && !dryRun only — NOT on
+  // originals.size > 0. If the snapshot pass failed for every file, originals
+  // is empty and the restore loop below is a no-op, but the unsnapshotted/
+  // editedFiles accounting still must run: a step can succeed in writing a
+  // file whose blanket snapshot read failed (its own read-before-write
+  // succeeded independently), and that edit is exactly as unrevertable as one
+  // whose restore write threw (#160/B59). Skipping this whole block when
+  // originals is empty silently dropped that signal.
+  if ((stepFailed || verifyFailed) && doRevert && !dryRun) {
     revertReason = stepFailed ? "step-failure" : "verification-failed";
     for (const [file, original] of originals) {
       try { await safeWrite(file, original); }

--- a/tests/plan-executor-rollback-accounting.test.ts
+++ b/tests/plan-executor-rollback-accounting.test.ts
@@ -1,0 +1,130 @@
+// #160 (B59): the revert/accounting block in executePlan was gated entirely
+// on `originals.size > 0`. If the pre-execution snapshot pass's readDecoded()
+// call fails for *every* target file (transient read error, permission
+// race, file briefly missing), `originals` stays empty even though a later
+// step can still succeed in writing a file (its own read-before-write inside
+// the step runs independently and can succeed). When a subsequent step then
+// fails, the whole revert/unsnapshotted-accounting block used to be skipped
+// solely because `originals.size === 0`, so the plan reported a bare failure
+// with no `unrevertedFiles` and no `ROLLBACK_INCOMPLETE` — a file sat
+// modified on disk with zero signal that manual cleanup might be needed.
+//
+// This file forces that exact scenario via `mock.module` on "../src/core/encoding":
+// readDecoded's first call for each file (the snapshot pass) throws, and every
+// call after that (the per-step read-before-write) delegates to the real
+// implementation.
+
+import { describe, test, expect, mock, afterAll } from "bun:test";
+import { join } from "path";
+
+const ENCODING_MODULE = join(import.meta.dir, "..", "src", "core", "encoding.ts");
+
+const callCounts = new Map<string, number>();
+
+// Capture the real implementations before mock.module replaces the module
+// registry entry. `mock.module` mutates the live module namespace object in
+// place, so these individual function references (rather than the namespace
+// object itself) are what let the mock delegate to the real implementation,
+// and what let afterAll below restore a genuinely pristine module for every
+// other test file sharing this process.
+const actualEncoding = await import(ENCODING_MODULE);
+const realReadDecoded = actualEncoding.readDecoded;
+const realDecodeText = actualEncoding.decodeText;
+const realEncodeText = actualEncoding.encodeText;
+
+mock.module(ENCODING_MODULE, () => ({
+  decodeText: realDecodeText,
+  encodeText: realEncodeText,
+  readDecoded: async (filePath: string) => {
+    const n = (callCounts.get(filePath) ?? 0) + 1;
+    callCounts.set(filePath, n);
+    if (n === 1) {
+      throw new Error("Simulated transient read failure during snapshot pass");
+    }
+    return realReadDecoded(filePath);
+  },
+}));
+
+// `bun test` runs every file in one process, so a module mock left in place
+// after this file finishes would silently corrupt every other test file that
+// imports "../src/core/encoding" (readDecoded would keep throwing on first
+// call). Restore the pristine module once this file's test has run.
+afterAll(() => {
+  mock.module(ENCODING_MODULE, () => ({
+    decodeText: realDecodeText,
+    encodeText: realEncodeText,
+    readDecoded: realReadDecoded,
+  }));
+});
+
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from "fs";
+
+// `mock.module` only intercepts modules evaluated *after* it runs. Static
+// `import` declarations are hoisted by the ES module spec, so a top-level
+// `import { executePlan } from "../src/core/plan-executor"` here would load
+// (and bind to) the *real* "../src/core/encoding" before the mock above ever
+// takes effect. A dynamic import inside the test body runs in program order,
+// after the mock is registered, so plan-executor's `readDecoded` binding
+// resolves to the mocked module.
+const { executePlan } = await import("../src/core/plan-executor");
+
+const TMP_DIR = join(import.meta.dir, "__tmp_b59_rollback_accounting__");
+const FILE_A = join(TMP_DIR, "a.ts");
+const FILE_B = join(TMP_DIR, "b.ts");
+
+function setup() {
+  callCounts.clear();
+  try { rmSync(TMP_DIR, { recursive: true, force: true }); } catch {}
+  mkdirSync(TMP_DIR, { recursive: true });
+  writeFileSync(FILE_A, `export const a = 1;\n`);
+  writeFileSync(FILE_B, `export const b = 1;\n`);
+}
+
+describe("executePlan — rollback accounting when the snapshot pass fails for all files (#160/B59)", () => {
+  test("a step that still writes successfully is reported as unreverted, not swallowed", async () => {
+    setup();
+
+    const plan = {
+      intent: { operation: "rename-exported-symbol", symbol: "a", newName: "aa" },
+      definition: { file: FILE_A, name: "a", kind: "variable", line: 1, column: 0 },
+      references: [],
+      steps: [
+        {
+          order: 0,
+          file: FILE_A,
+          operation: "diff",
+          description: "apply change to a.ts",
+          params: { oldContent: "export const a = 1;", newContent: "export const a = 2;" },
+        },
+        {
+          order: 1,
+          file: FILE_B,
+          operation: "diff",
+          description: "content that is not present — forces step failure",
+          params: { oldContent: "%%%NOT_FOUND%%%", newContent: "x" },
+        },
+      ],
+      impactSummary: "",
+    };
+
+    const result = await executePlan(plan, { verify: false, dryRun: false, revertOnFailure: true });
+
+    // The snapshot pass failed for both files (readDecoded's 1st call per file
+    // throws), so originals.size === 0 — the exact precondition #160 exploited.
+    // Step 0 still wrote FILE_A successfully before step 1 failed.
+    expect(result.success).toBe(false);
+
+    // Core assertion: this must NOT be a silent plain failure. The edited-but-
+    // unsnapshotted file must be surfaced explicitly.
+    expect(result.reverted).toBe(false);
+    expect(result.unrevertedFiles).toBeDefined();
+    expect(result.unrevertedFiles).toContain(FILE_A);
+    expect(result.errorCode).toBe("ROLLBACK_INCOMPLETE");
+
+    // And the file really is left modified on disk — proving there was
+    // something real to revert that never got reverted.
+    expect(readFileSync(FILE_A, "utf8")).toContain("export const a = 2;");
+
+    rmSync(TMP_DIR, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- `executePlan`'s revert/accounting block in `src/core/plan-executor.ts` was gated entirely on `originals.size > 0`. If `readDecoded()` fails for every file during the pre-execution snapshot pass, `originals` stays empty even though a later step can still succeed in writing a file (its own read-before-write runs independently of the snapshot pass). When a subsequent step then failed, the entire revert block — including the `unsnapshotted`/`editedFiles` accounting that exists to detect exactly this case — was skipped, so the plan reported a bare failure while a file sat modified on disk with no `unrevertedFiles` and no `ROLLBACK_INCOMPLETE` signal.
- Fix: hoist the `unsnapshotted`/`editedFiles` accounting out from under the `originals.size > 0` guard so it runs whenever `stepFailed || verifyFailed` is true, regardless of whether any file was successfully snapshotted. The existing `ROLLBACK_INCOMPLETE` error code now correctly fires for this path too.
- Existing revert behavior for the common case (successful snapshots, partial revert) is unchanged — the guard just drops the `originals.size > 0` clause; the restore loop over `originals` is a no-op when it's empty.

Closes #160

## Test plan
- [x] Added `tests/plan-executor-rollback-accounting.test.ts`, which mocks `readDecoded` (via `mock.module` on `../src/core/encoding`, with a real-module restore in `afterAll` so the mock doesn't leak into other test files sharing the `bun test` process) so its first call per file (the snapshot pass) throws and every later call (the per-step read-before-write) succeeds. A plan with a successful step 0 write followed by a failing step 1 now asserts `reverted: false`, `unrevertedFiles` containing the edited file, and `errorCode: "ROLLBACK_INCOMPLETE"`.
- [x] Verified the new test fails against the pre-fix code (`git stash` on `plan-executor.ts` only) and passes against the fix.
- [x] `bun test`: 983 pass / 1 fail (984 total, up from the 983-test baseline by the one new test). The single failure (`B19 — verify-changes security hardening > accepts a path form inside the project's node_modules/.bin`) is pre-existing and environment-related (this worktree lacks `node_modules/.bin`), reproduced identically on `main` with the same `-t` filter.
- [x] `bun run lint:docs` passes.