### PR TITLE
ci: migrate to bigknoxy/.github reusable security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,11 +1,11 @@
 name: Security
 
-# Free, open-source security gates that block on real findings:
-#   - CodeQL:    semantic taint analysis (SQLi, XSS, SSRF, path traversal)
-#   - Gitleaks:  secret detection in commits/diffs (full history on push)
-#   - OSV:       dependency vulnerabilities across all manifests
-#   - actionlint: workflow syntax validation
-#   - Scorecards: supply-chain risk on third-party actions (weekly)
+# CodeQL and Gitleaks (and, for Node repos, npm audit) now run via the
+# org-wide reusable workflow at bigknoxy/.github/.github/workflows/security-reusable.yml.
+# This file keeps only the jobs NOT covered by that reusable workflow:
+#   - OSV:         dependency vulnerabilities across all manifests
+#   - actionlint:  workflow syntax validation
+#   - Scorecards:  supply-chain risk on third-party actions (weekly)
 # All third-party actions pinned to a commit SHA, not a mutable tag.
 
 on:
@@ -18,55 +18,14 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
-  codeql:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: actions
-          - language: javascript-typescript
-          - language: python
-          - language: go
-          - language: rust
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@486fec2a3ea2626afcd8c7e9208b4f515078dd7e # codeql-bundle-v2.26.4
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-extended,security-and-quality
-      # CodeQL fatal-errors with exit 32 ("no source code seen during build")
-      # when the repo has no code in the matrix language. Skip the analyze
-      # step in that case so the job reports success instead of failure.
-      - name: Perform CodeQL Analysis
-        if: matrix.language == 'actions' ||
-             (matrix.language == 'javascript-typescript' && hashFiles('**/*.js **/*.jsx **/*.ts **/*.tsx **/*.mjs **/*.cjs') != '') ||
-             (matrix.language == 'python' && hashFiles('**/*.py') != '') ||
-             (matrix.language == 'go' && hashFiles('**/*.go') != '') ||
-             (matrix.language == 'rust' && hashFiles('**/*.rs') != '')
-        uses: github/codeql-action/analyze@486fec2a3ea2626afcd8c7e9208b4f515078dd7e # codeql-bundle-v2.26.4
-        with:
-          category: /language:${{ matrix.language }}
-
-  gitleaks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+  security:
+    uses: bigknoxy/.github/.github/workflows/security-reusable.yml@main
+    with:
+      language: node
+      has_docker: false
+    secrets: inherit
 
   osv-scanner:
     runs-on: ubuntu-latest
@@ -103,6 +62,8 @@ jobs:
           fi
       - name: Upload SARIF
         if: always()
+        permissions:
+          security-events: write
         uses: github/codeql-action/upload-sarif@486fec2a3ea2626afcd8c7e9208b4f515078dd7e # codeql-bundle-v2.26.4
         with:
           sarif_file: osv-results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,8 @@ jobs:
 
   osv-scanner:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install + run OSV-Scanner
@@ -62,8 +64,6 @@ jobs:
           fi
       - name: Upload SARIF
         if: always()
-        permissions:
-          security-events: write
         uses: github/codeql-action/upload-sarif@486fec2a3ea2626afcd8c7e9208b4f515078dd7e # codeql-bundle-v2.26.4
         with:
           sarif_file: osv-results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,6 +22,10 @@ permissions:
 jobs:
   security:
     uses: bigknoxy/.github/.github/workflows/security-reusable.yml@main
+    permissions:
+      contents: read
+      security-events: write   # SARIF upload (CodeQL)
+      pull-requests: write     # dependency-review PR comment
     with:
       language: node
       has_docker: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,8 @@ on:
 
 permissions:
   contents: read
+  security-events: write
+  pull-requests: write
 
 jobs:
   security:


### PR DESCRIPTION
## Summary
- `security.yml`'s `codeql` and `gitleaks` jobs are replaced with a single call to `bigknoxy/.github/.github/workflows/security-reusable.yml@main` (`language: node`, `has_docker: false`, `secrets: inherit`).
- Newly added by the reusable workflow: `dependency-review` (runs on PRs only) and npm-audit-based `dep-audit` (this repo is Node/Bun; no separate `node_audit_level` override needed for default behavior).
- Not added: `trivy-fs`/`trivy-image` — this repo has no Dockerfile (`has_docker: false`).
- Removed as now-duplicate: the in-repo `codeql` matrix job and the `gitleaks` job in `security.yml`.
- Kept unchanged in `security.yml`: `osv-scanner`, `actionlint`, `scorecards` — none of these are covered by the reusable workflow.
- Left untouched: `.github/workflows/codeql.yml`, a standalone workflow running CodeQL with `security-extended,security-and-quality` queries — that's beyond the reusable workflow's default CodeQL setup, so per migration guidance it stays as-is rather than being deleted.
- No README/docs changes needed — none reference the old security workflow or carry a related CI badge.

## Test plan
- [ ] `gitleaks`/`codeql`/`dep-audit` jobs from the reusable workflow run and pass on this PR
- [ ] `dependency-review` runs (PR-only job)
- [ ] `osv-scanner`, `actionlint`, `scorecards` continue to run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ytFpzywCnefadNQ7d9e6A