### PR TITLE
ci(release): allow manually re-running the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 on:
   push:
     branches: [main]
+  # Manual re-run without needing a new commit — e.g. to retry a release
+  # after fixing a publishing-credential issue (#147/#181) without waiting
+  # for the next fix/feat commit to land.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds `workflow_dispatch` to `release.yml` so it can be manually re-run without waiting for the next fix/feat commit — needed right now to test that OIDC trusted publishing (just configured on npmjs.com, #147) actually works, and useful going forward for retrying a release after any future publishing-credential hiccup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)