### PR TITLE
fix(ast): lazy-load tree-sitter so a missing binding degrades, not crashes

### DIFF
--- a/src/core/ast-edit.ts
+++ b/src/core/ast-edit.ts
@@ -1,9 +1,13 @@
-import Parser from "tree-sitter";
-import TypeScript from "tree-sitter-typescript";
-import Python from "tree-sitter-python";
-import JavaScript from "tree-sitter-javascript";
-import Go from "tree-sitter-go";
-import Rust from "tree-sitter-rust";
+// `tree-sitter` and its per-language grammars are native Node addons with no
+// prebuilt binary for every platform (e.g. linux-arm64 — #145). A *static*
+// top-level `import Parser from "tree-sitter"` runs at module-load time,
+// before any try/catch in this file can run, so on such a platform it used
+// to crash the whole process — even for commands like `--version` that never
+// touch AST at all. `import type` is erased at compile time (no runtime
+// import is emitted), and the actual native modules are `require()`d lazily
+// inside `getParser()`'s try/catch below, so a broken/missing binding
+// degrades to hash/diff routing with a recorded reason instead of a crash.
+import type Parser from "tree-sitter";
 import { escapeRegex } from "./utils";
 import { detectModuleSystem } from "./module-system";
 import { ErrorCode } from "./telemetry";
@@ -45,25 +49,30 @@ const PARSER_ERRORS: Record<string, string> = {};
 function getParser(lang: string): Parser | null {
   if (SUPPORTED_LANGUAGES[lang]) return SUPPORTED_LANGUAGES[lang].parser;
   try {
-    const p = new Parser();
+    // Lazy, synchronous `require()` — not a top-level `import` — so a
+    // missing/broken native binding throws here, inside this try/catch,
+    // instead of at module load (#145). `getParser` stays synchronous so
+    // every existing call site is unaffected.
+    const ParserCtor: typeof Parser = require("tree-sitter");
+    const p = new ParserCtor();
     switch (lang) {
       case "typescript":
-        p.setLanguage(TypeScript.typescript);
+        p.setLanguage(require("tree-sitter-typescript").typescript);
         break;
       case "tsx":
-        p.setLanguage(TypeScript.tsx);
+        p.setLanguage(require("tree-sitter-typescript").tsx);
         break;
       case "javascript":
-        p.setLanguage(JavaScript);
+        p.setLanguage(require("tree-sitter-javascript"));
         break;
       case "python":
-        p.setLanguage(Python);
+        p.setLanguage(require("tree-sitter-python"));
         break;
       case "go":
-        p.setLanguage(Go);
+        p.setLanguage(require("tree-sitter-go"));
         break;
       case "rust":
-        p.setLanguage(Rust);
+        p.setLanguage(require("tree-sitter-rust"));
         break;
       default:
         return null;

--- a/tests/fixtures/tree-sitter-absent-preload.ts
+++ b/tests/fixtures/tree-sitter-absent-preload.ts
@@ -1,0 +1,23 @@
+// Preload fixture for tests/parser-absent.test.ts (#145 / B56).
+//
+// Simulates a platform with no usable tree-sitter native binding (e.g.
+// linux-arm64, which has no prebuilt binary and whose from-source build can
+// fail against modern Node/V8 headers). `mock.module` replaces the module
+// registry entry for "tree-sitter" with a factory that throws, so any
+// `require("tree-sitter")` in this process — including the lazy one inside
+// `getParser()` in src/core/ast-edit.ts — throws exactly the way a genuine
+// `ERR_DLOPEN_FAILED` / "No native build was found" error would.
+//
+// This must be loaded via `bun --preload` (not a plain `import`) so the mock
+// is registered before the CLI's module graph is evaluated, and it must live
+// under the project tree (not /tmp) so its bare `"tree-sitter"` specifier
+// resolves against the *same* node_modules the CLI itself resolves against —
+// a preload script in an unrelated directory can resolve to a different
+// physical path and the mock silently fails to intercept.
+import { mock } from "bun:test";
+
+mock.module("tree-sitter", () => {
+  throw new Error(
+    "No native build was found for platform=linux arch=arm64 runtime=bun (simulated by tests/fixtures/tree-sitter-absent-preload.ts)",
+  );
+});

--- a/tests/parser-absent.test.ts
+++ b/tests/parser-absent.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, afterAll } from "bun:test";
+import { join } from "path";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+
+// #145 (B56): on a platform with no usable tree-sitter native binding (no
+// prebuild, e.g. linux-arm64, or a from-source build that failed), the
+// top-level `import Parser from "tree-sitter"` that used to sit at the top
+// of src/core/ast-edit.ts threw at *module load* — before any try/catch in
+// the file could run — crashing every command, including ones that never
+// touch AST at all (`--version`, `doctor`, `config`, `read-many`, ...) with a
+// raw stack trace instead of a JSON envelope.
+//
+// The fix makes the tree-sitter imports lazy (`require()` inside
+// `getParser()`'s try/catch, with only a type-only `import type Parser`
+// surviving at the top of the file). This file proves the degraded-not-
+// crashed behavior end to end, using tests/fixtures/tree-sitter-absent-preload.ts
+// (loaded via `bun --preload`) to simulate the missing binding without
+// requiring an actual arm64 runner.
+
+const CLI = join(import.meta.dir, "..", "src", "cli.ts");
+const PRELOAD = join(import.meta.dir, "fixtures", "tree-sitter-absent-preload.ts");
+const dirs: string[] = [];
+
+function scratchDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "hp-parser-absent-"));
+  dirs.push(dir);
+  return dir;
+}
+
+/** Run the real CLI in a subprocess with tree-sitter's module resolution stubbed to throw. */
+async function runWithBrokenParser(args: string[]) {
+  const proc = Bun.spawn(["bun", "--preload", PRELOAD, CLI, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { stdout, stderr, code: await proc.exited };
+}
+
+afterAll(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("degraded (not crashed) behavior with no usable tree-sitter binding (#145)", () => {
+  test("--version still works and prints a bare version, no envelope needed, no stack trace", async () => {
+    const { stdout, stderr, code } = await runWithBrokenParser(["--version"]);
+    expect(code).toBe(0);
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(stderr).not.toContain("ERR_DLOPEN_FAILED");
+    expect(stderr).not.toContain("No native build was found");
+  });
+
+  test("config succeeds — it needs no parser", async () => {
+    const { stdout, stderr, code } = await runWithBrokenParser(["config"]);
+    expect(code).toBe(0);
+    const env = JSON.parse(stdout);
+    expect(env.ok).toBe(true);
+    expect(stderr).toBe("");
+  });
+
+  test("changesets succeeds — it needs no parser", async () => {
+    const { stdout, stderr, code } = await runWithBrokenParser(["changesets"]);
+    expect(code).toBe(0);
+    const env = JSON.parse(stdout);
+    expect(env.ok).toBe(true);
+    expect(stderr).toBe("");
+  });
+
+  test("read-many succeeds — it needs no parser", async () => {
+    const dir = scratchDir();
+    const file = join(dir, "a.txt");
+    writeFileSync(file, "hello\n");
+    const { stdout, stderr, code } = await runWithBrokenParser(["read-many", file]);
+    expect(code).toBe(0);
+    const env = JSON.parse(stdout);
+    expect(env.ok).toBe(true);
+    expect(stderr).toBe("");
+  });
+
+  test("grep-many succeeds — it needs no parser", async () => {
+    const dir = scratchDir();
+    writeFileSync(join(dir, "a.txt"), "needle\n");
+    const { stdout, stderr, code } = await runWithBrokenParser(["grep-many", "needle", dir]);
+    expect(code).toBe(0);
+    const env = JSON.parse(stdout);
+    expect(env.ok).toBe(true);
+    expect(stderr).toBe("");
+  });
+
+  test("doctor reports ast-parsers: fail cleanly, with a real reason, and exits non-zero — it does not crash itself", async () => {
+    const { stdout, stderr, code } = await runWithBrokenParser(["doctor"]);
+    expect(stderr).toBe("");
+    const env = JSON.parse(stdout);
+    expect(env.apiVersion).toBe("1");
+    expect(env.ok).toBe(false);
+    expect(code).not.toBe(0);
+    expect(env.data.healthy).toBe(false);
+
+    const astCheck = env.data.checks.find((c: { name: string }) => c.name === "ast-parsers");
+    expect(astCheck.status).toBe("fail");
+    expect(astCheck.message).toContain("simulated");
+
+    expect(env.data.parsers).toHaveLength(6);
+    for (const p of env.data.parsers) {
+      expect(p.loaded).toBe(false);
+      expect(p.error).toBeTruthy();
+    }
+  });
+
+  test("an AST operation fails with a stable error code and no stack trace, instead of crashing", async () => {
+    const dir = scratchDir();
+    const file = join(dir, "a.js");
+    writeFileSync(file, "function foo() { return 1; }\n");
+
+    const { stdout, stderr, code } = await runWithBrokenParser(["ast", "rename-symbol", file, "foo", "bar"]);
+    expect(stderr).toBe("");
+    expect(code).not.toBe(0);
+
+    const env = JSON.parse(stdout);
+    expect(env.apiVersion).toBe("1");
+    expect(env.ok).toBe(false);
+    expect(env.error).toBeTruthy();
+    expect(env.error.code).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the crash-on-broken-parser part of #145 (B56); the native-build/prebuild gap itself remains open (see below).

- `src/core/ast-edit.ts` imported `tree-sitter` and every per-language grammar (`tree-sitter-typescript`, `-javascript`, `-python`, `-go`, `-rust`) as static top-level imports. Those run at module load, before `getParser()`'s try/catch can run. On a platform with no tree-sitter prebuild (linux-arm64 has none, and its from-source build needs a C++20 patch that modern Node/V8 headers require), the static import threw and crashed the whole process for **every** command — including `--version`, which never touches AST. Confirmed live today against the published `@bigknoxy/hashpilot` npm package on linux-arm64 (see the issue's most recent comment): `hashpilot --version` dies with a raw `ERR_DLOPEN_FAILED` stack trace instead of a JSON envelope.
- Fix: keep only a type-only `import type Parser from "tree-sitter"` (erased at compile time — no runtime import is emitted) and move the actual native module loads into lazy, synchronous `require()` calls inside `getParser()`'s existing try/catch. A broken/missing binding now degrades to hash/diff routing (recorded in `PARSER_ERRORS`), matching the already-shipped #46 pattern for parser-init failures, instead of crashing the process.
- `doctor`'s `ast-parsers` check already reads `PARSER_ERRORS` (#46) — verified it now reports the failure cleanly (`fail` status, real per-language reason, non-zero exit) instead of `doctor` crashing before it can render anything.

## What's still open, and why

The native-build/prebuild fix itself (patching `tree-sitter`'s `binding.gyp` for `-std=c++20`, running `node-gyp rebuild`, and — for `tree-sitter-typescript` specifically under Bun — copying the built `.node` to its `prebuilds/<platform>-<arch>/` path since its `bindings/node/index.js` bypasses `node-gyp-build`'s normal fallback) is a separate, more invasive change with real tradeoffs (bun's postinstall script-trust gate vs. baking the rebuild into `scripts/install.sh`, and `install.sh` never runs at all for `npm install -g` users). Given that gap, this lazy-import fix is the higher-leverage and more urgent half of #145: it means every non-AST command (`--version`, `doctor`, `config`, `read-many`, `grep-many`, `changesets`) works correctly even with a totally broken tree-sitter install, and any AST command fails with a clean, actionable envelope instead of a stack trace — regardless of whether the native-build gap is ever closed. **#145 stays open** to track that remaining native-build/prebuild work.

## Test plan

- [x] `bun test` — 997 pass / 0 fail (990 pre-existing + 7 new), up from the 990/0 baseline
- [x] New `tests/parser-absent.test.ts`, using `tests/fixtures/tree-sitter-absent-preload.ts` (a `bun --preload` fixture that mocks tree-sitter's module resolution to throw, simulating a missing/broken native binding without needing an actual arm64 runner) against the real CLI in a subprocess:
  - `--version`, `config`, `changesets`, `read-many`, `grep-many` all still succeed with a clean envelope/output and no stack trace on stderr
  - `doctor` reports `ast-parsers: fail` with the real per-language reason, exits non-zero, and does not crash itself
  - `hashpilot ast rename-symbol` returns `ok: false` with a stable `error.code` (`UNSUPPORTED_LANGUAGE`) and no stack trace, instead of crashing
- [x] Manually verified the same three scenarios directly against the real CLI (not just the test), on this linux-arm64 sandbox, with the fixture preload
- [x] `bun run lint:docs` — clean (no CLI surface changed, so no quickref regen needed)
- [x] `bun run build` — bundles cleanly; confirmed in the bundled `dist/cli.js` that the tree-sitter `require()` calls are wrapped in lazily-invoked `__commonJS` functions only called from inside `getParser()`, not at module top level

🤖 Generated with [Claude Code](https://claude.com/claude-code)