### PR TITLE
docs(ci): record real required-status-check names (#184)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,24 @@ Style: strict TypeScript, ES modules, two-space indent; camelCase values, Pascal
 
 `AGENTS.md` covers the same ground for other agents — keep the two in sync when commands or conventions change.
 
+### Branch protection required checks
+
+`main`'s branch protection `required_status_checks.contexts` must list the *real*
+current CI job names — not aspirational or historical ones. They drifted silently
+once before (#184/B78): the contexts were `Test` and `ShellCheck`, names that once
+matched real jobs in `.github/workflows/ci.yml` but were replaced (PR #149's
+language-agnostic CI rewrite) without updating branch protection, so those two
+required contexts never reported on any PR again. As of this fix the required
+contexts are: `Node test`, `actionlint`, `yaml lint`, `Packaging smoke test`,
+`codeql (javascript-typescript)`, `gitleaks`, `osv-scanner`. Note that plain
+`codeql` (unlike `gitleaks`/`osv-scanner`) never matches anything either: the
+`codeql` job in `security.yml` is matrixed by language, so its real check names
+are `codeql (<language>)` — `codeql (javascript-typescript)` is the one that
+actually runs against this repo's source. If you rename or restructure `ci.yml`
+or `security.yml` job `name:`/matrix values, update branch protection's required
+contexts in the *same* change — a stale context silently stops gating merges
+instead of failing loudly.
+
 ## Architecture
 
 HashPilot is a global, tool-agnostic structured editing core for coding agents. It exposes a single CLI binary (`hashpilot`) that agents invoke for safe, syntax-aware file edits.


### PR DESCRIPTION
## Summary

Branch protection's `required_status_checks.contexts` on `main` had drifted to `["Test", "ShellCheck", "codeql", "gitleaks", "osv-scanner"]`. Neither `Test` nor `ShellCheck` has matched any real CI check since PR #149 rewrote `.github/workflows/ci.yml` (the original `Test`/`ShellCheck` job names were replaced by `test-node`/`Node test`, `lint-actionlint`/`actionlint`, `lint-yaml`/`yaml lint`, etc., without updating branch protection). That means any normal (non-admin) merge into `main` has been permanently blocked by two required checks that can never report — the merge gate has only worked via admin override.

While verifying, I also found `codeql` doesn't actually match either: `security.yml`'s `codeql` job is matrixed by language, so its real check names are `codeql (actions)`, `codeql (javascript-typescript)`, `codeql (go)`, `codeql (python)`, `codeql (rust)` — never plain `codeql`. `gitleaks` and `osv-scanner` are unmatrixed job ids and do match literally, so those two were fine as-is.

- Investigated git history for `.github/workflows/ci.yml`: confirmed `Test`/`ShellCheck` were once real job names (from the original `ci: add GitHub Actions CI and release workflows` commit) but were removed wholesale by PR #149's generic multi-language CI rewrite — an unintentional drift, not a deliberate rename with a reason to preserve. No repo doc or external tool references the literal names `Test`/`ShellCheck`.
- Chose **Option A** (fix branch protection to match real, current job names) over Option B (rename jobs back to `Test`/`ShellCheck`): the current names (`Node test`, `actionlint`, `yaml lint`) are more descriptive, and `Packaging smoke test` (added in #185) is a valuable check that didn't exist when the original required-checks list was set.
- This PR documents the fix in `CLAUDE.md` (no existing CI/CD or CONTRIBUTING doc to extend).
- The actual branch-protection settings change is applied via the GitHub API **after** this PR is opened (see below), using:

```
gh api repos/bigknoxy/HashPilot/branches/main/protection/required_status_checks \
  --method PATCH \
  --input - <<'JSON'
{
  "strict": true,
  "contexts": [
    "Node test",
    "actionlint",
    "yaml lint",
    "Packaging smoke test",
    "codeql (javascript-typescript)",
    "gitleaks",
    "osv-scanner"
  ]
}
JSON
```

I'll comment on this PR once that command has been run and verified, so both changes can be checked for consistency.

Refs #184 (not closing yet — will confirm once the live settings verification below is complete).

## Test plan

- [ ] `gh api repos/bigknoxy/HashPilot/branches/main/protection/required_status_checks -q '.contexts'` reflects the new list after the API call
- [ ] A recent merged PR's `statusCheckRollup` shows all seven required names actually reporting (not just some)
- [ ] `bun run lint:docs` / no doc-consistency lints broken by the `CLAUDE.md` addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)