### PR TITLE
test(156): add missing regression coverage for MCP server + doctor.sh version

### DIFF
--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -14,6 +14,12 @@ import { join } from "path";
 import { handleLine, callTool, PROTOCOL_VERSION } from "../src/mcp/server";
 import { OPERATIONS } from "../src/core/operations";
 
+// #156: the MCP server used to read its version from
+// `process.env.HASHPILOT_VERSION || "dev"`, which nothing in a real install
+// ever sets, so every real install reported "dev" over the wire. It now
+// imports package.json directly (see src/mcp/server.ts).
+const PKG_VERSION: string = require(join(import.meta.dir, "..", "package.json")).version;
+
 /**
  * Fixtures live under the repo, not in `/tmp`.
  *
@@ -63,6 +69,9 @@ describe("mcp server over stdio", () => {
     expect(init.id).toBe(1);
     expect(init.result.protocolVersion).toBe(PROTOCOL_VERSION);
     expect(init.result.serverInfo.name).toBe("hashpilot");
+    // #156: must be the real package.json version, never "dev" or a stale
+    // hardcoded literal.
+    expect(init.result.serverInfo.version).toBe(PKG_VERSION);
     expect(init.result.capabilities.tools).toBeDefined();
 
     const list = responses[1] as any;

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -82,6 +82,19 @@ else
   fail "install.sh version banner (expected v${PKG_VERSION}, got: $(echo "$INSTALL_HELP_OUTPUT" | grep 'HashPilot Installer' || echo 'no match'))"
 fi
 
+# ── 0a2. Standalone doctor.sh version banner (#156 sibling gap) ─────────
+# scripts/doctor.sh had a hardcoded stale "0.1.0" literal until #156 was
+# fixed alongside the MCP server's own version bug; nothing previously
+# asserted this script prints the real version either.
+echo "--- doctor.sh version banner ---"
+DOCTOR_OUTPUT=$(bash "$REPO_ROOT/scripts/doctor.sh" 2>&1 || true)
+
+if [ -n "$PKG_VERSION" ] && echo "$DOCTOR_OUTPUT" | grep -qF "HashPilot Doctor v${PKG_VERSION}"; then
+  ok "doctor.sh prints package.json version ($PKG_VERSION)"
+else
+  fail "doctor.sh version banner (expected v${PKG_VERSION}, got: $(echo "$DOCTOR_OUTPUT" | grep 'HashPilot Doctor' || echo 'no match'))"
+fi
+
 # ── 0b. Lockfile is not stale (regression guard) ────────────────────────
 # bun.lock drifted out of sync with package.json after a Dependabot bump
 # landed without a lockfile regen, which silently broke every fresh


### PR DESCRIPTION
## Summary

Part of a TDD/falsifier audit across everything fixed this session. PR #176 fixed two real bugs (issue #156) but shipped with zero regression tests for either:
- MCP server's `serverInfo.version` defaulted to `process.env.HASHPILOT_VERSION || "dev"` — nothing in a real install sets that env var.
- `scripts/doctor.sh` had a hardcoded stale `"0.1.0"` literal.

Both are now covered, and both were verified as genuine falsifiers (not rubber-stamp tests) by reverting each fix in isolation and confirming the new assertion fails against the old code, then passes again after restoring the fix.

## Test plan

- [x] Reverted `src/mcp/server.ts`'s fix → `bun test tests/mcp-server.test.ts` fails with `Expected: "4.6.5", Received: "dev"` → restored fix → passes
- [x] Reverted `scripts/doctor.sh`'s fix → `bash tests/smoke.sh` fails with `expected v4.6.5, got: ...v0.1.0` → restored fix → passes
- [x] `bun test`: 997/997 pass
- [x] `bun run lint:docs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)