### PR TITLE
fix(redact): add missing Azure cloud-credential *Key names

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,6 +88,7 @@ Catching up to what competitors already ship: MCP distribution, interactivity, p
 | [#142](../../issues/142) | bench: coverage gaps that let #139/#140/#141 through | 36 | P2 | reported | testing |
 | [#78](../../issues/78) | Adopt competitive positioning & analysis as the tracked strategy artifact | 35 | P2 | reported | strategy |
 | [#79](../../issues/79) | Add Codex CLI integration adapter (4th platform) | 32 | P2 | reported | strategy |
+| [#179](../../issues/179) | B74 — cloud-credential-key redaction rule misses subscriptionKey/storageKey/encryptionKey/clientKey | 32 | P2 | verified | security · ✅ done |
 | [#164](../../issues/164) | B63 — `find-symbols` (read-only) takes the same exclusive lock as mutating AST operations | 31 | P2 | reported | correctness |
 | [#162](../../issues/162) | B61 — Hash-route read failures throw out of `routeEdit` instead of recording a failed result | 29 | P2 | reported | correctness |
 | [#171](../../issues/171) | B70 — Workflows use custom GH_TOKEN secret instead of default scoped GITHUB_TOKEN | 29 | P2 | reported | ops · security |

--- a/src/core/redact.ts
+++ b/src/core/redact.ts
@@ -45,7 +45,8 @@ const RULES: Rule[] = [
   // that merely contain "key" followed by more name, e.g. `primaryKeyColumn`.
   {
     name: "cloud-credential-key",
-    pattern: /\b([A-Za-z0-9_.-]*(?:account|primary|master|auth|private)[_-]?key["']?\s*[:=]\s*)(["']?)([^\s"',;)}]{20,})\2/gi,
+    pattern:
+      /\b([A-Za-z0-9_.-]*(?:account|primary|master|auth|private|subscription|storage|encryption|client)[_-]?key["']?\s*[:=]\s*)(["']?)([^\s"',;)}]{20,})\2/gi,
     replacement: `$1$2${REDACTED}$2`,
   },
 ];

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -67,6 +67,20 @@ describe("redactSecrets", () => {
     }
   });
 
+  test("redacts bare Azure-style *Key names beyond the original account/primary/master/auth/private set", () => {
+    // #179/B74: subscriptionKey (Cognitive Services), storageKey (Azure Storage),
+    // encryptionKey, clientKey (OAuth/encryption) all follow the identical shape
+    // as the already-covered names but weren't in the word list.
+    for (const line of [
+      "subscriptionKey: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+      "storageKey=AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==",
+      '"encryptionKey": "M7QF37edo9r238hXn+g83iEnfiPKmU2YhAoZEUuU"',
+      "clientKey = M7QF37edo9r238hXn+g83iEnfiPKmU2YhAoZEUuU",
+    ]) {
+      expect(redactSecrets(line)).toContain("[REDACTED]");
+    }
+  });
+
   test("does not redact ordinary identifiers that merely contain 'key'", () => {
     for (const line of [
       "const primaryKeyColumn = 'user_id'",
@@ -85,6 +99,7 @@ describe("redactSecrets", () => {
       '{"primaryKey": "ord_8827441"}',
       "MasterKey: row-42",
       "AccountKey=acct_001",
+      "clientKey=abc123",
     ]) {
       expect(redactSecrets(line)).not.toContain("[REDACTED]");
     }


### PR DESCRIPTION
## Summary

Closes #179 (B74). The `cloud-credential-key` redaction rule covered `account|primary|master|auth|private` *Key names but missed four other real Azure credential field names following the identical shape: `subscriptionKey` (Azure Cognitive Services), `storageKey` (Azure Storage), `encryptionKey`, `clientKey`. Real values under these names reached telemetry/provenance logs unredacted.

Also serving as the live test for OIDC trusted publishing (#147) now that it's configured — this is a genuine `fix:` commit that should trigger a real automated npm publish once merged.

## Test plan

- [x] `bun test tests/redact.test.ts`: 32/32 pass (new test covers all 4 names redacted; negative case confirms `clientKey=abc123` at 8 chars still correctly not redacted per the existing length-threshold guard)
- [x] `bun test`: 990/990 pass
- [x] `bun run lint:docs` passes
- [x] ROADMAP.md row added for #179/B74, marked done

🤖 Generated with [Claude Code](https://claude.com/claude-code)