### PR TITLE
ci(release): auto-file an issue when semantic-release fails after version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,67 @@ jobs:
         run: bun install
 
       - name: Semantic Release
+        id: semantic_release
         run: bun run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           # Consumed by @semantic-release/npm. Without this secret the npm
           # publish step fails and no release is cut (#96).
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # WHY THIS STEP EXISTS (#181): semantic-release's lifecycle runs every
+      # plugin's `prepare` step (changelog generation, the package.json version
+      # bump, and @semantic-release/git's commit+push to `main`) BEFORE any
+      # plugin's `publish` step (npm publish, GitHub release creation). That
+      # ordering is intrinsic to semantic-release's architecture — reordering
+      # `.releaserc.json`'s plugins array does not change it. So if the
+      # "Semantic Release" step above fails partway through (npm outage,
+      # expired trusted-publishing config, rate limiting, a credential
+      # regression, anything), the version-bump commit has ALREADY landed on
+      # `main` — package.json/CHANGELOG.md now claim a version that was never
+      # actually published anywhere, and nothing else in this workflow would
+      # otherwise notice. This happened for real, twice, and once persisted
+      # silently for 11 days before being caught by accident (see #181,
+      # #147, #96). Rather than trying to make semantic-release publish before
+      # it prepares (out of scope — it doesn't support that without replacing
+      # its core orchestration), this step guarantees the failure can never
+      # again go unnoticed: it files a GitHub issue naming the drifted
+      # version and linking straight to the failed run. Do not remove this as
+      # "seems redundant" without re-reading #181 first.
+      - name: Alert on release failure (package.json may be ahead of what's published)
+        if: failure() && steps.semantic_release.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          version="$(node -p "require('./package.json').version")"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          title="Release pipeline failed after version bump to v${version} — package.json is ahead of what's published"
+          body="$(printf '%s\n' \
+            "The **Semantic Release** step in this workflow run failed *after* semantic-release's \`prepare\` phase had already committed and pushed the version bump to \`main\`." \
+            "" \
+            "- Failed run: ${run_url}" \
+            "- \`package.json\` on \`main\` now reports version **${version}**." \
+            "" \
+            "semantic-release runs every plugin's \`prepare\` lifecycle step (changelog generation, the \`package.json\` version bump, \`@semantic-release/git\`'s commit+push) before any plugin's \`publish\` step (\`npm publish\`, GitHub release creation). This ordering is intrinsic to semantic-release's architecture, not just plugin list order — so a publish failure here does not undo the already-pushed commit." \
+            "" \
+            "**What this means:** \`package.json\` and/or \`CHANGELOG.md\` on \`main\` may now be ahead of what is actually published to npm and/or GitHub Releases. Manual investigation is needed:" \
+            "" \
+            "1. Check the failed run's log (link above) for the actual error." \
+            "2. Check whether npm (\`npm view @bigknoxy/hashpilot version\`) and/or the GitHub Releases page actually have v${version}." \
+            "3. If not published, fix the underlying issue (credentials, registry outage, etc.) and re-run the release (\`workflow_dispatch\`) — semantic-release will not re-bump the version since \`package.json\` already reflects it, so a manual publish or a targeted fix may be required depending on how far it got." \
+            "" \
+            "See #181 for the full background on this architectural gap (prepare-before-publish ordering) and why this alert exists instead of a silent failure.")"
+
+          labels=(--label bug)
+          if gh label list --repo "${{ github.repository }}" --json name -q '.[].name' | grep -qx "release-failure"; then
+            labels+=(--label release-failure)
+          fi
+
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "$title" \
+            --body "$body" \
+            "${labels[@]}"


### PR DESCRIPTION
## Summary

- Fixes #181 per its "at minimum" acceptance criterion: a future `npm publish` failure now triggers an unmissable signal (an auto-filed GitHub issue) instead of silently persisting.
- `.github/workflows/release.yml`'s "Semantic Release" step now has `id: semantic_release`. A new step, gated on `if: failure() && steps.semantic_release.outcome == 'failure'`, runs immediately after it.
- On trigger, the new step reads the (already-bumped) version from `package.json`, and runs `gh issue create` with a title like `Release pipeline failed after version bump to vX.Y.Z — package.json is ahead of what's published`, a body linking to the failed run and explaining the prepare-before-publish ordering constraint, and labels `bug` + `release-failure` (label created in this PR via `gh label create`).
- A long code comment above the new step explains *why* it exists (semantic-release's `prepare` lifecycle step — changelog, version bump, `@semantic-release/git` commit+push — runs before any plugin's `publish` step, which is intrinsic to its architecture and not fixable by reordering `.releaserc.json`'s plugin list), so it isn't removed later as "seems redundant" without re-reading #181.
- Gating on `steps.semantic_release.outcome == 'failure'` (not just job-level `failure()`) means the alert does **not** fire if the earlier "Verify a publishing credential is available" step exits early instead — that failure mode already surfaces loudly via `::error` and never reaches `prepare`, so package.json is never bumped in that case.
- The alerting step itself runs under `set -euo pipefail`, so if `gh issue create` fails, that failure is visible (not swallowed).

## Acceptance criteria satisfied (from #181)

- [x] "A future `npm publish` failure triggers an unmissable signal (failing required check, issue auto-filed, or similar) within the same workflow run, distinct from today's silent drift."
- [x] Comment in `release.yml` explaining the prepare-before-publish ordering constraint, referencing #181, so it isn't reintroduced/removed by someone unaware of the history.

Redesigning semantic-release's plugin lifecycle to publish before prepare is explicitly out of scope per the issue (semantic-release doesn't support this without replacing its core orchestration) — this PR implements the documented "at minimum" bar instead.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — YAML is syntactically valid.
- [x] Extracted the new step's `run:` script and checked it with `bash -n` — no syntax errors.
- [ ] `actionlint` — not available in this sandbox; CI's own `Docs Verify`/actionlint job will check it.
- [x] `bun test` — 988/990 pass. The 2 failures (a timing-sensitive large-output test in `tests/verify-scope.test.ts` and a `node_modules/.bin` path-resolution test in `tests/verify.test.ts`) are pre-existing/environment-related and unrelated to this change — this PR touches only `.github/workflows/release.yml`.
- [x] `bun run lint:docs` — passes (CLI quickref and ROADMAP.md checks unaffected, since no CLI surface changed).

**What could not be exercised:** This is a GitHub Actions failure-path workflow feature. I could not fully exercise it end-to-end without deliberately breaking npm publishing again in a real release run, which is not something to do in this PR. `if: failure()` combined with a step-`id`-scoped `steps.<id>.outcome == 'failure'` check is the standard, well-documented GitHub Actions mechanism for "only run this on a specific prior step's failure, not a job-wide failure" — verified by reading the current step structure (the credential-check step's own `exit 1` is a separate, already-loud failure mode that occurs *before* `semantic_release` ever runs, so it correctly does not trigger this alert). A "no release needed" run (commit-analyzer finds no fix/feat commits) is a SUCCESS conclusion for the Semantic Release step, so `if: failure()` naturally does not fire there either.

Closes #181