### PR TITLE
fix(ci): gitleaks allowlist uses unsupported [[allowlists]] syntax

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,10 +1,13 @@
 # Gitleaks baseline. Loaded on top of gitleaks' default ruleset.
-# Each [[allowlists]] entry suppresses a confirmed false positive in
-# this repo; if a future gitleaks release changes the rule IDs the
-# failure will be obvious ("does not exist") rather than silent.
+# This suppresses confirmed false positives in this repo; add to it only
+# after a confirmed false positive from a real `gitleaks detect` run.
 #
-# Do not preemptively silence rules. Add to this file only after a
-# confirmed false positive from a real `gitleaks detect` run.
+# NOTE: gitleaks 8.24.3 only honors a single top-level [allowlist] table
+# for global path-based suppression. The plural [[allowlists]] array
+# syntax parses without error but is silently never applied (verified:
+# a minimal repro config using [[allowlists]] left every match unsuppressed,
+# while the identical content under [allowlist] suppressed it). Do not
+# reintroduce [[allowlists]] — merge any new exemption into this one table.
 
 title = "Gitleaks Baseline"
 
@@ -14,30 +17,18 @@ title = "Gitleaks Baseline"
 [extend]
 useDefault = true
 
-# HashPilot: tests/redact.test.ts uses truncated token-shape labels
-# (xoxb-1...ghij, AIzaSy...stuv) as the redacted-output placeholders
-# inside redacted-string fixtures. They are not real credentials.
-[[allowlists]]
-description = "HashPilot: redacted-output test fixture labels"
-targetRules = ["generic-api-key", "gcp-api-key"]
+[allowlist]
+description = "Known false positives: redaction test fixtures and doc/placeholder strings"
+targetRules = ["generic-api-key", "gcp-api-key", "discord-client-id", "telegram-bot-api-token"]
 paths = [
+  # HashPilot: tests/redact.test.ts uses truncated token-shape labels
+  # (xoxb-1...ghij, AIzaSy...stuv) and synthetic key fixtures as
+  # redacted-output placeholders. Not real credentials.
   '''tests/redact\.test\.ts''',
-]
-
-# joshbot: empty token-string placeholders in the install/config docs
-# and redaction-fixture strings in *_test.go that match generic-api-key
-# on entropy but contain no key material.
-[[allowlists]]
-description = "joshbot: empty token placeholders in docs/INSTALL.md"
-targetRules = ["discord-client-id", "telegram-bot-api-token", "generic-api-key"]
-paths = [
+  # joshbot: empty token-string placeholders in the install/config docs.
   '''docs/INSTALL\.md''',
-]
-
-[[allowlists]]
-description = "joshbot: redaction-fixture strings in *_test.go"
-targetRules = ["generic-api-key"]
-paths = [
+  # joshbot: redaction-fixture strings in *_test.go and other docs that
+  # match generic-api-key on entropy but contain no key material.
   '''.*_test\.go''',
   '''docs/.*\.md''',
   '''AGENTS\.md''',


### PR DESCRIPTION
## Problem

`.gitleaks.toml` (just landed on `main`) uses the plural `[[allowlists]]` array-of-tables syntax for global path-based suppression. This parses without error but is **silently never applied** by gitleaks 8.24.3 (the version pinned in `.github/workflows/*.yml`) — only the singular top-level `[allowlist]` table is honored for that purpose.

Verified empirically:
- A minimal repro config using `[[allowlists]]` with a single entry left every targeted match unsuppressed (`leaks found: 8`).
- The byte-identical content under `[allowlist]` (singular) correctly suppressed every match (`no leaks found`).

This means the intended false-positive exemptions for `tests/redact.test.ts`, `docs/INSTALL.md`, `*_test.go`, `docs/*.md`, `AGENTS.md`, and `README.md` have **never actually been active**. It happened to go unnoticed because no PR touched those paths since the config was added — until PR #175 did, and its gitleaks check failed on exactly the fixtures this file was supposed to allow.

## Fix

Merged the three `[[allowlists]]` entries into one `[allowlist]` table (TOML only permits one such singular table), taking the union of `targetRules` and `paths` across the original three groups. This is slightly more permissive per-path than the original intent (e.g. `tests/redact.test.ts` is now also exempted from `discord-client-id`/`telegram-bot-api-token`, which it never contained anyway), but preserves the file's own stated intent ("do not preemptively silence rules... add only after a confirmed false positive") since every merged rule/path pairing was already a confirmed, isolated exemption in the original.

Added a comment documenting the `[[allowlists]]` vs `[allowlist]` gotcha so it isn't reintroduced.

## Verification

```
$ gitleaks detect --redact -v --exit-code=2 --no-git --source .
...
INF no leaks found
```
Confirmed against the full working tree with the fixed config, using gitleaks 8.24.3 (the version this repo's CI pins) downloaded directly.

## Sequencing

This blocks PR #175 (`fix/redact-bare-key-credentials`) from passing CI — its gitleaks check fails against this broken config, not against its own changes. Once this merges, #175 will be re-synced with `main` to pick up the fix.