### PR TITLE
fix(security): override transitive ip-address and js-yaml vulnerabilities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,10 @@
       },
     },
   },
+  "overrides": {
+    "ip-address": "^10.3.1",
+    "js-yaml": "^4.3.1",
+  },
   "packages": {
     "@actions/core": ["@actions/core@3.0.1", "", { "dependencies": { "@actions/exec": "^3.0.0", "@actions/http-client": "^4.0.0" } }, "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA=="],
 
@@ -295,7 +299,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@4.3.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA=="],
 
     "json-parse-better-errors": ["json-parse-better-errors@1.0.2", "", {}, "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="],
 
@@ -725,7 +729,7 @@
 
     "npm/init-package-json": ["init-package-json@8.2.5", "", { "dependencies": { "@npmcli/package-json": "^7.0.0", "npm-package-arg": "^13.0.0", "promzard": "^3.0.1", "read": "^5.0.1", "semver": "^7.7.2", "validate-npm-package-name": "^7.0.0" }, "bundled": true }, "sha512-IknQ+upLuJU6t3p0uo9wS3GjFD/1GtxIwcIGYOWR8zL2HxQeJwvxYTgZr9brJ8pyZ4kvpkebM8ZKcyqOeLOHSg=="],
 
-    "npm/ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+    "npm/ip-address": ["ip-address@10.7.0", "", {}, "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA=="],
 
     "npm/is-cidr": ["is-cidr@6.0.4", "", { "dependencies": { "cidr-regex": "^5.0.4" }, "bundled": true }, "sha512-tOIBU3QiXy0W4LvHbcKWAWSuQfGwDiEILphFCAZtDqj7C57uv3ClO6K8aNEGV4VTA7bWJlpQ0suKQkUe6Rd6ag=="],
 

--- a/package.json
+++ b/package.json
@@ -73,5 +73,9 @@
     "conventional-changelog-conventionalcommits": "^10.4.0",
     "fast-check": "^4.9.0",
     "semantic-release": "^25.0.9"
+  },
+  "overrides": {
+    "ip-address": "^10.3.1",
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
## Findings -> Fix

| Finding | Package (chain) | Fix |
|---|---|---|
| GHSA-mwp4-54f8-5fhr (high) | ip-address@10.1.0 via semantic-release>npm>...>socks>ip-address | override -> ^10.3.1 |
| GHSA-52cp-r559-cp3m (high) | js-yaml@4.1.1 via semantic-release>cosmiconfig>js-yaml | override -> ^4.3.1 |
| GHSA-5p4m-2wfm-xmqj (high) | js-yaml@4.1.1 via semantic-release>cosmiconfig>js-yaml | override -> ^4.3.1 (same bump) |

Both are transitive dev-only dependencies (semantic-release toolchain); neither semantic-release nor its intermediate deps have shipped an update yet, so this uses a `package.json` `overrides` entry (narrowest fix) rather than a direct dependency bump.

**Tests**: `bun test` -> 994 pass, 3 fail. Confirmed the 3 failures (`module-system.test.ts` x2, `dry-run-preview.test.ts` timing) are pre-existing on `origin/main` (reproduced identically before this change) — unrelated to this fix.

**Audit before**: `bun audit` -> 3 vulnerabilities (3 high): ip-address, js-yaml x2
**Audit after**: `bun audit` -> 1 vulnerability (1 low, postcss-selector-parser, no fix available yet) — clean at `--audit-level=high` / matches the `security / dep-audit (node)` CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ytFpzywCnefadNQ7d9e6A