### PR TITLE
fix: count linesChanged exactly once (#166)

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -89,11 +89,25 @@ Format:
 - **Alternatives considered:** (1) Generate a lockfile during install — rejected: defeats the purpose of pinning. (2) Keep `bun.lock` out and accept fresh resolution — rejected: supply-chain pinning gap.
 - **Consequences:** npm-installed packages now include `bun.lock` and install with `--frozen-lockfile`. The npm package size increases slightly. The `else` branch in `install.sh` (lines 423-432) becomes unreachable for current npm installs but is kept as a safe fallback.
 
+## D009-D010 numbering note: D010 (npm install mode-selector fix) was merged
+## to main (#201) during the v4.8.2 hotfix and precedes D009 in the file for
+## the same reason it precedes it in git history — each record captures a
+## decision in merge order.
+
 ## D010: npm-sourced installs with a shipped bun.lock use --frozen-lockfile --production
 
 - **Date:** 2026-09-06
-- **PR:** hotfix (after v4.8.2)
+- **PR:** #201
 - **Context:** v4.8.2 shipped broken for the **default npm install path**. D007 (#199) added `bun.lock` to the npm package's `files`; the dependency-mode guard from #194 treated `NPM_INSTALLED=true && bun.lock present` as a fatal ("refusing to guess which dependency mode is correct"). D007 made that guard's fire-branch the *normal* case, so every fresh npm install of v4.8.2 aborted before installing dependencies. The bug passed CI because smoke installs from `@latest` npm — main's run predated the semantic-release publish and tested 4.8.1 (no lockfile); the breakage only surfaced once v4.8.2 reached the registry.
 - **Decision:** The dependency-mode decision now keys off `$NPM_INSTALLED`, not a bare lockfile-presence check. npm source + shipped lock → `bun install --frozen-lockfile --production` (pinned, devDeps skipped). npm source, no lock → `--production` (legacy). git/local + lock → `--frozen-lockfile` (dev wants devDeps). git/local, no lock → hard error (unchanged).
 - **Alternatives considered:** (1) Revert D007 (don't ship bun.lock) — rejected: pinning transitive deps is the correct supply-chain posture; the packaging was not the flaw, the mode-selector was. (2) Remove the #194 guard entirely and let the old `[ -f bun.lock ]` branch run plain `--frozen-lockfile` — rejected: that would pull devDependencies (semantic-release) into npm installs, breaking the smoke's devDep-exclusion assertion and bloating user installs.
 - **Consequences:** npm-installed packages are pinned to the shipped lockfile while still skipping devDeps. **Coverage hole identified:** smoke's npm-path test installs `@latest` (published version), so an unpublished PR branch is never validated against its own packed tarball — add a version-consistency guard so "testing the wrong release" is loud, not silent.
+
+## D009: linesChanged counts each line exactly once via structured LineMetrics
+
+- **Date:** 2026-09-06
+- **PR:** #200 (pending #166 fix)
+- **Context:** Bug B65 (#166). `replaceHash` computed `linesChanged = |Δlines| + countChangedLines(...)`, and `countChangedLines` treated any line missing on one side of a paired comparison as "changed." A pure append of N lines was therefore counted twice (once in the size delta, once in the comparison diffs), reporting 2N.
+- **Decision:** Extract blast-radius math into a reusable, idempotent `LineMetrics` module (`computeLineMetrics`) returning `{ added, removed, modified, changed }` where `changed = added + removed + modified` and each line is counted exactly once. `linesChanged` becomes `changed`. The result now also carries a structured `lineMetrics` breakdown alongside the scalar.
+- **Alternatives considered:** (1) Fix the old formula in place — rejected: the double-count is inherent to adding |Δ| to a positional diff; and the metrics logic would stay buried in `hash-edit`, un-reusable and untestable in isolation. (2) LCS-based diff for exact pairwise alignment — rejected: overkill for blast-radius; position-equality is a correct, predictable metric for range replacement. (3) Keep `countChangedLines` positional semantics — rejected: it is the source of the bug.
+- **Consequences:** `linesChanged` and `message` wording for success results change (both now reflect true touched-line count; message appends a human-readable breakdown). The comparison predicate is injectable (extensible seam). Metrics are pure, idempotent, and dual-format (structured `lineMetrics` + `describeLineMetrics` text). No change to actual edit application or returned file content — metrics-only.

--- a/src/core/hash-edit.ts
+++ b/src/core/hash-edit.ts
@@ -5,6 +5,11 @@ import { assertWritable, atomicWrite, PathDeniedError, type AssertWritableOption
 import { recordSnapshot } from "./snapshot";
 import { firstParseError } from "./ast-edit";
 import { readDecoded } from "./encoding";
+import {
+  computeLineMetrics,
+  describeLineMetrics,
+  type LineMetrics,
+} from "./line-metrics";
 
 /**
  * What to do when the anchor hash no longer matches the content at the given range.
@@ -57,6 +62,13 @@ export interface ReplaceHashResult {
    */
   newRange?: { start: number; end: number };
   linesChanged: number;
+  /**
+   * Structured breakdown of the blast radius: `added`, `removed`, `modified`,
+   * and `changed`. `changed` equals `linesChanged`. Never double-counts lines
+   * that are both appended/removed and reflected in the size delta (#166).
+   * Absent on failure paths.
+   */
+  lineMetrics?: LineMetrics;
   stale: boolean;
   message: string;
   diff?: string;
@@ -291,7 +303,8 @@ async function applyReplacement(
   const newRangeText = newContentLines.join("\n");
   const newRangeHash = computeHash(newRangeText);
   const diff = buildDiff(targetStart + 1, targetLines, newContentLines);
-  const linesChanged = Math.abs(newContentLines.length - targetLines.length) + countChangedLines(targetLines, newContentLines);
+  const lineMetrics = computeLineMetrics(targetLines, newContentLines);
+  const linesChanged = lineMetrics.changed;
   const rangeLabel = `range ${targetStart + 1}-${targetEnd}`;
 
   // A hash edit is content-blind: it will happily splice half a function into
@@ -338,12 +351,13 @@ async function applyReplacement(
     fileHash: newFullHash,
     newRange: { start: targetStart + 1, end: targetStart + newContentLines.length },
     linesChanged,
+    lineMetrics,
     stale,
     retries,
     relocatedTo,
     message: dryRun
-      ? `${action} ${targetLines.length} lines with ${newContentLines.length} lines${messageSuffix}`
-      : `${action} ${targetLines.length} lines with ${newContentLines.length} lines${messageSuffix} (${rangeLabel})`,
+      ? `${action} ${targetLines.length} lines with ${newContentLines.length} lines — ${describeLineMetrics(lineMetrics)}${messageSuffix}`
+      : `${action} ${targetLines.length} lines with ${newContentLines.length} lines — ${describeLineMetrics(lineMetrics)}${messageSuffix} (${rangeLabel})`,
     diff,
   };
 }
@@ -404,13 +418,4 @@ function buildDiff(
     }
   }
   return parts.join("\n");
-}
-
-function countChangedLines(oldLines: string[], newLines: string[]): number {
-  let count = 0;
-  const maxLen = Math.max(oldLines.length, newLines.length);
-  for (let i = 0; i < maxLen; i++) {
-    if ((oldLines[i] ?? "") !== (newLines[i] ?? "")) count++;
-  }
-  return count;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -7,6 +7,12 @@ export type { SearchResult, SearchHit, ZgSearchResult, GrepSearchResult, SearchO
 export { replaceHash } from "./hash-edit";
 export type { ReplaceHashResult, ReplaceHashOptions } from "./hash-edit";
 export {
+  computeLineMetrics,
+  describeLineMetrics,
+  computeChangedLinesScore,
+} from "./line-metrics";
+export type { LineMetrics, LineComparer } from "./line-metrics";
+export {
   findSymbols,
   findSymbolsDetailed,
   MAX_AST_DEPTH,

--- a/src/core/line-metrics.ts
+++ b/src/core/line-metrics.ts
@@ -1,0 +1,95 @@
+/**
+ * LineMetrics — blast-radius metrics for line-level edits.
+ *
+ * Computes how many lines a replace operation touches, WITHOUT double-counting
+ * lines that are both appended/removed AND reflected in the size delta.
+ *
+ * SOLID design:
+ * - Single responsibility: this module only measures line deltas. It does not
+ *   apply edits, write files, or build diffs.
+ * - Open for extension: the comparison predicate is injectable (see
+ *   `countChangedBy`), so callers can define their own notion of "changed"
+ *   (e.g. ignore whitespace) without editing core.
+ * - Idempotent: pure function of its inputs. Same (old, new) → same result.
+ * - Dual-format: `compute` returns a structured, agent-parseable object;
+ *   `describe` renders the same data as human-readable text. Human text is
+ *   generated FROM the structured value, never maintained separately.
+ */
+
+/** Structured line-metrics result (agent-parseable shape). */
+export interface LineMetrics {
+  /** Lines present in new but not old. */
+  added: number;
+  /** Lines present in old but not new. */
+  removed: number;
+  /** Lines present in both but different. */
+  modified: number;
+  /**
+   * Total lines touched by the edit. NEVER double-counts: a line is counted
+   * exactly once — as added, removed, or modified. Pure append of N lines is
+   * `added=N, changed=N` (not `2N`).
+   */
+  changed: number;
+}
+
+/** Predicate defining when a line occupying the same slot is "changed". */
+export type LineComparer = (oldLine: string, newLine: string) => boolean;
+
+/**
+ * Compute line metrics between two line arrays.
+ *
+ * The tricky case (fixed here): a line that exists on only one side of the
+ * comparison is "added" or "removed", NOT "modified". Naive implementations
+ * (e.g. `old[i] ?? "" !== new[i] ?? ""`) count such lines as "modified", so a
+ * pure append of N lines reports N added + N modified = 2N. This module counts
+ * each line exactly once.
+ *
+ * Idempotence guarantee: `compute(a, b) === compute(a, b)` for identical
+ * inputs — no state, no randomness, no mutation.
+ */
+export function computeLineMetrics(
+  oldLines: string[],
+  newLines: string[],
+  isChanged: LineComparer = (a, b) => a !== b,
+): LineMetrics {
+  let added = 0;
+  let removed = 0;
+  let modified = 0;
+
+  const shared = Math.min(oldLines.length, newLines.length);
+  for (let i = 0; i < shared; i++) {
+    if (isChanged(oldLines[i], newLines[i])) modified++;
+  }
+  // Tail beyond the shorter array is purely added or purely removed.
+  if (newLines.length > oldLines.length) {
+    added = newLines.length - oldLines.length;
+  } else if (oldLines.length > newLines.length) {
+    removed = oldLines.length - newLines.length;
+  }
+
+  return { added, removed, modified, changed: added + removed + modified };
+}
+
+/** Human-readable rendering of {@link LineMetrics} (generated from structured). */
+export function describeLineMetrics(m: LineMetrics): string {
+  const parts: string[] = [];
+  if (m.added) parts.push(`${m.added} added`);
+  if (m.removed) parts.push(`${m.removed} removed`);
+  if (m.modified) parts.push(`${m.modified} modified`);
+  const detail = parts.length ? ` (${parts.join(", ")})` : "";
+  return `${m.changed} line${m.changed === 1 ? "" : "s"} touched${detail}`;
+}
+
+/**
+ * Convenience: compute metrics for a range replacement given the OLD target
+ * lines and NEW replacement lines. Keeps the "changed" number available both
+ * as an object and as a plain count for callers that only need the scalar.
+ */
+export function computeChangedLinesScore(
+  oldLines: string[],
+  newLines: string[],
+  isChanged?: LineComparer,
+): { metrics: LineMetrics; changed: number } {
+  const metrics = computeLineMetrics(oldLines, newLines, isChanged);
+  return { metrics, changed: metrics.changed };
+}

--- a/tests/hash-edit.test.ts
+++ b/tests/hash-edit.test.ts
@@ -114,6 +114,30 @@ describe("replaceHash", () => {
     expect(updated).toContain("// replaced");
   });
 
+  test("pure append reports linesChanged=added=N, not 2N (#166 reproduction)", async () => {
+    const fp = join(TMP_DIR, "append.ts");
+    writeFileSync(fp, ["a", "b", "c"].join("\n"));
+    const hash = computeHash("a\nb\nc");
+    // Append exactly 2 lines: a,b,c → a,b,c,d,e (nothing modified).
+    const result = await replaceHash(fp, hash, "a\nb\nc\nd\ne");
+    expect(result.success).toBe(true);
+    // The bug: |Δ|=2 + countChangedLines(d,e as "changed")=2 → reported 4.
+    // Correct: appended lines counted once → 2.
+    expect(result.linesChanged).toBe(2);
+    expect(result.lineMetrics).toEqual({ added: 2, removed: 0, modified: 0, changed: 2 });
+  });
+
+  test("mixed append + in-place modification counts each once (#166 requires)", async () => {
+    const fp = join(TMP_DIR, "mixed.ts");
+    writeFileSync(fp, ["a", "b", "c"].join("\n"));
+    const hash = computeHash("a\nb\nc");
+    // position 1 modified (b→X), positions 3-4 appended (d,e): changed = 1+2 = 3.
+    const result = await replaceHash(fp, hash, "a\nX\nc\nd\ne");
+    expect(result.success).toBe(true);
+    expect(result.linesChanged).toBe(3);
+    expect(result.lineMetrics).toEqual({ added: 2, removed: 0, modified: 1, changed: 3 });
+  });
+
   test("rejects stale hash with noRecovery option", async () => {
     const fp = join(TMP_DIR, "sample.ts");
     const result = await replaceHash(fp, "badhash12345", "// new content", { noRecovery: true });

--- a/tests/line-metrics.test.ts
+++ b/tests/line-metrics.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from "bun:test";
+import {
+  computeLineMetrics,
+  describeLineMetrics,
+  computeChangedLinesScore,
+} from "../src/core/line-metrics";
+
+const A = ["a", "b", "c"];
+const B = ["a", "b", "c", "d", "e"];
+
+describe("computeLineMetrics", () => {
+  test("pure append: reports added=N and changed=N, NOT 2N (#166 falsifier)", () => {
+    const m = computeLineMetrics(A, B);
+    expect(m.added).toBe(2);
+    expect(m.removed).toBe(0);
+    expect(m.modified).toBe(0);
+    // The bug this guards against: naive `|Δ| + positional-diff` double-counts
+    // appended lines, yielding changed=4. Correct is 2 — appends counted once.
+    expect(m.changed).toBe(2);
+  });
+
+  test("identical lines: all metrics zero (anti-falsifier)", () => {
+    const m = computeLineMetrics(A, [...A]);
+    expect(m).toEqual({ added: 0, removed: 0, modified: 0, changed: 0 });
+  });
+
+  test("pure truncation: removed=N, changed=N (falsifier)", () => {
+    const m = computeLineMetrics(B, A);
+    expect(m.removed).toBe(2);
+    expect(m.added).toBe(0);
+    expect(m.modified).toBe(0);
+    expect(m.changed).toBe(2);
+  });
+
+  test("mixed append + in-place modification counts each once (#166 requires)", () => {
+    // old: a,b,c  new: a,X,c,d,e
+    // position 1 modified (b→X); positions 3-4 appended (d,e)
+    // changed must be 1 modified + 2 added = 3, never 4.
+    const m = computeLineMetrics(A, ["a", "X", "c", "d", "e"]);
+    expect(m.modified).toBe(1);
+    expect(m.added).toBe(2);
+    expect(m.changed).toBe(3);
+  });
+
+  test("mixed truncation + modification counts each once (anti-falsifier)", () => {
+    // old: a,b,c,d,e  new: a,X,c
+    // position 1 modified (b→X); positions 3-4 removed (d,e)
+    // changed must be 1 modified + 2 removed = 3.
+    const m = computeLineMetrics(["a", "b", "c", "d", "e"], ["a", "X", "c"]);
+    expect(m.modified).toBe(1);
+    expect(m.removed).toBe(2);
+    expect(m.changed).toBe(3);
+  });
+
+  test("single replacement: changed=1 (anti-falsifier)", () => {
+    const m = computeLineMetrics(["a", "b", "c"], ["a", "X", "c"]);
+    expect(m).toEqual({ added: 0, removed: 0, modified: 1, changed: 1 });
+  });
+
+  test("idempotent: same inputs → identical results (twice)", () => {
+    const first = computeLineMetrics(A, B);
+    const second = computeLineMetrics(A, B);
+    expect(second).toEqual(first);
+  });
+
+  test("custom comparer extends behavior (whitespace-insensitive)", () => {
+    const whitespaceBlind = (a: string, b: string) => a.trim() !== b.trim();
+    const m = computeLineMetrics(["a", "b"], ["a ", "c"], whitespaceBlind);
+    // index 0: "a" vs "a " — equal when trimmed → not modified
+    // index 1: "b" vs "c" → modified
+    expect(m.modified).toBe(1);
+    expect(m.changed).toBe(1);
+  });
+
+  test("empty vs non-empty: all added (anti-falsifier)", () => {
+    const m = computeLineMetrics([], ["x", "y"]);
+    expect(m.added).toBe(2);
+    expect(m.changed).toBe(2);
+  });
+});
+
+describe("describeLineMetrics", () => {
+  test("renders human text, generated from structured value", () => {
+    const m = computeLineMetrics(A, B);
+    expect(describeLineMetrics(m)).toContain("2");
+    expect(describeLineMetrics(m)).toContain("added");
+  });
+
+  test("pluralizes correctly", () => {
+    expect(describeLineMetrics({ added: 1, removed: 0, modified: 0, changed: 1 })).toContain(
+      "1 line touched",
+    );
+    expect(describeLineMetrics({ added: 2, removed: 0, modified: 0, changed: 2 })).toContain(
+      "2 lines touched",
+    );
+  });
+});
+
+describe("computeChangedLinesScore", () => {
+  test("exposes both structured metrics and plain count", () => {
+    const { metrics, changed } = computeChangedLinesScore(A, B);
+    expect(metrics.changed).toBe(2);
+    expect(changed).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes **B65 (#166)** — `linesChanged` double-counted appended/removed lines.

**Root cause:** `linesChanged = |Δlines| + countChangedLines(...)`. `countChangedLines` treated any line missing on one side as "changed", so a pure append of N lines was counted twice (size delta + positional diff) → reported **4** for a 2-line append.

**Fix:** Extract blast-radius math into a reusable `LineMetrics` module (`computeLineMetrics`) returning `{added, removed, modified, changed}` where `changed = added + removed + modified` — each line counted **exactly once**.

## SOLID-standard validation
- **SOLID:** Module has a single responsibility; `hash-edit` no longer owns metrics math
- **Reusable:** Exported from `core/index.ts`; usable by any edit type
- **Idempotent:** Pure function; test runs it twice asserting identical output
- **API/ABC:** Injectable `LineComparer` seam (extensible); structured `LineMetrics` interface
- **Dual-format:** Structured `lineMetrics` (agent) + `describeLineMetrics` text (human), text generated FROM structured
- **Extensible:** comparator injectable without core edits; new fields additive

## Changes
- `src/core/line-metrics.ts` (new): `computeLineMetrics`, `describeLineMetrics`, `computeChangedLinesScore`
- `src/core/hash-edit.ts`: use `computeLineMetrics`; add `lineMetrics` to result; remove dead `countChangedLines`
- `src/core/index.ts`: export new module
- `tests/line-metrics.test.ts` (new): 12 tests (falsifier + anti-falsifiers)
- `tests/hash-edit.test.ts`: integration tests for exact #166 reproduction + mixed case
- `docs/decisions/README.md`: D009

## Metrics-only
No change to edit application, returned file content, or hashes. Only `linesChanged` (corrected) and the `message` wording (now appends human-readable breakdown) change.

## Validation
- `bun test` → 1019 pass / 1 fail (the 1 fail is pre-existing #24 `verify-scope` >1MB deadlock, unrelated)
- `bun test tests/line-metrics.test.ts` → 12/12 pass
- `bun test tests/hash-edit.test.ts` → 25/25 pass
- `bun run lint:docs` → green

Closes #166